### PR TITLE
Update SolarPanels.cfg

### DIFF
--- a/build/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -7,7 +7,7 @@
     // If you want to keep your ModuleDeployableSolarPanel, add "useKopernicusSolarPanels = false" to the MODULE node
     // That will stop Kopernicus from replacing it
     //
-    @MODULE[ModuleDeployableSolarPanel]:HAS[#useKopernicusSolarPanels[*]]
+    @MODULE:HAS[#useKopernicusSolarPanels[*]]
     {
         @useKopernicusSolarPanels,* ^= :F:f:
         @useKopernicusSolarPanels,* ^= :A:a:
@@ -15,7 +15,7 @@
         @useKopernicusSolarPanels,* ^= :S:s:
         @useKopernicusSolarPanels,* ^= :E:e:
     }
-    @MODULE[ModuleDeployableSolarPanel]:HAS[~useKopernicusSolarPanels[false]]
+    @MODULE:HAS[#name[ModuleDeployableSolarPanel],~useKopernicusSolarPanels[false]]
     {
         @name = KopernicusSolarPanel
     }

--- a/build/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -1,11 +1,13 @@
-@PART:FINAL
+@PART[*]:HAS[@MODULE[ModuleDeployableSolarPanel]]:FINAL
 {
+    //
     // This will replace all instances of ModuleDeployableSolarPanel with the Kopernicus version
     // that has proper support for multiple lightsources
     // 
     // If you want to keep your ModuleDeployableSolarPanel, add "useKopernicusSolarPanels = false" to the MODULE node
     // That will stop Kopernicus from replacing it
-    @MODULE:HAS[#useKopernicusSolarPanels[*]]
+    //
+    @MODULE[ModuleDeployableSolarPanel]:HAS[#useKopernicusSolarPanels[*]]
     {
         @useKopernicusSolarPanels,* ^= :F:f:
         @useKopernicusSolarPanels,* ^= :A:a:
@@ -13,7 +15,7 @@
         @useKopernicusSolarPanels,* ^= :S:s:
         @useKopernicusSolarPanels,* ^= :E:e:
     }
-    @MODULE:HAS[#name[ModuleDeployableSolarPanel],~useKopernicusSolarPanels[false]]
+    @MODULE[ModuleDeployableSolarPanel]:HAS[~useKopernicusSolarPanels[false]]
     {
         @name = KopernicusSolarPanel
     }


### PR DESCRIPTION
Reduce the inflated number of parts allegedly patched by Module Manager (make it so that this patch only goes through parts with specific modules). The change in syntax requires later versions of MM but Kopernicus already requires that. Assumption is that parts can only have one ModuleDeployableSolarPanel