### PR TITLE
Multiple sp test

### DIFF
--- a/build/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -1,20 +1,21 @@
-@PART:HAS[@MODULE:HAS[#name[ModuleDeployableSolarPanel]]]:FINAL
+@PART:HAS[#useKopernicusSolarPanels[*]]:FINAL
 {
-    // This will replace all instances of ModuleDeployableSolarPanel with the Kopernicus version
-    // that has proper support for multiple lightsources
+    // This cfg will enable KopernicusSolarPanels
+    // to allow support for multiple lightsources
     // 
-    // If you want to keep your ModuleDeployableSolarPanel, add "useKopernicusSolarPanels = false" to the MODULE node
-    // That will stop Kopernicus from replacing it
-    @MODULE:HAS[#useKopernicusSolarPanels[*]]
+    // If you want to avoid this, add "useKopernicusSolarPanels = false" to the PART node
+    // That will stop Kopernicus from changing the behaviour of SolarPanels
+    @useKopernicusSolarPanels,* ^= :F:f:
+    @useKopernicusSolarPanels,* ^= :A:a:
+    @useKopernicusSolarPanels,* ^= :L:l:
+    @useKopernicusSolarPanels,* ^= :S:s:
+    @useKopernicusSolarPanels,* ^= :E:e:
+}
+
+@PART:HAS[@MODULE[ModuleDeployableSolarPanel],~useKopernicusSolarPanels[false]]
+{
+    MODULE
     {
-        @useKopernicusSolarPanels,* ^= :F:f:
-        @useKopernicusSolarPanels,* ^= :A:a:
-        @useKopernicusSolarPanels,* ^= :L:l:
-        @useKopernicusSolarPanels,* ^= :S:s:
-        @useKopernicusSolarPanels,* ^= :E:e:
-    }
-    +MODULE:HAS[#name[ModuleDeployableSolarPanel],~useKopernicusSolarPanels[false]]
-    {
-        @name = KopernicusSolarPanel
+        name = KopernicusSolarPanels
     }
 }

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -47,7 +47,7 @@ namespace Kopernicus.Components
         [KSPField(isPersistant = true)]
         private Boolean _relativeSunAoa;
 
-        private ModuleDeployableSolarPanel SP;
+        private ModuleDeployableSolarPanel[] SPs;
 
         private static readonly Double StockLuminosity;
 
@@ -65,16 +65,21 @@ namespace Kopernicus.Components
 
         public void LatePostCalculateTracking()
         {
+            foreach (var SP in SPs)
+            {
             if (SP?.deployState == ModuleDeployablePart.DeployState.EXTENDED)
             {
                 Vector3 normalized = (SP.trackingTransformLocal.position - SP.panelRotationTransform.position).normalized;
                 FieldInfo trackingLOS = typeof(ModuleDeployableSolarPanel).GetFields(BindingFlags.Instance | BindingFlags.NonPublic).FirstOrDefault(f => f.Name == "trackingLOS");
                 LatePostCalculateTracking((bool)trackingLOS.GetValue(SP), normalized);
             }
+            }
         }
 
         public void LatePostCalculateTracking(Boolean trackingLos, Vector3 trackingDirection)
         {
+            foreach (var SP in SPs)
+            {
             // Maximum values
             Double maxEnergy = 0;
             KopernicusStar maxStar = null;
@@ -222,10 +227,13 @@ namespace Kopernicus.Components
 
             // Use the flow rate
             SP.flowRate = (Single)(SP.resHandler.UpdateModuleResourceOutputs(SP._flowRate) * SP.flowMult);
+            }
         }
 
         public void EarlyLateUpdate()
         {
+            foreach (var SP in SPs)
+            {
             if (SP?.deployState == ModuleDeployablePart.DeployState.EXTENDED)
             {
                 // Update the name
@@ -234,11 +242,14 @@ namespace Kopernicus.Components
                 // Update the guiName for SwitchAOAMode
                 Events["SwitchAoaMode"].guiName = _relativeSunAoa ? "Use absolute exposure" : "Use relative exposure";
             }
+            }
         }
 
         [KSPEvent(active = true, guiActive = true, guiName = "Select Tracking Body")]
         public void ManualTracking()
         {
+            foreach (var SP in SPs)
+            {
             // Assemble the buttons
             DialogGUIBase[] options = new DialogGUIBase[KopernicusStar.Stars.Count + 1];
             options[0] = new DialogGUIButton("Auto", () => { _manualTracking = false; }, true);
@@ -259,6 +270,7 @@ namespace Kopernicus.Components
                 "Select Tracking Body",
                 UISkinManager.GetSkin("MainMenuSkin"),
                 options), false, UISkinManager.GetSkin("MainMenuSkin"));
+            }
         }
 
         [KSPEvent(active = true, guiActive = true, guiName = "Use relative exposure")]
@@ -272,7 +284,7 @@ namespace Kopernicus.Components
             TimingManager.LateUpdateAdd(TimingManager.TimingStage.Early, EarlyLateUpdate);
             TimingManager.FixedUpdateAdd(TimingManager.TimingStage.Late, LatePostCalculateTracking);
 
-            SP = GetComponent<ModuleDeployableSolarPanel>();
+            SPs = GetComponents<ModuleDeployableSolarPanel>();
 
             base.OnStart(state);
         }


### PR DESCRIPTION
This PR contains changes for the KopernicusSolarPanels.

Overview of the changes:
- Changed from `KopernicusSolarPanel` to `KopernicusSolarPanels`
- Only one 'KopernicusSolarPanels' will be added for each `PART`
- `useKopernicusSolarPanels = true/false` has been moved from the `MODULE` to the `PART` node
- replaced all `foreach` with `for` loops
- changed existing `for` loops so that they only check the length once
- fixed solarpanels blocked status
- hidden tracking info by default, only display them if the solar panel can track
- activate KopernicusSolarPanels only in flight mode