### PR TITLE
Fix cfg syntax errors

### DIFF
--- a/build/KSP18/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/KSP18/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -22,5 +22,5 @@
 //First delete all old "KopernicusSolarPanels" fixers
 @PART:HAS[@MODULE[ModuleDeployableSolarPanel]]:FINAL
 {
-	!MODULE[KopernicusSolarPanels]
+	!MODULE[KopernicusSolarPanels] {}
 }

--- a/build/KSP19+/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/KSP19+/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -22,5 +22,5 @@
 //First delete all old "KopernicusSolarPanels" fixers
 @PART:HAS[@MODULE[ModuleDeployableSolarPanel]]:FINAL
 {
-	!MODULE[KopernicusSolarPanels]
+	!MODULE[KopernicusSolarPanels] {}
 }


### PR DESCRIPTION
Hi @R-T-B,

I'm using Kopernicus to test some cfg parser code for KSP-CKAN/CKAN#3525, and I found a minor syntax error.

This pull request fixes it.

Cheers!
