### PR TITLE
Fix exported height maps

### DIFF
--- a/src/Kopernicus/UI/PlanetTextureExporter.cs
+++ b/src/Kopernicus/UI/PlanetTextureExporter.cs
@@ -274,6 +274,7 @@ namespace Kopernicus.UI
                     }
 
                     // Adjust the height
+                    height -= minHeight;
                     height /= deltaRadius;
                     if (height < 0)
                     {


### PR DESCRIPTION
By subtracting minHeight, we put the height value within the minHeight/maxHeight range first before normalizing to 0-1.