### PR TITLE
Check if ocean is null in KopernicusBuoyancy & VS2013 build fixes

### DIFF
--- a/Kopernicus/Configuration/Parser/BuiltinTypeParsers.cs
+++ b/Kopernicus/Configuration/Parser/BuiltinTypeParsers.cs
@@ -656,7 +656,7 @@ namespace Kopernicus
                     if (mesh == null)
                     {
                         string meshName = Regex.Replace(s, "BUILTIN/", "");
-                        mesh = Resources.FindObjectsOfTypeAll<Mesh>().Where(mesh => mesh.name == meshName).First();
+                        mesh = Resources.FindObjectsOfTypeAll<Mesh>().Where(m => m.name == meshName).First();
                         Object = new GameObject(meshName);
                         Object.AddComponent<MeshFilter>().sharedMesh = mesh;
                         MonoBehaviour.DontDestroyOnLoad(Object);

--- a/Kopernicus/RuntimeUtility/OceanUtility.cs
+++ b/Kopernicus/RuntimeUtility/OceanUtility.cs
@@ -56,6 +56,9 @@ namespace Kopernicus
             if (!part.rb)
                 return;
 
+            if (GetOcean() == null)
+                return;
+
             // Get the center of the Buoyancy
             Vector3 oldCenter = centerOfBuoyancy;
             centerOfBuoyancy = part.partTransform.position + (part.partTransform.rotation * part.CenterOfBuoyancy);

--- a/Kopernicus/RuntimeUtility/OceanUtility.cs
+++ b/Kopernicus/RuntimeUtility/OceanUtility.cs
@@ -43,7 +43,7 @@ namespace Kopernicus
     // Our own implementation of PartBuoyancy
     public class KopernicusBuoyancy : PartBuoyancy
     {
-        public Part part => GetComponent<Part>();
+        public Part part { get { return GetComponent<Part>(); } }
 
         private PQS _ocean;
         private CelestialBody mainBody;


### PR DESCRIPTION
So I had a bit of extra time today and figured I'd try and help out a bit.

First of all I fixed a few build errors in VS2013 (since that's what I use).
See commit c9bbb04 for details on that.

Secondly I added a check to see if the ocean is null in the KopernicusBuoyancy FixedUpdate function before it tries to actually do anything with the ocean.

This should fix some [NullReferenceExceptions that were reported](http://forum.kerbalspaceprogram.com/threads/114649-1-0-4-Kopernicus-Beta-%280-3-3%29-August-28?p=2177577&viewfull=1#post2177577) in the forum thread.

This should also fix #87 as the frame drop was most likely coming from the NullReferenceException error spam.

**Note:** I haven't tested this change, if someone could test this change and confirm it works, and that it fixes the NullReferenceExceptions, that would be great, but I'm almost certain it will ;)