### PR TITLE
Fix KopernicusSunFlare.LateUpdate performance

### DIFF
--- a/src/Kopernicus/Components/KopernicusSunFlare.cs
+++ b/src/Kopernicus/Components/KopernicusSunFlare.cs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Kopernicus Planetary System Modifier
  * ------------------------------------------------------------- 
  * This library is free software; you can redistribute it and/or
@@ -69,65 +69,11 @@ namespace Kopernicus.Components
                                                            ScaledSpace.LocalToScaledSpace(sun.position)) /
                                                        (AU * ScaledSpace.InverseScaleFactor))));
 
-            if (PlanetariumCamera.fetch.target == null ||
-                HighLogic.LoadedScene != GameScenes.TRACKSTATION && HighLogic.LoadedScene != GameScenes.FLIGHT)
-            {
-                return;
-            }
-
-            Boolean state = true;
-            for (Int32 index = 0; index < PlanetariumCamera.fetch.targets.Count; index++)
-            {
-                MapObject mapTarget = PlanetariumCamera.fetch.targets[index];
-                if (mapTarget == null)
-                {
-                    continue;
-                }
-
-                if (mapTarget.type != MapObject.ObjectType.CelestialBody)
-                {
-                    continue;
-                }
-
-                if (mapTarget.GetComponent<SphereCollider>() == null)
-                {
-                    continue;
-                }
-
-                if (!mapTarget.GetComponent<MeshRenderer>().enabled)
-                {
-                    continue;
-                }
-
-                if (mapTarget.celestialBody == sun)
-                {
-                    continue;
-                }
-
-                if (mapTarget.transform.localScale.x < 1.0 || mapTarget.transform.localScale.x >= 3.0)
-                {
-                    continue;
-                }
-
-                Vector3d targetDistance = PlanetariumCamera.fetch.transform.position - mapTarget.transform.position;
-                Single radius = mapTarget.GetComponent<SphereCollider>().radius;
-                Double num1 = 2.0 * Vector3d.Dot(-sunDirection, targetDistance);
-                Double num2 = Vector3d.Dot(targetDistance, targetDistance) - radius * (Double) radius;
-                Double d = num1 * num1 - 4.0 * num2;
-                if (d < 0)
-                {
-                    continue;
-                }
-
-                Double num3 = (-num1 + Math.Sqrt(d)) * 0.5;
-                Double num4 = (-num1 - Math.Sqrt(d)) * 0.5;
-                if (num3 >= 0.0 && num4 >= 0.0)
-                {
-                    state = false;
-                }
-            }
-
-            SunlightEnabled(state);
+            // The stock code does a lot of work here to calculate obstruction
+            // however it excludes bodies that have localscale <1 or >3, which is pretty much everything but jool
+            // (scaled space bodies seem to be 1000 scaled-space units in radius and then scaled with localscale (jool is scale 1))
+            // There must be some other system (maybe stock unity behaviors?) that is handling occlusion, because it still works correctly for the skipped bodies - it just fades out instead of going out immediately
+            // The stock code is extremely slow for systems with lots of stars and map targets (it iterates over vessels too!) so we get a massive speed boost by just skipping it and letting the unity system handle it
         }
     }
 }


### PR DESCRIPTION
this was slow because it iterates over all map targets (bodies + vessels) and runs for each star in the universe

This was modeled after the stock code, which excludes bodies with localscale <1 or >3.  The scaledspace bodies seem to have a neutral scale at 1000 radius units - that means Jool is scale 1 and everything else in the stock system is smaller, and most bodies would just be ignored by this code anyway.  The effect of the stock code is to immediately turn off the sun flare when the sun goes behind jool's horizon - but the lensflares still turn off for other bodies, they just fade out.  Deleting this code causes large bodies to have the same behavior as the smaller ones (fading out) and massively improves performance for systems with large numbers of stars and bodies.