### PR TITLE
Disabled biome map OD again

### DIFF
--- a/src/Kopernicus/OnDemand/OnDemandStorage.cs
+++ b/src/Kopernicus/OnDemand/OnDemandStorage.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.OnDemand
 
         // OnDemand flags
         public static Boolean UseOnDemand = true;
-        public static Boolean UseOnDemandBiomes = true;
+        public static Boolean UseOnDemandBiomes = false;
         public static Boolean OnDemandLoadOnMissing = true;
         public static Boolean OnDemandLogOnMissing = true;
         public static Int32 OnDemandUnloadDelay = 10;


### PR DESCRIPTION
Even with dds textures, as @Poodmund confirmed, it takes some time to load in
the map view. And as biome maps are not that big, I think it can be safely
disabled again.