### PR TITLE
Set default flightGlobalsIndex to 20, removing need for flightGlobalsIndex in non-template planet configs.

### DIFF
--- a/Kopernicus/Configuration/Body.cs
+++ b/Kopernicus/Configuration/Body.cs
@@ -203,7 +203,7 @@ namespace Kopernicus
                     GameObject generatedBodyGameObject = new GameObject (name);
                     generatedBodyGameObject.transform.parent = Utility.Deactivator;
                     generatedBody = generatedBodyGameObject.AddComponent<PSystemBody> ();
-                    generatedBody.flightGlobalsIndex = 0;
+                    generatedBody.flightGlobalsIndex = 20;
 
                     // Create the celestial body
                     GameObject generatedBodyProperties = new GameObject (name);


### PR DESCRIPTION
I was having an issue with configs earlier, which caused the game to hang on the PSystemSpawn scene after the Kopernicus injector ran, without any errors logged in the Logs file or output_log.txt.

It still worked if I gave my planets a template, but that was only because this issue only affected non-template planets.

It turned out that my config was missing the flightGlobalsIndex value, so I added it and set it to zero. That failed, so I tried setting it to a value that wouldn't conflict with a stock planet (anywhere above 16), and it worked. I also tested having 2 planets with the same flightGlobalsIndex, and that worked too.

Kopernicus already patches flightGlobalsIndex [here](https://github.com/BryceSchroeder/Kopernicus/blob/master/Kopernicus/Injector.cs#L112), so it seems pointless to require that people include it in their configs.

Edit: crap, I forgot to set it to merge into development. Still a bit of a newbie with source control.