### PR TITLE
Add properties for a thick ring

### DIFF
--- a/Kopernicus/Kopernicus.Components/Ring.cs
+++ b/Kopernicus/Kopernicus.Components/Ring.cs
@@ -51,6 +51,12 @@ namespace Kopernicus
             public Texture2D texture;
             public Color color;
             public bool lockRotation;
+            /// <summary>
+            /// Number of seconds for the ring to complete one rotation.
+            /// If zero, fall back to matching parent body if lockRotation=false,
+            /// and standing perfectly still if it's true.
+            /// </summary>
+            public float rotationPeriod;
             public bool unlit;
             public bool useNewShader;
             public int steps = 128;
@@ -414,9 +420,8 @@ namespace Kopernicus
             /// </summary>
             void Update()
             {
-
                 transform.localScale = transform.parent.localScale;
-                if (lockRotation) transform.rotation = rotation;
+                setRotation();
 
                 if (useNewShader)
                 {
@@ -424,7 +429,6 @@ namespace Kopernicus
                     Vector3 sunPosRelativeToPlanet = KopernicusStar.Current.sun.transform.position - ScaledSpace.ScaledToLocalSpace(transform.position);
                     ringMR.material.SetVector("sunPosRelativeToPlanet", sunPosRelativeToPlanet);
                 }
-
             }
 
             /// <summary>
@@ -433,7 +437,7 @@ namespace Kopernicus
             void FixedUpdate()
             {
                 transform.localScale = transform.parent.localScale;
-                if (lockRotation) transform.rotation = rotation;
+                setRotation();
             }
 
             /// <summary>
@@ -442,7 +446,23 @@ namespace Kopernicus
             void LateUpdate()
             {
                 transform.localScale = transform.parent.localScale;
-                if (lockRotation) transform.rotation = rotation;
+                setRotation();
+            }
+
+            /// <summary>
+            /// Populate our transform's rotation quaternion
+            /// </summary>
+            private void setRotation()
+            {
+                if (rotationPeriod != 0f) {
+                    float degreesPerSecond = -360f / rotationPeriod;
+                    transform.rotation = rotation * Quaternion.Euler(
+                        0,
+                        (float)Planetarium.GetUniversalTime() * degreesPerSecond,
+                        0
+                    );
+                } else if (lockRotation)
+                    transform.rotation = rotation;
             }
         }
     }

--- a/Kopernicus/Kopernicus/Configuration/RingLoader.cs
+++ b/Kopernicus/Kopernicus/Configuration/RingLoader.cs
@@ -101,6 +101,18 @@ namespace Kopernicus
                 set { ring.lockRotation = value; }
             }
 
+            /// <summary>
+            /// Number of seconds for the ring to complete one rotation.
+            /// If zero, fall back to matching parent body if lockRotation=false,
+            /// and standing perfectly still if it's true.
+            /// </summary>
+            [ParserTarget("rotationPeriod")]
+            public NumericParser<float> rotationPeriod
+            {
+                get { return ring.rotationPeriod;  }
+                set { ring.rotationPeriod = value; }
+            }
+
             // Unlit our ring?
             [ParserTarget("unlit")]
             public NumericParser<bool> unlit

--- a/Kopernicus/Kopernicus/Configuration/RingLoader.cs
+++ b/Kopernicus/Kopernicus/Configuration/RingLoader.cs
@@ -30,7 +30,7 @@
  *
  * https://kerbalspaceprogram.com
  */
- 
+
 using Kopernicus.Components;
 using UnityEngine;
 
@@ -58,6 +58,15 @@ namespace Kopernicus
             {
                 get { return ring.outerRadius; }
                 set { ring.outerRadius = value; }
+            }
+
+            /// <summary>
+            /// Distance between the top and bottom faces in milliradii
+            /// </summary>
+            [ParserTarget("thickness")]
+            public NumericParser<float> thickness {
+                get { return ring.thickness;  }
+                set { ring.thickness = value; }
             }
 
             // Axis angle of our ring
@@ -122,6 +131,18 @@ namespace Kopernicus
             {
                 get { return ring.steps; }
                 set { ring.steps = value; }
+            }
+
+            /// <summary>
+            /// Number of times the texture should be tiled around the cylinder
+            /// If zero, use the old behavior of sampling a thin diagonal strip
+            /// from (0,0) to (1,1).
+            /// </summary>
+            [ParserTarget("tiles")]
+            public NumericParser<int> tiles
+            {
+                get { return ring.tiles; }
+                set { ring.tiles = value; }
             }
 
             // Initialize the RingLoader

--- a/Kopernicus/Kopernicus/RuntimeUtility/AtmosphereFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/AtmosphereFixer.cs
@@ -136,6 +136,12 @@ namespace Kopernicus
         double timeCounter = 0d;
         void Awake()
         {
+            if (HighLogic.LoadedScene == GameScenes.SPACECENTER)
+            {
+                if (FlightGlobals.GetHomeBody()?.atmosphericAmbientColor != null)
+                    RenderSettings.ambientLight = FlightGlobals.GetHomeBody().atmosphericAmbientColor;
+            }
+
             if (!CompatibilityChecker.IsCompatible())
             {
                 Destroy(this);


### PR DESCRIPTION
This patch extends Ring and RingLoader:

- Support thickness, i.e. a distance between the top and bottom face of the ring, with inner and outer faces added in between
- Support for tiling the texture onto the various faces of the resulting cylinder
- Support for giving each ring its own rotation period

The changes are designed to be backwards compatible; existing planets will not be changed unless they are modified to support the new features (tested with JoolRings from KopernicusExamples). Also hoped to be future compatible with features like ring-on-ring shadows and a solid landable terrain surface.

Intended for visualizing classic fictional megastructures, for example:

![ringworld_screenshot](https://user-images.githubusercontent.com/1559108/28936436-5e9a96f8-784d-11e7-84ee-bfed5153e623.png)

(I'll be releasing the config for that screenshot as a separate mod if this patch is merged.)