### PR TITLE
workaround for multiple kerbins

### DIFF
--- a/Kopernicus/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -183,6 +183,9 @@ namespace Kopernicus
             PlanetariumCamera.fetch.targets.Clear();
             PlanetariumCamera.fetch.targets.AddRange(trackingstation);
 
+            // Update the initialTarget of the tracking station
+            Resources.FindObjectsOfTypeAll<PlanetariumCamera>().FirstOrDefault().initialTarget = Resources.FindObjectsOfTypeAll<ScaledMovement>().FirstOrDefault(o => o.celestialBody.isHomeWorld);
+
             // Undo stuff
             foreach (CelestialBody b in PSystemManager.Instance.localBodies.Where(b_ => b_.Has("orbitPatches")))
             {


### PR DESCRIPTION
this should solve half of the issues caused by having multiple kerbins ( #186 )

specifically, it solves the issue of having the camera "bounce around" the solar system when entering the trackingstation