### PR TITLE
Clean Logs

### DIFF
--- a/src/Kopernicus/Logger.cs
+++ b/src/Kopernicus/Logger.cs
@@ -201,10 +201,7 @@ namespace Kopernicus
                 }
 
                 // Clear out the old log files
-                foreach(String file in Directory.GetFiles(LogDirectory))
-                {
-                    File.Delete(file);
-                }
+                Directory.Delete(LogDirectory, true);
             }
             catch (Exception e) 
             {

--- a/src/Kopernicus/RuntimeUtility/LogAggregator.cs
+++ b/src/Kopernicus/RuntimeUtility/LogAggregator.cs
@@ -119,14 +119,17 @@ namespace Kopernicus.RuntimeUtility
             {
                 String modName = kvP.Key;
                 String[] filePaths = kvP.Value;
-                
-                // Does the file already exist?
+
+                // Does the folder already exist?
+                String folder = KSPUtil.ApplicationRootPath + "Logs/";
                 String path = KSPUtil.ApplicationRootPath + "Logs/" + "Logs-" + modName + ".zip";
-                Directory.CreateDirectory(Path.GetDirectoryName(path));
-                if (File.Exists(path))
+
+                if (Directory.Exists(folder))
                 {
-                    File.Delete(path);
+                    Directory.Delete(folder, true);
                 }
+
+                Directory.CreateDirectory(folder);
 
                 using (ZipStorer zip = ZipStorer.Create(path, ""))
                 {

--- a/src/Kopernicus/RuntimeUtility/LogAggregator.cs
+++ b/src/Kopernicus/RuntimeUtility/LogAggregator.cs
@@ -119,17 +119,14 @@ namespace Kopernicus.RuntimeUtility
             {
                 String modName = kvP.Key;
                 String[] filePaths = kvP.Value;
-
-                // Does the folder already exist?
-                String folder = KSPUtil.ApplicationRootPath + "Logs/";
+                
+                // Does the file already exist?
                 String path = KSPUtil.ApplicationRootPath + "Logs/" + "Logs-" + modName + ".zip";
-
-                if (Directory.Exists(folder))
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                if (File.Exists(path))
                 {
-                    Directory.Delete(folder, true);
+                    File.Delete(path);
                 }
-
-                Directory.CreateDirectory(folder);
 
                 using (ZipStorer zip = ZipStorer.Create(path, ""))
                 {


### PR DESCRIPTION
when running kopernicus, old Logs remain in the Logs folder and are not
properly cleaned
this change makes sure every time the whole Logs folder is cleared