### PR TITLE
Fix to #201: Z-ordering problem with thick rings

### DIFF
--- a/Kopernicus/Kopernicus.Components/Ring.cs
+++ b/Kopernicus/Kopernicus.Components/Ring.cs
@@ -416,7 +416,11 @@ namespace Kopernicus
                         Tris.Add(firstTop + Wrapping+2 + (i    ));
                         Tris.Add(firstTop +              (i + 2));
                         Tris.Add(firstTop + Wrapping+2 + (i + 2));
-
+                    }
+                    // Outer faces should always draw after inner to
+                    // make the overlaps render correctly
+                    for (int i = 0; i < Wrapping; i += 2)
+                    {
                         // Outer faces
                         Tris.Add(firstTop +              (i + 1));
                         Tris.Add(firstTop + Wrapping+2 + (i + 1));


### PR DESCRIPTION
Since there's no z-buffering, ring faces need to render in the correct
order, and previously the inner and outer faces were interleaved, which
allowed inner faces to be drawn on top of outer.

Now all inner faces will always be drawn before all outer faces, which
produces the correct rendering for overlaps.

(You can only see overlaps if you're outside the ring, and only if an
inner face overlaps an outer. Since you're outside the ring, the outer
face must be closer to you than the inner face.)