### PR TITLE
Allow configuration to specify LAN of rings

### DIFF
--- a/Kopernicus/Kopernicus/Configuration/RingLoader.cs
+++ b/Kopernicus/Kopernicus/Configuration/RingLoader.cs
@@ -2,10 +2,10 @@
  * Kopernicus Planetary System Modifier
  * ====================================
  * Created by: - Bryce C Schroeder (bryce.schroeder@gmail.com)
- * 			   - Nathaniel R. Lewis (linux.robotdude@gmail.com)
+ *             - Nathaniel R. Lewis (linux.robotdude@gmail.com)
  *
  * Maintained by: - Thomas P.
- * 				  - NathanKell
+ *                - NathanKell
  *
 * Additional Content by: Gravitasi, aftokino, KCreator, Padishar, Kragrathea, OvenProofMars, zengei, MrHappyFace
  * -------------------------------------------------------------
@@ -30,7 +30,7 @@
  *
  * https://kerbalspaceprogram.com
  */
- 
+
 using Kopernicus.Components;
 using UnityEngine;
 
@@ -60,12 +60,23 @@ namespace Kopernicus
                 set { ring.outerRadius = value; }
             }
 
-            // Axis angle of our ring
+            // Axis angle (inclination) of our ring
             [ParserTarget("angle")]
             public NumericParser<float> angle
             {
-                get { return ring.rotation.eulerAngles.x; }
-                set { ring.rotation = Quaternion.Euler(value, 0, 0); }
+                get { return -ring.rotation.eulerAngles.x; }
+                set { ring.rotation = Quaternion.Euler(-value, 0, 0); }
+            }
+
+            /// <summary>
+            /// Angle between the absolute reference direction and the ascending node.
+            /// Works just like the corresponding property on celestial bodies.
+            /// </summary>
+            [ParserTarget("longitudeOfAscendingNode")]
+            public NumericParser<float> longitudeOfAscendingNode
+            {
+                get { return ring.longitudeOfAscendingNode;  }
+                set { ring.longitudeOfAscendingNode = value; }
             }
 
             // Texture of our ring
@@ -130,6 +141,9 @@ namespace Kopernicus
                 ring = new GameObject(generatedBody.name + "Ring").AddComponent<Ring>();
                 ring.transform.parent = generatedBody.scaledVersion.transform;
                 ring.planetRadius = (float) generatedBody.celestialBody.Radius;
+
+                // Need to check the parent body's rotation to orient the LAN properly
+                ring.referenceBody = generatedBody.celestialBody;
             }
 
             // Initialize the RingLoader


### PR DESCRIPTION
@PhineasFreak mentioned in a response to #201 that there were some problems with ring orientation, specifically that inclined rings are not consistently oriented the same way across sessions, and the longitude of their ascending nodes could not be set. Among other things, this makes it impossible to align an inclined moon with a nearby inclined ring, or to create texture effects on the parent body that are aligned with Uranus-like rings. This forum post by @OhioBob corroborates that report, and I found the same problems upon investigation:

- http://forum.kerbalspaceprogram.com/index.php?/topic/140580-130-122-kopernicus-release-4-june-15/&do=findComment&comment=2805897

Rather than fix this issue in that pull request, I thought it would be best to split it out into a separate, smaller patch:

- Add longitudeOfAscendingNode property
- Make lockRotation property consistently fix ring to same orientation

After these changes, I can put my inclined Laythe and my inclined JoolRings test case into the same plane by setting their longitudeOfAscendingNode properties to the same value in the cfg:

![jool-rings-and-laythe](https://user-images.githubusercontent.com/1559108/29263751-d0a3eb50-809f-11e7-83e8-181b7ea0dedb.png)
