### PR TITLE
Update HazardousOcean.cs

### DIFF
--- a/src/Kopernicus.Components/HazardousOcean.cs
+++ b/src/Kopernicus.Components/HazardousOcean.cs
@@ -71,7 +71,7 @@ namespace Kopernicus
                     Double distanceToPlanet = Math.Abs(Vector3d.Distance(vessel.transform.position, body.transform.position)) - ocean.GetSurfaceHeight(ocean.GetRelativePosition(vessel.transform.position));
                     Double heatingRate = heatCurve.Evaluate((Single)distanceToPlanet);
                     foreach (Part part in vessel.Parts)
-                        part.temperature += heatingRate;
+                        part.temperature += (heatingRate * Time.deltaTime); // scale from degrees per frame to degrees per second.
                 }
             }
         }


### PR DESCRIPTION
Currently HazardousOcean adds temperature per _frame_ and not per _second._ Not only is degrees per second a much easier unit to work with, it will also remain consistent with respect to lag spikes. Besides that, it'll make even the tiniest of HazardousOcean temperature emissions impossible to deal with for beefy computers, as even the slightest additions will hit like a truck when multiplied by 120 as a consequence of running at 120 FPS.