### PR TITLE
Improve KopernicusOrbitRendererUpdater performance

### DIFF
--- a/src/Kopernicus/Components/KopernicusOrbitRendererData.cs
+++ b/src/Kopernicus/Components/KopernicusOrbitRendererData.cs
@@ -33,17 +33,6 @@ namespace Kopernicus.Components
     // Wrapper for the OrbitRendererData class to make it a bit easier to use
     public class KopernicusOrbitRendererData : OrbitRendererData
     {
-        // Accessor for the nodeColor field
-        private static readonly FieldInfo NodeColor = typeof(OrbitRendererData)
-            .GetFields(BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault();
-
-        [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public Color nodeColor
-        {
-            get { return (Color)NodeColor.GetValue(this); }
-            set { NodeColor.SetValue(this, value); }
-        }
-
         public KopernicusOrbitRendererData(CelestialBody body, OrbitRendererBase renderer) : base(body)
         {
             orbitColor = renderer.orbitColor;
@@ -55,7 +44,7 @@ namespace Kopernicus.Components
         public KopernicusOrbitRendererData(CelestialBody body, OrbitRendererData data) : base(body)
         {
             orbitColor = data.orbitColor;
-            nodeColor = (Color)NodeColor.GetValue(data);
+            nodeColor = data.nodeColor;
             lowerCamVsSmaRatio = data.lowerCamVsSmaRatio;
             upperCamVsSmaRatio = data.upperCamVsSmaRatio;
         }

--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -115,6 +115,7 @@
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.minLevel" />
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.cacheCreated" />
     <Publicize Include="Assembly-CSharp:PhysicsGlobals.solarLuminosity" />
+    <Publicize Include="Assembly-CSharp:OrbitRendererData.nodeColor" />
   </ItemGroup>
   <!--Source-->
   <ItemGroup>


### PR DESCRIPTION
-previously this was calling through reflection which caused GC allocs every frame
-since this was called per body, the cost added up pretty significantly in systems with large numbers of bodies

This change takes the cost in GU from 0.81ms/frame to 0.16ms/frame, or about 5x faster