### PR TITLE
Duplicate body/asteroid loader fix

### DIFF
--- a/src/Kopernicus/Configuration/Loader.cs
+++ b/src/Kopernicus/Configuration/Loader.cs
@@ -206,6 +206,8 @@ namespace Kopernicus
                 // Dictionary of bodies generated
                 Dictionary<String, Body> bodies = new Dictionary<String, Body>();
 
+                Logger logger = new Logger();
+
                 // Load all of the bodies
                 foreach (ConfigNode bodyNode in node.GetNodes(bodyNodeName))
                 {
@@ -221,9 +223,9 @@ namespace Kopernicus
 
                     try
                     {
-                        // Create a logger for this body
-                        Logger bodyLogger = new Logger(bodyNode.GetValue("name") + ".Body");
-                        bodyLogger.SetAsActive();
+                        // Create a logfile for this body
+                        logger.SetFilename(bodyNode.GetValue("name") + ".Body");
+                        logger.SetAsActive();
 
                         // Attempt to create the body
                         currentBody = new Body();
@@ -233,16 +235,16 @@ namespace Kopernicus
                         Logger.Default.Log("[Kopernicus]: Configuration.Loader: Loaded Body: " + currentBody.name);
 
                         // Restore default logger
-                        bodyLogger.Flush();
                         Logger.Default.SetAsActive();
+                        logger.Close(); //implicit flush
                     }
                     catch (Exception e)
                     {
-                        //bodyLogger.LogException(e);  -- This would be nice but becomes a problem when duplicate loggers are created: can't log then
+                        logger.LogException(e);
+                        logger.Close(); //implicit flush
                         Logger.Default.Log("[Kopernicus]: Configuration.Loader: Failed to load Body: " + bodyNode.GetValue("name") + ": " + e.Message); 
                         throw new Exception("Failed to load Body: " + bodyNode.GetValue("name"));
                     }
-
                 }
                 seen.Clear();
 
@@ -263,8 +265,8 @@ namespace Kopernicus
                     }
                     try
                     {
-                        // Create a logger for this asteroid
-                        Logger logger = new Logger(asteroidNode.GetValue("name") + ".Asteroid");
+                        // Create a logfile for this asteroid
+                        logger.SetFilename(asteroidNode.GetValue("name") + ".Asteroid");
                         logger.SetAsActive();
 
                         // Attempt to create the Asteroid
@@ -274,17 +276,21 @@ namespace Kopernicus
                         Logger.Default.Log("[Kopernicus]: Configuration.Loader: Loaded Asteroid: " + asteroid.name);
 
                         // Restore default logger
-                        logger.Flush();
                         Logger.Default.SetAsActive();
+                        logger.Close(); //implicit flush
                     }
                     catch (Exception e)
                     {
                         Logger.Default.Log("[Kopernicus]: Configuration.Loader: Failed to load Asteroid: " + asteroidNode.GetValue("name") + ": " + e.Message);
+                        logger.LogException(e);
+                        logger.Close();
                         throw new Exception("Failed to load Asteroid: " + asteroidNode.GetValue("name"));
                     }
 
                 }
                 seen.Clear();
+                logger.Close();
+                logger = null;
 
                 // Load all of the PQS Presets                
                 foreach (ConfigNode presetNode in node.GetNodes(presetNodeName))

--- a/src/Kopernicus/Configuration/Loader.cs
+++ b/src/Kopernicus/Configuration/Loader.cs
@@ -200,66 +200,91 @@ namespace Kopernicus
             // Generates the system prefab from the configuration 
             void IParserEventSubscriber.PostApply(ConfigNode node)
             {
+                //Set of items seen while loading, to prevent duplicate loggers being created (throws IOExceptions)
+                HashSet<String> seen = new HashSet<String>();
+
                 // Dictionary of bodies generated
                 Dictionary<String, Body> bodies = new Dictionary<String, Body>();
 
                 // Load all of the bodies
                 foreach (ConfigNode bodyNode in node.GetNodes(bodyNodeName))
                 {
-                    // Create a logger for this body
-                    Logger bodyLogger = new Logger(bodyNode.GetValue("name") + ".Body");
-                    bodyLogger.SetAsActive();
+                    if ( seen.Contains(bodyNode.GetValue("name")) )
+                    {
+                        Logger.Default.Log("[Kopernicus::PostApply] Skipped duplicate body " + bodyNode.GetValue("name"));
+                        continue; //next body, please
+                    }
+                    else
+                    {
+                        seen.Add(bodyNode.GetValue("name"));
+                    }
 
-                    // Attempt to create the body
                     try
                     {
+                        // Create a logger for this body
+                        Logger bodyLogger = new Logger(bodyNode.GetValue("name") + ".Body");
+                        bodyLogger.SetAsActive();
+
+                        // Attempt to create the body
                         currentBody = new Body();
-                        Parser.LoadObjectFromConfigurationNode(currentBody, bodyNode, "Kopernicus");
+                        Parser.LoadObjectFromConfigurationNode(currentBody, bodyNode, "Kopernicus"); //logs to active logger
                         bodies.Add(currentBody.name, currentBody);
                         Events.OnLoaderLoadBody.Fire(currentBody, bodyNode);
                         Logger.Default.Log("[Kopernicus]: Configuration.Loader: Loaded Body: " + currentBody.name);
+
+                        // Restore default logger
+                        bodyLogger.Flush();
+                        Logger.Default.SetAsActive();
                     }
                     catch (Exception e)
                     {
-                        bodyLogger.LogException(e);
-                        Logger.Default.Log("[Kopernicus]: Configuration.Loader: Failed to load Body: " + bodyNode.GetValue("name"));
+                        //bodyLogger.LogException(e);  -- This would be nice but becomes a problem when duplicate loggers are created: can't log then
+                        Logger.Default.Log("[Kopernicus]: Configuration.Loader: Failed to load Body: " + bodyNode.GetValue("name") + ": " + e.Message); 
                         throw new Exception("Failed to load Body: " + bodyNode.GetValue("name"));
                     }
 
-                    // Restore default logger
-                    bodyLogger.Flush();
-                    Logger.Default.SetAsActive();
                 }
+                seen.Clear();
 
                 // Event
                 Events.OnLoaderLoadedAllBodies.Fire(this, node);
 
-                // Load all of the asteroids                
+                // Load all of the asteroids
                 foreach (ConfigNode asteroidNode in node.GetNodes(asteroidNodeName))
                 {
-                    // Create a logger for this asteroid
-                    Logger logger = new Logger(asteroidNode.GetValue("name") + ".Asteroid");
-                    logger.SetAsActive();
-
-                    // Attempt to create the Asteroid
+                    if (seen.Contains(asteroidNode.GetValue("name")))
+                    {
+                        Logger.Default.Log("[Kopernicus::PostApply] Skipped duplicate asteroid " + asteroidNode.GetValue("name"));
+                        continue; //next roid, please
+                    }
+                    else
+                    {
+                        seen.Add(asteroidNode.GetValue("name"));
+                    }
                     try
                     {
-                        Asteroid asteroid = Parser.CreateObjectFromConfigNode<Asteroid>(asteroidNode, "Kopernicus");
+                        // Create a logger for this asteroid
+                        Logger logger = new Logger(asteroidNode.GetValue("name") + ".Asteroid");
+                        logger.SetAsActive();
+
+                        // Attempt to create the Asteroid
+                        Asteroid asteroid = Parser.CreateObjectFromConfigNode<Asteroid>(asteroidNode, "Kopernicus"); //logs to active logger
                         DiscoverableObjects.asteroids.Add(asteroid);
                         Events.OnLoaderLoadAsteroid.Fire(asteroid, asteroidNode);
                         Logger.Default.Log("[Kopernicus]: Configuration.Loader: Loaded Asteroid: " + asteroid.name);
+
+                        // Restore default logger
+                        logger.Flush();
+                        Logger.Default.SetAsActive();
                     }
                     catch (Exception e)
                     {
-                        logger.LogException(e);
-                        Logger.Default.Log("[Kopernicus]: Configuration.Loader: Failed to load Asteroid: " + asteroidNode.GetValue("name"));
+                        Logger.Default.Log("[Kopernicus]: Configuration.Loader: Failed to load Asteroid: " + asteroidNode.GetValue("name") + ": " + e.Message);
                         throw new Exception("Failed to load Asteroid: " + asteroidNode.GetValue("name"));
                     }
 
-                    // Restore default logger
-                    logger.Flush();
-                    Logger.Default.SetAsActive();
                 }
+                seen.Clear();
 
                 // Load all of the PQS Presets                
                 foreach (ConfigNode presetNode in node.GetNodes(presetNodeName))

--- a/src/Kopernicus/Logger.cs
+++ b/src/Kopernicus/Logger.cs
@@ -56,8 +56,10 @@ namespace Kopernicus
         {
             get
             {
-                if (_DefaultLogger == null)
-                    _DefaultLogger = new Logger();
+                if (_DefaultLogger == null) {
+                    _DefaultLogger = new Logger(LogFileName: typeof(Logger).Assembly.GetName().Name);
+                    Debug.Log("[Kopernicus] Default logger initialized as " + typeof(Logger).Assembly.GetName().Name);
+                }
                 return _DefaultLogger;
             }
         }
@@ -132,11 +134,19 @@ namespace Kopernicus
         // Create a logger
         public Logger([Optional] String LogFileName)
         {
+            SetFilename(LogFileName);
+        }
+
+        // Set/Change the filename we log to
+        public void SetFilename(String LogFileName)
+        {
+            Close();
+
             if (!isInitialized)
                 return;
-            if (String.IsNullOrEmpty(LogFileName))
-                LogFileName = typeof(Logger).Assembly.GetName().Name;
 
+            if (String.IsNullOrEmpty(LogFileName))
+                return; //effectively makes this logger a black hole
 
             try
             {
@@ -147,23 +157,22 @@ namespace Kopernicus
 
                 // Write an opening message
                 String logVersion = "//=====  " + version + "  =====//";
-                String logHeader = new string('=',logVersion.Length-4);
+                String logHeader = new string('=', logVersion.Length - 4);
                 logHeader = "//" + logHeader + "//";
 
                 loggerStream.WriteLine(logHeader + "\n" + logVersion + "\n" + logHeader); // Don't use Log() because we don't want a date time in front of the Versioning.
-                Log ("Logger \"" + LogFileName + "\" was created");
+                Log("Logger \"" + LogFileName + "\" was created");
             }
-            catch (Exception e) 
+            catch (Exception e)
             {
-                Debug.LogException (e);
+                Debug.LogException(e);
             }
         }
 
         // Cleanup the logger
         ~Logger()
         {
-            loggerStream.Flush ();
-            loggerStream.Close ();
+            Close();
         }
 
         // Initialize the Logger (i.e. delete old logs) 
@@ -183,7 +192,7 @@ namespace Kopernicus
             }
             catch (Exception e) 
             {
-                Debug.LogException (e);
+                Debug.LogException(e);
                 return;
             }
 


### PR DESCRIPTION
Duplicate bodies/asteroids cause duplicate loggers to be created, throwing IOExceptions and killing loading. Now loader skips duplicated entries gracefully.