### PR TITLE
Use Vector3d instead of Vector3

### DIFF
--- a/src/Kopernicus.Components/KopernicusStar.cs
+++ b/src/Kopernicus.Components/KopernicusStar.cs
@@ -155,10 +155,10 @@ namespace Kopernicus
                 // Get sunVector
                 RaycastHit raycastHit;
                 Boolean directSunlight = false;
-                Vector3d scaledSpace = ScaledSpace.LocalToScaledSpace(fi.IntegratorTransform.position);
+                Vector3d scaledSpace = ScaledSpace.LocalToScaledSpace(fi.Vessel.CoMD);
                 Double scale = Math.Max((star.sun.scaledBody.transform.position - scaledSpace).magnitude, 1);
-                Vector3 sunVector = (star.sun.scaledBody.transform.position - scaledSpace) / scale;
-                Ray ray = new Ray(ScaledSpace.LocalToScaledSpace(fi.IntegratorTransform.position), sunVector);
+                Vector3 sunVector = (star.sun.position - scaledSpace) / scale;
+                Ray ray = new Ray(ScaledSpace.LocalToScaledSpace(fi.Vessel.CoMD), sunVector);
 
                 // Get Solar Flux
                 Double realDistanceToSun = 0;


### PR DESCRIPTION
by using vector3d instead of Vector3, the calculated distance is much more accurate, resulting in much less instability in the final solar power