### PR TITLE
Ring shader fixes and enhancements

### DIFF
--- a/Kopernicus/Kopernicus.Components/Ring.cs
+++ b/Kopernicus/Kopernicus.Components/Ring.cs
@@ -152,6 +152,7 @@ namespace Kopernicus
                 {
                     ringMR.material.SetFloat("planetRadius",       planetRadius);
                     ringMR.material.SetFloat("penumbraMultiplier", penumbraMultiplier);
+                    ringMR.material.SetFloat("sunRadius",          (float) KopernicusStar.Current.sun.Radius);
                 }
 
                 ringMR.material.color = color;
@@ -443,9 +444,8 @@ namespace Kopernicus
 
                 if (useNewShader)
                 {
-                    ringMR.material.SetFloat("sunRadius", (float)KopernicusStar.Current.sun.Radius);
-                    Vector3 sunPosRelativeToPlanet = KopernicusStar.Current.sun.transform.position - ScaledSpace.ScaledToLocalSpace(transform.position);
-                    ringMR.material.SetVector("sunPosRelativeToPlanet", sunPosRelativeToPlanet);
+                    ringMR.material.SetVector("sunPosRelativeToPlanet",
+                        (Vector3) (KopernicusStar.Current.sun.transform.position - ScaledSpace.ScaledToLocalSpace(transform.position)));
                 }
             }
 

--- a/Kopernicus/Kopernicus/Configuration/RingLoader.cs
+++ b/Kopernicus/Kopernicus/Configuration/RingLoader.cs
@@ -168,6 +168,36 @@ namespace Kopernicus
                 set { ring.tiles = value; }
             }
 
+            /// <summary>
+            /// This texture's opaque pixels cast shadows on our inner surface
+            /// </summary>
+            [ParserTarget("innerShadeTexture")]
+            public Texture2DParser innerShadeTexture
+            {
+                get { return ring.innerShadeTexture;  }
+                set { ring.innerShadeTexture = value; }
+            }
+
+            /// <summary>
+            /// The inner shade texture repeats this many times over the inner surface
+            /// </summary>
+            [ParserTarget("innerShadeTiles")]
+            public NumericParser<int> innerShadeTiles
+            {
+                get { return ring.innerShadeTiles;  }
+                set { ring.innerShadeTiles = value; }
+            }
+
+            /// <summary>
+            /// Number of seconds the inner shade texture takes to complete one rotation
+            /// </summary>
+            [ParserTarget("innerShadeRotationPeriod")]
+            public NumericParser<float> innerShadeRotationPeriod
+            {
+                get { return ring.innerShadeRotationPeriod;  }
+                set { ring.innerShadeRotationPeriod = value; }
+            }
+
             // Initialize the RingLoader
             public RingLoader()
             {

--- a/Shaders/readme.md
+++ b/Shaders/readme.md
@@ -1,12 +1,17 @@
-How to use:
+# How to compile the ring shader
 
-1) Get Unity version that matches KSP (5.4.0.f3 at this time)
+1) Get [Unity version that matches KSP] (5.4.0p4 for 1.2.2 and 1.3.0)
 
-2) Download https://github.com/Kopernicus/shader-export
+2) Clone https://github.com/Kopernicus/shader-export
 
-2) Navigate to this project in Unity
+3) Copy ringsShader.shader into the shader-export project directory
 
-4) Do your changes to ringsShader.shader
+4) Navigate to this project in Unity
 
-5) In unity Editor, go to the assets menu and press "export shader bundles"
+5) Do your changes to ringsShader.shader
 
+6) In Unity Editor, right click on ringsShader.shader and select "Build Shader Bundles"
+
+7) In the popup, enter the file name prefix you wish to use for the compiled shaders. The released shaders are called "kopernicusshaders".
+
+[Unity version that matches KSP]: https://forum.kerbalspaceprogram.com/index.php?/topic/160487-parttools-updated/

--- a/Shaders/ringsShader.shader
+++ b/Shaders/ringsShader.shader
@@ -1,5 +1,5 @@
-//Ring shader for Kopernicus
-//by Ghassen Lahmar (blackrack)
+// Ring shader for Kopernicus
+// by Ghassen Lahmar (blackrack)
 
 Shader "Kopernicus/Rings"
 {
@@ -7,17 +7,17 @@ Shader "Kopernicus/Rings"
   {
     Tags
     {
-      "Queue" = "Transparent"
+      "Queue"           = "Transparent"
       "IgnoreProjector" = "True"
-      "RenderType" = "Transparent"
+      "RenderType"      = "Transparent"
     }
 
     Pass
     {
-      ZWrite off
-
+      ZWrite On
       Cull Off
-      Blend SrcAlpha OneMinusSrcAlpha //alpha blend
+      // Alpha blend
+      Blend SrcAlpha OneMinusSrcAlpha
 
       CGPROGRAM
       #pragma vertex vert
@@ -27,9 +27,9 @@ Shader "Kopernicus/Rings"
 
       #include "UnityCG.cginc"
 
-      uniform sampler2D _MainTex;
+      // These properties are the global inputs shared by all pixels
 
-      uniform sampler2D _noiseTexture;
+      uniform sampler2D _MainTex;
 
       uniform float innerRadius;
       uniform float outerRadius;
@@ -41,110 +41,99 @@ Shader "Kopernicus/Rings"
 
       uniform float penumbraMultiplier;
 
+      // Unity will set this to the material color automatically
+      uniform float4 _Color;
+
       #define M_PI 3.1415926535897932384626
 
+      // This structure defines the inputs for each pixel
       struct v2f
       {
-        float4 pos: SV_POSITION;
-        float3 worldPos: TEXCOORD0;
-        //float3 worldNormal: TEXCOORD1;  //we don't need normals where we're going
-        //LIGHTING_COORDS(3,4) //nor do we need this crap
-        float3 planetOrigin: TEXCOORD1; //moved from fragment shader
-        //float4 objectVertex: TEXCOORD2;
+        float4 pos:          SV_POSITION;
+        float3 worldPos:     TEXCOORD0;
+        // Moved from fragment shader
+        float3 planetOrigin: TEXCOORD1;
+        float2 texCoord:     TEXCOORD2;
       };
 
+      // Set up the inputs for the fragment shader
       v2f vert(appdata_base v)
       {
         v2f o;
-        o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
-
-        o.worldPos = mul(unity_ObjectToWorld, v.vertex);
-
-        //o.viewDir = normalize(o.worldPos - _WorldSpaceCameraPos); //viewdir calculation moved to fragment shader because of interpolation artifacts (that frankly don't make any sense to me)
-
-        //o.worldNormal = normalize(mul( unity_ObjectToWorld, float4(v.normal, 0)).xyz); //should be fine
-
+        o.pos          = mul(UNITY_MATRIX_MVP,    v.vertex);
+        o.worldPos     = mul(unity_ObjectToWorld, v.vertex);
         o.planetOrigin = mul(unity_ObjectToWorld, float4(0, 0, 0, 1)).xyz;
-
-        //o.objectVertex = v.vertex;
-
+        o.texCoord     = v.texcoord;
         return o;
       }
 
-      //mie scattering
-      //copied from scatterer/Proland
+      // Mie scattering
+      // Copied from Scatterer/Proland
       float PhaseFunctionM(float mu, float mieG)
       {
         // Mie phase function
         return 1.5 * 1.0 / (4.0 * M_PI) * (1.0 - mieG * mieG) * pow(1.0 + (mieG * mieG) - 2.0 * mieG * mu, -3.0 / 2.0) * (1.0 + mu * mu) / (2.0 + mieG * mieG);
       }
 
-      //eclipse function from scatterer
-      //used here to cast the planet shadow on the ring
-      //will simplify it later and keep only the necessary bits for the ring
-      //Original Source:   wikibooks.org/wiki/GLSL_Programming/Unity/Soft_Shadows_of_Spheres
-      float getEclipseShadow(float3 worldPos, float3 worldLightPos, float3 occluderSpherePosition,float3 occluderSphereRadius, float3 lightSourceRadius)
+      // Eclipse function from Scatterer
+      // Used here to cast the planet shadow on the ring
+      // Will simplify it later and keep only the necessary bits for the ring
+      // Original Source:   wikibooks.org/wiki/GLSL_Programming/Unity/Soft_Shadows_of_Spheres
+      float getEclipseShadow(float3 worldPos, float3 worldLightPos, float3 occluderSpherePosition, float3 occluderSphereRadius, float3 lightSourceRadius)
       {
         float3 lightDirection = float3(worldLightPos - worldPos);
-        float3 lightDistance = length(lightDirection);
+        float3 lightDistance  = length(lightDirection);
         lightDirection = lightDirection / lightDistance;
 
-        // computation of level of shadowing w  
-        float3 sphereDirection = float3(occluderSpherePosition - worldPos); //occluder planet
-        float sphereDistance = length(sphereDirection);
+        // Computation of level of shadowing w
+        // Occluder planet
+        float3 sphereDirection = float3(occluderSpherePosition - worldPos);
+        float  sphereDistance  = length(sphereDirection);
         sphereDirection = sphereDirection / sphereDistance;
 
         float dd = lightDistance * (asin(min(1.0, length(cross(lightDirection, sphereDirection)))) - asin(min(1.0, occluderSphereRadius / sphereDistance)));
 
-        float w = smoothstep(-1.0, 1.0, -dd / lightSourceRadius);
-        w = w * smoothstep(0.0, 0.2, dot(lightDirection, sphereDirection));
+        float w = smoothstep(-1.0, 1.0, -dd / lightSourceRadius)
+            * smoothstep(0.0, 0.2, dot(lightDirection, sphereDirection));
 
         return (1 - w);
       }
 
+      // Choose a color to use for the pixel represented by 'i'
       float4 frag(v2f i): COLOR
       {
+        // Lighting
+        // Fix this for additional lights later, will be useful when I do the Planetshine update for Scatterer
+        // Assuming directional light only for now
+        float3 lightDir = normalize(_WorldSpaceLightPos0.xyz);
 
-        //fix this for additional lights later, will be useful when I do the planetshine update for scatterer	
-        float3 lightDir = normalize(_WorldSpaceLightPos0.xyz); //assuming directional light only for now
+        // Instead use the viewing direction (inspired from observing space engine rings)
+        // Looks more interesting than I expected
+        float3 viewdir  = normalize(i.worldPos - _WorldSpaceCameraPos);
+        float  mu       = dot(lightDir, -viewdir);
+        float  dotLight = 0.5 * (mu + 1);
 
+        // Mie scattering through rings when observed from the back
+        // Needs to be negative?
+        float mieG = -0.95;
+        // Result too bright for some reason, the 0.03 fixes it
+        float mieScattering = 0.03 * PhaseFunctionM(mu, mieG);
+
+        // Planet shadow on ring
+        // Do everything relative to planet position
+        // *6000 to convert to local space, might be simpler in scaled?
         float3 worldPosRelPlanet = i.worldPos - i.planetOrigin;
-        float distance = length(worldPosRelPlanet);
-
-        float texturePosition = (distance - innerRadius) / (outerRadius - innerRadius);
-        texturePosition = 1 - texturePosition; //flip to match UVs
-
-        //lighting
-        //float dotLight = dot (i.worldNormal,lightDir);  //boring
-        //instead use the viewing direction (inspired from observing space engine rings)
-        //looks more interesting than I expected 
-        float3 viewdir = normalize(i.worldPos - _WorldSpaceCameraPos);
-        float mu = dot(lightDir, -viewdir);
-        float dotLight = 0.5 * (mu + 1);
-
-        //mie scattering through rings when observed from the back
-        float mieG = -0.95; //needs to be negative?
-        float mieScattering = PhaseFunctionM(mu, mieG);
-        mieScattering *= 0.03; // result too bright for some reason, this fixes it
-
-        //planet shadow on ring								
-        //do everything relative to planet position
-        float shadow = getEclipseShadow(worldPosRelPlanet * 6000, sunPosRelativeToPlanet, 0, planetRadius, sunRadius * penumbraMultiplier); //*6000 to convert to local space, might be simpler in scaled?
+        float shadow = getEclipseShadow(worldPosRelPlanet * 6000, sunPosRelativeToPlanet, 0, planetRadius, sunRadius * penumbraMultiplier);
 
         //TODO: Fade in some noise here when getting close to the rings
-        //make it procedural noise?
+        //      Make it procedural noise?
 
-        float4 color = tex2D(_MainTex, float2(texturePosition, 0.25)); //let's say left side = front texture and right side = back texture
-        float4 backColor = tex2D(_MainTex, float2(texturePosition, 0.75)); //back color, same as frontColor if only one band is included
-        //haven't tested a different back texture yet
+        // Look up the texture color
+        float4 color = tex2D(_MainTex, i.texCoord);
+        // Combine material color with texture color and shadow
+        color.xyz = _Color * shadow * (color.xyz * dotLight + color.xyz * mieScattering);
 
-        color.xyz = color.xyz * dotLight + backColor.xyz * mieScattering; //for now alpha is taken from front color only, I'll try to think of something
-        color.xyz *= shadow;
-
-        color = (texturePosition > 1 || texturePosition < 0) ? float4(0, 0, 0, 0) : color; //return transparent pixels if not between inner and outer radiuses
-
-        //I'm kinda proud of this shader so far, it's short and clean
-
+        // I'm kinda proud of this shader so far, it's short and clean
         return color;
       }
       ENDCG


### PR DESCRIPTION
This patch makes the configuration of the "new shader" more consistent with the old shader, so old rings can be updated to use it without modification:

- Use mesh's texture coordinates (fixes the problem where you have to rotate the textures to use the new shader, so the shaders can now share textures)
- Obey `color` property (required for tinted rings as in the green JoolRings example)
- Plus a few quality of life improvements like z-buffering and backface culling

Then a new concept of "inner shade" is added to the "thick" rings. This is a texture that can be used to cast independently mobile shadows on the inner face of a thick ring.

- Property for the texture
- Property specifying how many times it should be tiled
- Property for its rotation period

After these changes, I'm able to configure a real-scale Ringworld complete with functional shadow squares:

![newshader_and_shadowsquareshadows](https://user-images.githubusercontent.com/1559108/29487873-d70bd834-84c5-11e7-8172-90e057f5ec27.gif)