### PR TITLE
RDVisibility.HIDDEN now hides only the tagged body

### DIFF
--- a/Kopernicus/Kopernicus/Configuration/PropertiesLoader.cs
+++ b/Kopernicus/Kopernicus/Configuration/PropertiesLoader.cs
@@ -284,7 +284,8 @@ namespace Kopernicus
             {
                 VISIBLE,
                 NOICON,
-                HIDDEN
+                HIDDEN,
+                SKIP
             }
 
             // Apply Event

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -68,9 +68,9 @@ namespace Kopernicus
                         PSystemBody parent = PSystemManager.Instance.systemPrefab.GetComponentsInChildren<PSystemBody>(true).First(b => b.children.Contains(hidden));
                         if (parent != null)
                         {
-                            if (skipList.Any(b => b.Value == parent))
+                            if (skipList.Any(b => b.Key == parent))
                             {
-                                int index = skipList.IndexOf(skipList.First(b => b.Value == parent));
+                                int index = skipList.IndexOf(skipList.First(b => b.Key == parent));
                                 skipList.Insert(index, new KeyValuePair<PSystemBody, PSystemBody>(hidden, parent));
                             }
                             else

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -217,7 +217,7 @@ namespace Kopernicus
         {
             // Stuff needed for AddPlanets
             FieldInfo list = typeof(RDArchivesController).GetFields(BindingFlags.Instance | BindingFlags.NonPublic).Skip(7).First();
-            MethodInfo add = typeof(RDArchivesController).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic).Skip(27).First();
+            MethodInfo add = typeof(RDArchivesController).GetMethod("AddPlanets");
             var RDAC = Resources.FindObjectsOfTypeAll<RDArchivesController>().First();
 
             // AddPlanets requires this list to be empty when triggered

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -112,11 +112,11 @@ namespace Kopernicus
 
                 // Undo the changes to the PSystem
 
-                foreach (KeyValuePair<PSystemBody, PSystemBody> pair in skipList)
-                {     
-                    PSystemBody hidden = pair.Key;
-                    PSystemBody parent = pair.Value;
-                    
+                for (int i = skipList.Count; i > 0; i = i - 1)
+                {
+                    PSystemBody hidden = skipList.ElementAt(i).Key;
+                    PSystemBody parent = skipList.ElementAt(i).Value;
+
                     int oldIndex = parent.children.IndexOf(hidden.children.First());
 
                     parent.children.Insert(oldIndex, hidden);
@@ -126,6 +126,7 @@ namespace Kopernicus
                         if (parent.children.Contains(child))
                             parent.children.Remove(child);
                     }
+
                 }
             }
 


### PR DESCRIPTION
entries for the children are moved to where the hidden body should be

alternatively, you could add a new option to RDVisibility, for example RDVisibility.SKIP

so that you can keep both option:
HIDDEN > to hide the body and all its children
SKIP > to hide that body only