### PR TITLE
Fix for bad garbage thrash when panning camera in map/tracking station

### DIFF
--- a/Kopernicus/Kopernicus.OnDemand/CBAttributeMapSODemand.cs
+++ b/Kopernicus/Kopernicus.OnDemand/CBAttributeMapSODemand.cs
@@ -67,7 +67,7 @@ namespace Kopernicus
                 {
                     CreateMap(Depth, map);
                     IsLoaded = true;
-                    Debug.Log("[OD] CBmap " + name + " enabling self. Path = " + Path);
+                    Debug.Log("[OD] ---> CBmap " + name + " enabling self. Path = " + Path);
                     return;
                 }
 
@@ -90,7 +90,7 @@ namespace Kopernicus
                 IsLoaded = false;
 
                 // Log
-                Debug.Log("[OD] CBmap " + name + " disabling self. Path = " + Path);
+                Debug.Log("[OD] <--- CBmap " + name + " disabling self. Path = " + Path);
             }
 
             // Create a map from a Texture2D

--- a/Kopernicus/Kopernicus.OnDemand/Kopernicus.OnDemand.csproj
+++ b/Kopernicus/Kopernicus.OnDemand/Kopernicus.OnDemand.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">

--- a/Kopernicus/Kopernicus.OnDemand/MapSODemand.cs
+++ b/Kopernicus/Kopernicus.OnDemand/MapSODemand.cs
@@ -68,7 +68,7 @@ namespace Kopernicus
                 {
                     CreateMap(Depth, map);
                     IsLoaded = true;
-                    Debug.Log("[OD] Map " + name + " enabling self. Path = " + Path);
+                    Debug.Log("[OD] ---> Map " + name + " enabling self. Path = " + Path);
                     return;
                 }
 
@@ -90,7 +90,7 @@ namespace Kopernicus
                 IsLoaded = false;
 
                 // Log
-                Debug.Log("[OD] map " + name + " disabling self. Path = " + Path);
+                Debug.Log("[OD] <--- Map " + name + " disabling self. Path = " + Path);
             }
 
             // Create a map from a Texture2D

--- a/Kopernicus/Kopernicus.OnDemand/OnDemandStorage.cs
+++ b/Kopernicus/Kopernicus.OnDemand/OnDemandStorage.cs
@@ -186,7 +186,7 @@ namespace Kopernicus
             {
                 // If we haven't worked out if we can patch array length then do it
                 if (arrayLengthOffset == 0)
-                    CalculateByteArrayLengthOffset();
+                    CalculateArrayLengthOffset();
 
                 // If we can't patch array length then just use the normal function
                 if (arrayLengthOffset == 1)
@@ -203,7 +203,7 @@ namespace Kopernicus
                 {
                     // Round it up to a 1MB multiple
                     sizeWholeFile = (fileBytes + 0xFFFFF) & ~0xFFFFF;
-                    MonoBehaviour.print("LoadWholeFile reallocating buffer to " + sizeWholeFile);
+                    Debug.Log("[OD] LoadWholeFile reallocating buffer to " + sizeWholeFile);
                     wholeFileBuffer = new byte[sizeWholeFile];
                 }
                 else
@@ -234,7 +234,7 @@ namespace Kopernicus
             {
                 // If we haven't worked out if we can patch array length then do it
                 if (arrayLengthOffset == 0)
-                    CalculateByteArrayLengthOffset();
+                    CalculateArrayLengthOffset();
 
                 long chunkBytes = reader.BaseStream.Length - reader.BaseStream.Position;
                 if (chunkBytes > int.MaxValue)
@@ -250,7 +250,7 @@ namespace Kopernicus
                 {
                     // Round it up to a 1MB multiple
                     sizeWholeFile = (fileBytes + 0xFFFFF) & ~0xFFFFF;
-                    MonoBehaviour.print("LoadRestOfReader reallocating buffer to " + sizeWholeFile);
+                    Debug.Log("[OD] LoadRestOfReader reallocating buffer to " + sizeWholeFile);
                     wholeFileBuffer = new byte[sizeWholeFile];
                 }
                 else
@@ -277,7 +277,7 @@ namespace Kopernicus
                 return wholeFileBuffer;
             }
 
-            unsafe static void CalculateByteArrayLengthOffset()
+            unsafe static void CalculateArrayLengthOffset()
             {
                 // Work out the offset by allocating a small array and searching backwards until we find the correct value
                 int[] temp = new int[3];
@@ -292,7 +292,7 @@ namespace Kopernicus
                     }
 
                     arrayLengthOffset = (*p == 3) ? offset : 1;
-                    MonoBehaviour.print("Using arrayLengthOffset of " + arrayLengthOffset);
+                    Debug.Log("[OD] CalculateArrayLengthOffset using offset of " + arrayLengthOffset);
                 }
             }
 

--- a/Kopernicus/Kopernicus.OnDemand/OnDemandStorage.cs
+++ b/Kopernicus/Kopernicus.OnDemand/OnDemandStorage.cs
@@ -48,6 +48,11 @@ namespace Kopernicus
             public static Dictionary<PQS, PQSMod_OnDemandHandler> handlers = new Dictionary<PQS, PQSMod_OnDemandHandler>();
             public static string currentBody = "";
 
+            // Whole file buffer management
+            private static byte[] wholeFileBuffer = null;
+            private static int sizeWholeFile = 0;
+            private static int arrayLengthOffset = 0;
+
             // OnDemand flags
             public static bool useOnDemand = true;
             public static bool useOnDemandBiomes = true;
@@ -177,6 +182,129 @@ namespace Kopernicus
                 return false;
             }
 
+            public static byte[] LoadWholeFile(string path)
+            {
+                // If we haven't worked out if we can patch array length then do it
+                if (arrayLengthOffset == 0)
+                    CalculateByteArrayLengthOffset();
+
+                // If we can't patch array length then just use the normal function
+                if (arrayLengthOffset == 1)
+                    return File.ReadAllBytes(path);
+
+                // Otherwise we do cunning stuff
+                FileStream file = File.OpenRead(path);
+                if (file.Length > int.MaxValue)
+                    throw new Exception("File too large");
+
+                int fileBytes = (int)file.Length;
+
+                if (wholeFileBuffer == null || fileBytes > sizeWholeFile)
+                {
+                    // Round it up to a 1MB multiple
+                    sizeWholeFile = (fileBytes + 0xFFFFF) & ~0xFFFFF;
+                    MonoBehaviour.print("LoadWholeFile reallocating buffer to " + sizeWholeFile);
+                    wholeFileBuffer = new byte[sizeWholeFile];
+                }
+                else
+                {
+                    // Reset the length of the array to the full size
+                    FudgeByteArrayLength(wholeFileBuffer, sizeWholeFile);
+                }
+
+                // Read all the data from the file
+                int i = 0;
+                while (fileBytes > 0)
+                {
+                    int read = file.Read(wholeFileBuffer, i, (fileBytes > 0x100000) ? 0x100000 : fileBytes);
+                    if (read > 0)
+                    {
+                        i += read;
+                        fileBytes -= read;
+                    }
+                }
+
+                // Fudge the length of the array
+                FudgeByteArrayLength(wholeFileBuffer, i);
+
+                return wholeFileBuffer;
+            }
+
+            public static byte[] LoadRestOfReader(BinaryReader reader)
+            {
+                // If we haven't worked out if we can patch array length then do it
+                if (arrayLengthOffset == 0)
+                    CalculateByteArrayLengthOffset();
+
+                long chunkBytes = reader.BaseStream.Length - reader.BaseStream.Position;
+                if (chunkBytes > int.MaxValue)
+                    throw new Exception("Chunk too large");
+
+                // If we can't patch array length then just use the normal function
+                if (arrayLengthOffset == 1)
+                    return reader.ReadBytes((int)chunkBytes);
+
+                // Otherwise we do cunning stuff
+                int fileBytes = (int)chunkBytes;
+                if (wholeFileBuffer == null || fileBytes > sizeWholeFile)
+                {
+                    // Round it up to a 1MB multiple
+                    sizeWholeFile = (fileBytes + 0xFFFFF) & ~0xFFFFF;
+                    MonoBehaviour.print("LoadRestOfReader reallocating buffer to " + sizeWholeFile);
+                    wholeFileBuffer = new byte[sizeWholeFile];
+                }
+                else
+                {
+                    // Reset the length of the array to the full size
+                    FudgeByteArrayLength(wholeFileBuffer, sizeWholeFile);
+                }
+
+                // Read all the data from the file
+                int i = 0;
+                while (fileBytes > 0)
+                {
+                    int read = reader.Read(wholeFileBuffer, i, (fileBytes > 0x100000) ? 0x100000 : fileBytes);
+                    if (read > 0)
+                    {
+                        i += read;
+                        fileBytes -= read;
+                    }
+                }
+
+                // Fudge the length of the array
+                FudgeByteArrayLength(wholeFileBuffer, i);
+
+                return wholeFileBuffer;
+            }
+
+            unsafe static void CalculateByteArrayLengthOffset()
+            {
+                // Work out the offset by allocating a small array and searching backwards until we find the correct value
+                int[] temp = new int[3];
+                int offset = -4;
+                fixed (int* ptr = &temp[0])
+                {
+                    int* p = ptr - 1;
+                    while (*p != 3 && offset > -44)
+                    {
+                        offset -= 4;
+                        p--;
+                    }
+
+                    arrayLengthOffset = (*p == 3) ? offset : 1;
+                    MonoBehaviour.print("Using arrayLengthOffset of " + arrayLengthOffset);
+                }
+            }
+
+            unsafe static void FudgeByteArrayLength(byte[] array, int len)
+            {
+                fixed (byte* ptr = &array[0])
+                {
+                    int* pLen = (int*)(ptr + arrayLengthOffset);
+                    *pLen = len;
+                }
+            }
+
             // Loads a texture
             public static Texture2D LoadTexture(string path, bool compress, bool upload, bool unreadable)
             {
@@ -191,8 +319,9 @@ namespace Kopernicus
                         {
                             // Borrowed from stock KSP 1.0 DDS loader (hi Mike!)
                             // Also borrowed the extra bits from Sarbian.
-                            byte[] buffer = File.ReadAllBytes(path);
-                            BinaryReader binaryReader = new BinaryReader(new MemoryStream(buffer));
+                            //byte[] buffer = File.ReadAllBytes(path);
+                            //BinaryReader binaryReader = new BinaryReader(new MemoryStream(buffer));
+                            BinaryReader binaryReader = new BinaryReader(File.OpenRead(path));
                             uint num = binaryReader.ReadUInt32();
                             if (num == DDSHeaders.DDSValues.uintMagic)
                             {
@@ -222,17 +351,17 @@ namespace Kopernicus
                                     if (dDSHeader.ddspf.dwFourCC == DDSHeaders.DDSValues.uintDXT1)
                                     {
                                         map = new Texture2D((int)dDSHeader.dwWidth, (int)dDSHeader.dwHeight, TextureFormat.DXT1, mipmap);
-                                        map.LoadRawTextureData(binaryReader.ReadBytes((int)(binaryReader.BaseStream.Length - binaryReader.BaseStream.Position)));
+                                        map.LoadRawTextureData(LoadRestOfReader(binaryReader));
                                     }
                                     else if (dDSHeader.ddspf.dwFourCC == DDSHeaders.DDSValues.uintDXT3)
                                     {
                                         map = new Texture2D((int)dDSHeader.dwWidth, (int)dDSHeader.dwHeight, (TextureFormat)11, mipmap);
-                                        map.LoadRawTextureData(binaryReader.ReadBytes((int)(binaryReader.BaseStream.Length - binaryReader.BaseStream.Position)));
+                                        map.LoadRawTextureData(LoadRestOfReader(binaryReader));
                                     }
                                     else if (dDSHeader.ddspf.dwFourCC == DDSHeaders.DDSValues.uintDXT5)
                                     {
                                         map = new Texture2D((int)dDSHeader.dwWidth, (int)dDSHeader.dwHeight, TextureFormat.DXT5, mipmap);
-                                        map.LoadRawTextureData(binaryReader.ReadBytes((int)(binaryReader.BaseStream.Length - binaryReader.BaseStream.Position)));
+                                        map.LoadRawTextureData(LoadRestOfReader(binaryReader));
                                     }
                                     else if (dDSHeader.ddspf.dwFourCC == DDSHeaders.DDSValues.uintDXT2)
                                     {
@@ -287,7 +416,7 @@ namespace Kopernicus
                                     if (ok)
                                     {
                                         map = new Texture2D((int)dDSHeader.dwWidth, (int)dDSHeader.dwHeight, textureFormat, mipmap);
-                                        map.LoadRawTextureData(binaryReader.ReadBytes((int)(binaryReader.BaseStream.Length - binaryReader.BaseStream.Position)));
+                                        map.LoadRawTextureData(LoadRestOfReader(binaryReader));
                                     }
 
                                 }
@@ -301,7 +430,11 @@ namespace Kopernicus
                         else
                         {
                             map = new Texture2D(2, 2);
-                            map.LoadImage(System.IO.File.ReadAllBytes(path));
+                            byte[] data = LoadWholeFile(path);
+                            if (data == null)
+                                throw new Exception("LoadWholeFile failed");
+
+                            map.LoadImage(data);
                             if (compress)
                                 map.Compress(true);
                             if (upload)

--- a/Kopernicus/Kopernicus.OnDemand/OnDemandStorage.cs
+++ b/Kopernicus/Kopernicus.OnDemand/OnDemandStorage.cs
@@ -319,8 +319,6 @@ namespace Kopernicus
                         {
                             // Borrowed from stock KSP 1.0 DDS loader (hi Mike!)
                             // Also borrowed the extra bits from Sarbian.
-                            //byte[] buffer = File.ReadAllBytes(path);
-                            //BinaryReader binaryReader = new BinaryReader(new MemoryStream(buffer));
                             BinaryReader binaryReader = new BinaryReader(File.OpenRead(path));
                             uint num = binaryReader.ReadUInt32();
                             if (num == DDSHeaders.DDSValues.uintMagic)

--- a/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
+++ b/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
@@ -27,7 +27,6 @@
 * https://kerbalspaceprogram.com
 */
 
-using System.Collections;
 using System.Diagnostics;
 using UnityEngine;
 

--- a/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
+++ b/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
@@ -27,7 +27,6 @@
 * https://kerbalspaceprogram.com
 */
 
-using System.Diagnostics;
 using UnityEngine;
 
 namespace Kopernicus
@@ -37,6 +36,8 @@ namespace Kopernicus
         // Class to load ScaledSpace Textures on Demand
         public class ScaledSpaceDemand : MonoBehaviour
         {
+            const int UnloadDelaySeconds = 10;
+            
             // Path to the Texture
             public string texture;
 
@@ -58,7 +59,7 @@ namespace Kopernicus
             // Start(), get the scaled Mesh renderer
             void Start()
             {
-                unloadDelay = Stopwatch.Frequency * 10;
+                unloadDelay = System.Diagnostics.Stopwatch.Frequency * UnloadDelaySeconds;
                 scaledRenderer = GetComponent<MeshRenderer>();
                 OnBecameInvisible();
             }
@@ -70,7 +71,7 @@ namespace Kopernicus
                     return;
 
                 // If we're past the unload time then unload
-                if (Stopwatch.GetTimestamp() > unloadTime)
+                if (System.Diagnostics.Stopwatch.GetTimestamp() > unloadTime)
                     UnloadTextures();
             }
 
@@ -96,22 +97,21 @@ namespace Kopernicus
                     return;
 
                 // Set the time at which to unload
-                unloadTime = Stopwatch.GetTimestamp() + unloadDelay;
+                unloadTime = System.Diagnostics.Stopwatch.GetTimestamp() + unloadDelay;
             }
 
             void LoadTextures()
             {
+                Debug.Log("[OD] --> ScaledSpaceDemand.LoadTextures loading " + texture + " and " + normals);
                 // Load Diffuse
                 if (OnDemandStorage.TextureExists(texture))
                 {
-                    //print("ScaledSpaceDemand.LoadTextures loading " + texture);
                     scaledRenderer.material.SetTexture("_MainTex", OnDemandStorage.LoadTexture(texture, false, true, true));
                 }
 
                 // Load Normals
                 if (OnDemandStorage.TextureExists(normals))
                 {
-                    //print("ScaledSpaceDemand.LoadTextures loading " + normals);
                     scaledRenderer.material.SetTexture("_BumpMap", OnDemandStorage.LoadTexture(normals, false, true, false));
                 }
 
@@ -121,17 +121,16 @@ namespace Kopernicus
 
             void UnloadTextures()
             {
+                Debug.Log("[OD] <--- ScaledSpaceDemand.UnloadTextures destroying " + texture + " and " + normals);
                 // Kill Diffuse
                 if (OnDemandStorage.TextureExists(texture))
                 {
-                    //print("ScaledSpaceDemand.UnloadTextures destroying " + texture);
                     DestroyImmediate(scaledRenderer.material.GetTexture("_MainTex"));
                 }
 
                 // Kill Normals
                 if (OnDemandStorage.TextureExists(normals))
                 {
-                    //print("ScaledSpaceDemand.UnloadTextures destroying " + normals);
                     DestroyImmediate(scaledRenderer.material.GetTexture("_BumpMap"));
                 }
 

--- a/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
+++ b/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
@@ -28,6 +28,7 @@
 */
 
 using System.Collections;
+using System.Diagnostics;
 using UnityEngine;
 
 namespace Kopernicus
@@ -49,46 +50,91 @@ namespace Kopernicus
             // State of the texture
             public bool isLoaded = true;
 
+            // If non-zero the textures will be unloaded once the timer exceeds the value
+            private long unloadTime;
+
+            // The number of timestamp ticks in a second
+            private long unloadDelay;
+
             // Start(), get the scaled Mesh renderer
             void Start()
             {
+                unloadDelay = Stopwatch.Frequency * 30;
                 scaledRenderer = GetComponent<MeshRenderer>();
                 OnBecameInvisible();
+            }
+
+            void LateUpdate()
+            {
+                // If we aren't loaded or we're not wanting to unload then do nothing
+                if (!isLoaded || unloadTime == 0)
+                    return;
+
+                // If we're past the unload time then unload
+                if (Stopwatch.GetTimestamp() > unloadTime)
+                    UnloadTextures();
             }
 
             // OnBecameVisible(), load the texture
             void OnBecameVisible()
             {
-                // If it is already loaded, return
+                // It is supposed to be loaded now so clear the unload time
+                unloadTime = 0;
+
+                // If it is already loaded then do nothing
                 if (isLoaded)
                     return;
 
-                // Load Diffuse
-                if (OnDemandStorage.TextureExists(texture))
-                    scaledRenderer.material.SetTexture("_MainTex", OnDemandStorage.LoadTexture(texture, false, true, true));
-
-                // Load Normals
-                if (OnDemandStorage.TextureExists(normals))
-                    scaledRenderer.material.SetTexture("_BumpMap", OnDemandStorage.LoadTexture(normals, false, true, false));
-
-                // Flags
-                isLoaded = true;
+                // Otherwise we load it
+                LoadTextures();
             }
 
             // OnBecameInvisible(), kill the texture
             void OnBecameInvisible()
             {
-                // If it is already loaded, return
+                // If it's not loaded then do nothing
                 if (!isLoaded)
                     return;
 
+                // Set the time at which to unload
+                unloadTime = Stopwatch.GetTimestamp() + unloadDelay;
+            }
+
+            void LoadTextures()
+            {
+                // Load Diffuse
+                if (OnDemandStorage.TextureExists(texture))
+                {
+                    //print("ScaledSpaceDemand.OnBecameVisible loading " + texture);
+                    scaledRenderer.material.SetTexture("_MainTex", OnDemandStorage.LoadTexture(texture, false, true, true));
+                }
+
+                // Load Normals
+                if (OnDemandStorage.TextureExists(normals))
+                {
+                    //print("ScaledSpaceDemand.OnBecameVisible loading " + normals);
+                    scaledRenderer.material.SetTexture("_BumpMap", OnDemandStorage.LoadTexture(normals, false, true, false));
+                }
+
+                // Flags
+                isLoaded = true;
+            }
+
+            void UnloadTextures()
+            {
                 // Kill Diffuse
                 if (OnDemandStorage.TextureExists(texture))
+                {
+                    //print("ScaledSpaceDemand.OnBecameInvisible destroying " + texture);
                     DestroyImmediate(scaledRenderer.material.GetTexture("_MainTex"));
+                }
 
                 // Kill Normals
                 if (OnDemandStorage.TextureExists(normals))
+                {
+                    //print("ScaledSpaceDemand.OnBecameInvisible destroying " + normals);
                     DestroyImmediate(scaledRenderer.material.GetTexture("_BumpMap"));
+                }
 
                 // Flags
                 isLoaded = false;

--- a/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
+++ b/Kopernicus/Kopernicus.OnDemand/ScaledSpaceDemand.cs
@@ -58,7 +58,7 @@ namespace Kopernicus
             // Start(), get the scaled Mesh renderer
             void Start()
             {
-                unloadDelay = Stopwatch.Frequency * 30;
+                unloadDelay = Stopwatch.Frequency * 10;
                 scaledRenderer = GetComponent<MeshRenderer>();
                 OnBecameInvisible();
             }
@@ -104,14 +104,14 @@ namespace Kopernicus
                 // Load Diffuse
                 if (OnDemandStorage.TextureExists(texture))
                 {
-                    //print("ScaledSpaceDemand.OnBecameVisible loading " + texture);
+                    //print("ScaledSpaceDemand.LoadTextures loading " + texture);
                     scaledRenderer.material.SetTexture("_MainTex", OnDemandStorage.LoadTexture(texture, false, true, true));
                 }
 
                 // Load Normals
                 if (OnDemandStorage.TextureExists(normals))
                 {
-                    //print("ScaledSpaceDemand.OnBecameVisible loading " + normals);
+                    //print("ScaledSpaceDemand.LoadTextures loading " + normals);
                     scaledRenderer.material.SetTexture("_BumpMap", OnDemandStorage.LoadTexture(normals, false, true, false));
                 }
 
@@ -124,14 +124,14 @@ namespace Kopernicus
                 // Kill Diffuse
                 if (OnDemandStorage.TextureExists(texture))
                 {
-                    //print("ScaledSpaceDemand.OnBecameInvisible destroying " + texture);
+                    //print("ScaledSpaceDemand.UnloadTextures destroying " + texture);
                     DestroyImmediate(scaledRenderer.material.GetTexture("_MainTex"));
                 }
 
                 // Kill Normals
                 if (OnDemandStorage.TextureExists(normals))
                 {
-                    //print("ScaledSpaceDemand.OnBecameInvisible destroying " + normals);
+                    //print("ScaledSpaceDemand.UnloadTextures destroying " + normals);
                     DestroyImmediate(scaledRenderer.material.GetTexture("_BumpMap"));
                 }
 


### PR DESCRIPTION
This significantly improves the horrible garbage thrash when panning the camera around in the map view in OPM.

Further improvements are possible (even desirable) but it will involve rewriting the LoadTexture function to avoid the allocation of a new byte[] containing the entire texture file for each texture that is loaded.