### PR TITLE
Use double vs int

### DIFF
--- a/Kopernicus/PostInject.cs
+++ b/Kopernicus/PostInject.cs
@@ -471,7 +471,7 @@ namespace Kopernicus
                     {
                         // Only recalculate the SOI, if it's not forced
                         if (!Templates.hillSphere.ContainsKey(body.transform.name))
-                            body.hillSphere = body.orbit.semiMajorAxis * (1.0 - body.orbit.eccentricity) * Math.Pow(body.Mass / body.orbit.referenceBody.Mass, 1 / 3);
+                            body.hillSphere = body.orbit.semiMajorAxis * (1.0 - body.orbit.eccentricity) * Math.Pow(body.Mass / body.orbit.referenceBody.Mass, 1.0 / 3.0);
 
                         if (!Templates.sphereOfInfluence.ContainsKey(body.transform.name))
                             body.sphereOfInfluence = Math.Max(


### PR DESCRIPTION
You are dividing two int's wich each other that become a new int, in this case it is 0. If you'ld make one or both of the int's a double, it will use the power of 0.33 instead of just 0.

I had this problem in my own code too.

Fixes my comment on e70b466964c6bd20bca962a72d31cf990d0f32c5