### PR TITLE
WIP: Orbital icon customization loop performance issues

### DIFF
--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -51,6 +51,7 @@ namespace Kopernicus
     {
         // Variables
         public MapObject previous;
+        private readonly Dictionary<CelestialBody, Sprite> _spriteCache = new Dictionary<CelestialBody, Sprite>();
 
         // Awake() - flag this class as don't destroy on load and register delegates
         void Awake()
@@ -391,17 +392,28 @@ namespace Kopernicus
                         }
                     }
                 }
-                
+
                 // Apply orbit icon customization
-                foreach (MapNode node in Resources.FindObjectsOfTypeAll<MapNode>())
+                foreach (CelestialBody body in FlightGlobals.Bodies)
                 {
-                    if (node.mapObject != null && node.mapObject.celestialBody != null && node.mapObject.celestialBody.Has("iconTexture"))
+                    if (body.MapObject != null && body.MapObject.uiNode != null && body.Has("iconTexture"))
                     {
-                        Texture2D texture = node.mapObject.celestialBody.Get<Texture2D>("iconTexture");
-                        node.SetIcon(Sprite.Create(texture,
-                            new Rect(0, 0, texture.width, texture.height),
-                            new Vector2(0.5f, 0.5f), 100, 1, SpriteMeshType.Tight,
-                            Vector4.zero));
+                        _spriteCache.TryGetValue(body, out Sprite sprite);
+                        if (sprite == null)
+                        {
+                            Texture2D texture = body.Get<Texture2D>("iconTexture");
+                            sprite = Sprite.Create(
+                                texture,
+                                new Rect(0, 0, texture.width, texture.height),
+                                new Vector2(0.5f, 0.5f),
+                                100,
+                                1,
+                                SpriteMeshType.Tight,
+                                Vector4.zero
+                            );
+                            _spriteCache[body] = sprite;
+                        }
+                        body.MapObject.uiNode.SetIcon(sprite);
                     }
                 }
             }


### PR DESCRIPTION
See #309 
By looping through just `FlightGlobals.Bodies` instead of all resources, this loop is quite a bit faster (doubled my framerate with GPP + GEP + OPM). I don't know if important bodies are excluded or if this can be optimized more aggressively without better test data (a config with customized icons, preferably a planet pack). Off the top of my head, a more aggressive optimization would be to identify a smaller set of customized bodies once and then loop through only those bodies OR determine if the icons can be set less frequently (only once, for example).

Very open to ideas and discussion. I'm not much of an artist/designer (or great with working with those assets) so I question how realistic an orbital icon test case I can put together without some outside guidance.