### PR TITLE
Fix RnDFixer

### DIFF
--- a/Kopernicus/Kopernicus/Configuration/Body.cs
+++ b/Kopernicus/Kopernicus/Configuration/Body.cs
@@ -63,6 +63,10 @@ namespace Kopernicus
                 }
                 set
                 {
+                    // Change the displayName
+                    generatedBody.celestialBody.bodyDisplayName = value;
+
+                    // Set the NameChanger component
                     if (!generatedBody.celestialBody.GetComponent<NameChanger>())
                     {
                         NameChanger changer = generatedBody.celestialBody.gameObject.AddComponent<NameChanger>();
@@ -70,7 +74,7 @@ namespace Kopernicus
                         changer.newName = value;
                     }
                     else
-                        generatedBody.celestialBody.gameObject.GetComponent<NameChanger>().newName = cbNameLater;
+                        generatedBody.celestialBody.gameObject.GetComponent<NameChanger>().newName = value;
                 }
             }
             

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -202,6 +202,8 @@ namespace Kopernicus
             for (int i = 0; i < containers?.Count(); i++)
             {
                 RDPlanetListItemContainer planetItem = containers[i];
+
+                // The label text is set from the CelestialBody's displayName
                 CelestialBody body = PSystemManager.Instance?.localBodies?.FirstOrDefault(b => b.bodyDisplayName.Replace("^N", "") == planetItem.label_planetName.text);
                 if (body == null)
                 {

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -69,7 +69,7 @@ namespace Kopernicus
                         NumericParser<Double> newSMA = body.orbitDriver.orbit.semiMajorAxis;
                         if (patch.GetValue("semiMajorAxis") != null)
                             newSMA.SetFromString(patch.GetValue("semiMajorAxis"));
-                        
+
                         // Count how many children comes before our body in the newParent.child list
                         Int32 index = 0;
                         foreach (PSystemBody child in newParent.children)
@@ -77,13 +77,13 @@ namespace Kopernicus
                             if (child.orbitDriver.orbit.semiMajorAxis < newSMA.value)
                                 index++;
                         }
-                        
+
                         // Add the body as child for the new parent and remove it for the old parent
                         if (index > newParent.children.Count)
                             newParent.children.Add(body);
                         else
                             newParent.children.Insert(index, body);
-                        
+
                         oldParent.children.Remove(body);
                         postSpawnChanges = true;
                     }
@@ -101,18 +101,16 @@ namespace Kopernicus
 
             // Create a list with body to hide and their parent
             PSystemBody[] bodies = PSystemManager.Instance.systemPrefab.GetComponentsInChildren<PSystemBody>(true);
-            
 
+            // Replaced 'foreach' with 'for' to improve performance
             CelestialBody[] hideBodies = PSystemManager.Instance?.localBodies?.Where(b => b.Has("hiddenRnD")).ToArray();
-            
+
             for (int i = 0; i < hideBodies?.Length; i++)
             {
                 CelestialBody body = hideBodies[i];
-            
 
                 if (body.Get<PropertiesLoader.RDVisibility>("hiddenRnD") == PropertiesLoader.RDVisibility.SKIP)
                 {
-            
                     PSystemBody hidden = Utility.FindBody(PSystemManager.Instance.systemPrefab.rootBody, body.name);
                     if (hidden.children.Count == 0)
                     {

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -44,8 +44,14 @@ namespace Kopernicus
         {
             //  FIX BODIES MOVED POSTSPAWN  //
             Boolean postSpawnChanges = false;
-            foreach (CelestialBody cb in PSystemManager.Instance.localBodies.Where(b => b.Has("orbitPatches")))
+
+            // Replaced 'foreach' with 'for' to improve performance
+            CelestialBody[] postSpawnBodies = PSystemManager.Instance?.localBodies?.Where(b => b.Has("orbitPatches")).ToArray();
+
+            for (int i = 0; i < postSpawnBodies?.Length; i++)
             {
+                CelestialBody cb = postSpawnBodies[i];
+
                 // Fix position if the body gets moved PostSpawn
                 ConfigNode patch = cb.Get<ConfigNode>("orbitPatches");
                 if (patch.GetValue("referenceBody") != null || patch.GetValue("semiMajorAxis") != null)
@@ -95,8 +101,15 @@ namespace Kopernicus
 
             // Create a list with body to hide and their parent
             PSystemBody[] bodies = PSystemManager.Instance.systemPrefab.GetComponentsInChildren<PSystemBody>(true);
-            foreach (CelestialBody body in PSystemManager.Instance.localBodies.Where(b => b.Has("hiddenRnD")))
-            { 
+            
+
+            CelestialBody[] hideBodies = PSystemManager.Instance?.localBodies?.Where(b => b.Has("hiddenRnD")).ToArray();
+            
+            for (int i = 0; i < hideBodies?.Length; i++)
+            {
+                CelestialBody body = hideBodies[i];
+            
+
                 if (body.Get<PropertiesLoader.RDVisibility>("hiddenRnD") == PropertiesLoader.RDVisibility.SKIP)
                 {
                     PSystemBody hidden = Utility.FindBody(PSystemManager.Instance.systemPrefab.rootBody, name);
@@ -137,7 +150,7 @@ namespace Kopernicus
                 parent.children.Remove(hidden);
             }
 
-            if (skipList.Count > 0)
+            if (skipList?.Count > 0)
             {
                 // Rebuild Archives
                 AddPlanets();

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -112,7 +112,8 @@ namespace Kopernicus
 
                 if (body.Get<PropertiesLoader.RDVisibility>("hiddenRnD") == PropertiesLoader.RDVisibility.SKIP)
                 {
-                    PSystemBody hidden = Utility.FindBody(PSystemManager.Instance.systemPrefab.rootBody, name);
+            
+                    PSystemBody hidden = Utility.FindBody(PSystemManager.Instance.systemPrefab.rootBody, body.name);
                     if (hidden.children.Count == 0)
                     {
                         body.Set("hiddenRnd", PropertiesLoader.RDVisibility.HIDDEN);

--- a/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
+++ b/Kopernicus/Kopernicus/RuntimeUtility/RnDFixer.cs
@@ -222,7 +222,7 @@ namespace Kopernicus
         {
             // Stuff needed for AddPlanets
             FieldInfo list = typeof(RDArchivesController).GetFields(BindingFlags.Instance | BindingFlags.NonPublic).Skip(7).First();
-            MethodInfo add = typeof(RDArchivesController).GetMethod("AddPlanets");
+            MethodInfo add = typeof(RDArchivesController).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)?.Skip(26)?.FirstOrDefault();
             var RDAC = Resources.FindObjectsOfTypeAll<RDArchivesController>().First();
 
             // AddPlanets requires this list to be empty when triggered


### PR DESCRIPTION
this fixes numerous issues with *RnDFixer*:

- *fixed reflection* of method "AddPlanets" that was not working
- *added checks* to catch errors more easily
- *changed all foreach* to for to improve performance
- *removed namechanger* code from RnDFixed (not necessary anymore)

also, now using *cbNameLater* will set the *displayName* as well