### PR TITLE
Improve SunBodyFlux performance

### DIFF
--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -114,6 +114,7 @@
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.qc" />
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.minLevel" />
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.cacheCreated" />
+    <Publicize Include="Assembly-CSharp:PhysicsGlobals.solarLuminosity" />
   </ItemGroup>
   <!--Source-->
   <ItemGroup>

--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -161,6 +161,8 @@ namespace Kopernicus.RuntimeUtility
             {
                 ApplyStarPatches(PSystemManager.Instance.localBodies[i]);
             }
+
+            CalculateHomeBodySMA();
         }
 
         // Stuff
@@ -290,6 +292,22 @@ namespace Kopernicus.RuntimeUtility
             flareObj.transform.localRotation = Quaternion.identity;
             flareObj.transform.localScale = Vector3.one;
             flareObj.transform.SetPositionAndRotation(body.position, body.rotation);
+        }
+
+        private static void CalculateHomeBodySMA()
+        {
+            CelestialBody homeBody = FlightGlobals.GetHomeBody();
+            if (homeBody == null)
+            {
+                return;
+            }
+
+            while (KopernicusStar.Stars.All(s => s.sun != homeBody.referenceBody) && homeBody.referenceBody != null)
+            {
+                homeBody = homeBody.referenceBody;
+            }
+
+            KopernicusStar.HomeBodySMA = homeBody.orbit.semiMajorAxis;
         }
 
         private static void ApplyLaunchSitePatches()

--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -147,15 +147,15 @@ namespace Kopernicus.RuntimeUtility
 
         // Execute MainMenu functions
         private void Start()
-		{
-			WriteConfigIfNoneExists();
-			RemoveUnselectableObjects();
-			ApplyLaunchSitePatches();
-			ApplyMusicAltitude();
-			ApplyInitialTarget();
-			ApplyOrbitPatches();
-			ApplyStarPatchSun();
-			ApplyFlagFixes();
+        {
+            WriteConfigIfNoneExists();
+            RemoveUnselectableObjects();
+            ApplyLaunchSitePatches();
+            ApplyMusicAltitude();
+            ApplyInitialTarget();
+            ApplyOrbitPatches();
+            ApplyStarPatchSun();
+            ApplyFlagFixes();
 
             for (Int32 i = 0; i < PSystemManager.Instance.localBodies.Count; i++)
             {
@@ -165,8 +165,8 @@ namespace Kopernicus.RuntimeUtility
             CalculateHomeBodySMA();
         }
 
-		// Stuff
-		private void LateUpdate()
+        // Stuff
+        private void LateUpdate()
         {
             FixZooming();
             ApplyRnDPatches();


### PR DESCRIPTION
-cache the home body SMA for purposes of SolarLuminanceAtHome
-cache the star name instead of using Object.name which allocates a string for every call
-don't use reflection to set PhysicsGlobals.solarLuminosity

-this results in a ~10x speedup of FlightIntegrator.LateUpdate in a Galaxies Unbound install with all optional systems