### PR TITLE
Fix new version files for KSP 1.10.1 and 1.11.1

### DIFF
--- a/build/KSP1101/GameData/Kopernicus/Plugins/Kopernicus.version
+++ b/build/KSP1101/GameData/Kopernicus/Plugins/Kopernicus.version
@@ -1,6 +1,6 @@
 {
-	"NAME": "<b><color=#CA7B3C>Kopernicus</color></b>",
-	"URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/build/KSP191/GameData/Kopernicus/Plugins/Kopernicus.version",
+	"NAME": "Kopernicus",
+	"URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/build/KSP1101/GameData/Kopernicus/Plugins/Kopernicus.version",
 	"DOWNLOAD": "https://github.com/Kopernicus/Kopernicus/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/README.md",
 	"VERSION":
@@ -13,7 +13,7 @@
 	"KSP_VERSION":
 	{
 		"MAJOR": 1,
-		"MINOR": 9,
+		"MINOR": 10,
 		"PATCH": 1
 	}
 }

--- a/build/KSP1111/GameData/Kopernicus/Plugins/Kopernicus.version
+++ b/build/KSP1111/GameData/Kopernicus/Plugins/Kopernicus.version
@@ -1,6 +1,6 @@
 {
-	"NAME": "<b><color=#CA7B3C>Kopernicus</color></b>",
-	"URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/build/KSP191/GameData/Kopernicus/Plugins/Kopernicus.version",
+	"NAME": "Kopernicus",
+	"URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/build/KSP1111/GameData/Kopernicus/Plugins/Kopernicus.version",
 	"DOWNLOAD": "https://github.com/Kopernicus/Kopernicus/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/README.md",
 	"VERSION":
@@ -13,7 +13,7 @@
 	"KSP_VERSION":
 	{
 		"MAJOR": 1,
-		"MINOR": 9,
+		"MINOR": 11,
 		"PATCH": 1
 	}
 }

--- a/build/KSP181/GameData/Kopernicus/Plugins/Kopernicus.version
+++ b/build/KSP181/GameData/Kopernicus/Plugins/Kopernicus.version
@@ -1,5 +1,5 @@
 {
-	"NAME": "<b><color=#CA7B3C>Kopernicus</color></b>",
+	"NAME": "Kopernicus",
 	"URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/build/KSP181/GameData/Kopernicus/Plugins/Kopernicus.version",
 	"DOWNLOAD": "https://github.com/Kopernicus/Kopernicus/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/README.md",

--- a/build/KSP191/GameData/Kopernicus/Plugins/Kopernicus.version
+++ b/build/KSP191/GameData/Kopernicus/Plugins/Kopernicus.version
@@ -1,5 +1,5 @@
 {
-	"NAME": "<b><color=#CA7B3C>Kopernicus</color></b>",
+	"NAME": "Kopernicus",
 	"URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/build/KSP191/GameData/Kopernicus/Plugins/Kopernicus.version",
 	"DOWNLOAD": "https://github.com/Kopernicus/Kopernicus/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/README.md",


### PR DESCRIPTION
## Problems

The new version files for the KSP 1.10.1 and 1.11.1 release files are incorrect.
They are just a copy of the one for KSP 1.9.1, thus they have incorrect `KSP_VERSION` and `URL` values, stating incorrect compatibility, which is reflected in CKAN:
![image](https://user-images.githubusercontent.com/28812678/107153032-bab87500-696b-11eb-9ac6-9ba538f3a48f.png)

This will likely cause a lot of issues for CKAN users, because not only KSP 1.10.1/1.11.1 users won't see a compatible version, KSP 1.9.1 users will get the wrong one.

## Changes

This PR changes them to the correct compatibility, and fixes the `URL` property.
Additionally it removes that weird HTML code from `NAME`, and converts the two new version files from LF to CRLF newlines to match the old ones and the rest of the repository (yeah ideally it should be the other way around, but for the sake of consistency...).

Unfortunately, because the `URL` property isn't set correctly, this change won't be picked up by CKAN. Ideally you create a new release as soon as this PR is merged, then we can either fix or freeze the incorrect -27 versions.

Pinging @R-T-B to make sure you get a notification, and @HebaruSan FYI.