### PR TITLE
Ram and OnDemand

### DIFF
--- a/src/Kopernicus.OnDemand/CBAttributeMapSODemand.cs
+++ b/src/Kopernicus.OnDemand/CBAttributeMapSODemand.cs
@@ -81,7 +81,7 @@ namespace Kopernicus
             public void Unload()
             {
                 // We can only destroy the map, if it is loaded and initialized
-                if (!IsLoaded || !String.IsNullOrEmpty(Path))
+                if (!IsLoaded || String.IsNullOrEmpty(Path))
                     return;
 
                 // Nuke the map

--- a/src/Kopernicus.OnDemand/CBAttributeMapSODemand.cs
+++ b/src/Kopernicus.OnDemand/CBAttributeMapSODemand.cs
@@ -81,7 +81,7 @@ namespace Kopernicus
             public void Unload()
             {
                 // We can only destroy the map, if it is loaded and initialized
-                if (!IsLoaded || String.IsNullOrEmpty(Path))
+                if (!IsLoaded || !String.IsNullOrEmpty(Path))
                     return;
 
                 // Nuke the map

--- a/src/Kopernicus/Utility.cs
+++ b/src/Kopernicus/Utility.cs
@@ -467,6 +467,7 @@ namespace Kopernicus
                 pqsVersion.isBuildingMaps = false;
                 pqsVersion.DeactivateSphere();
                 UnityEngine.Object.Destroy(pqsVersionGameObject);
+                OnDemand.OnDemandStorage.DisableBody(body.bodyName);
             }
 
             // Return the generated scaled space mesh

--- a/src/Kopernicus/Utility.cs
+++ b/src/Kopernicus/Utility.cs
@@ -467,7 +467,6 @@ namespace Kopernicus
                 pqsVersion.isBuildingMaps = false;
                 pqsVersion.DeactivateSphere();
                 UnityEngine.Object.Destroy(pqsVersionGameObject);
-                OnDemand.OnDemandStorage.DisableBody(body.bodyName);
             }
 
             // Return the generated scaled space mesh


### PR DESCRIPTION
this fixes a couple of issues:

1- CBAttributeMapSODemand.Unload()

this method wasn't working properly since it was expecting textures to have an empty path, now it's fixed


2- Utility.ComputeScaledSpaceMesh()

this method was using a lot of RAM because it was calling OnDemand.OnDemandStorage.EnableBody() but it wasn't calling OnDemand.OnDemandStorage.DisableBody(), now this is fixed as well