### PR TITLE
Fixed HazardousBody and HazardousOcean heating rates

### DIFF
--- a/src/Kopernicus/Components/HazardousOcean.cs
+++ b/src/Kopernicus/Components/HazardousOcean.cs
@@ -55,9 +55,9 @@ namespace Kopernicus.Components
         }
 
         /// <summary>
-        /// Update the heat
+        /// Update the heat. Heating is physics phenomenon so do it in the physics loop.
         /// </summary>
-        public void Update()
+        public void FixedUpdate()
         {
             if (!FlightGlobals.ready)
             {
@@ -77,7 +77,7 @@ namespace Kopernicus.Components
                 Double heatingRate = heatCurve.Evaluate((Single) distanceToPlanet);
                 foreach (Part part in vessel.Parts)
                 {
-                    part.temperature += heatingRate * Time.deltaTime;
+                    part.temperature += heatingRate * TimeWarp.fixedDeltaTime;
                 }
             }
         }

--- a/src/Kopernicus/Components/HazardousOcean.cs
+++ b/src/Kopernicus/Components/HazardousOcean.cs
@@ -77,7 +77,9 @@ namespace Kopernicus.Components
                 Double heatingRate = heatCurve.Evaluate((Single) distanceToPlanet);
                 foreach (Part part in vessel.Parts)
                 {
-                    part.temperature += heatingRate * TimeWarp.fixedDeltaTime;
+                    // Multiplying by 50 to counteract the effect of multiplying by physics delta-time (1/50 by
+                    // default). The heating rate is per frame, not per second, for legacy compatibility.
+                    part.temperature += heatingRate * TimeWarp.fixedDeltaTime * 50;
                 }
             }
         }


### PR DESCRIPTION
**Before:**
HazardousBody heating rate was fluctuating based on framerate, physics speed and physics warp level.
HazardousOcean heating rate was fluctuating based on physics speed and the heating rate was about 50 times smaller than intended.

**After:**
Heating rates are very smooth.

Fixes #345 