### PR TITLE
Asteroid Performance Improvements

### DIFF
--- a/src/Kopernicus/Configuration/Asteroids/Asteroid.cs
+++ b/src/Kopernicus/Configuration/Asteroids/Asteroid.cs
@@ -89,5 +89,7 @@ namespace Kopernicus.Configuration.Asteroids
         }
 
         public FloatCurve Size { get; set; }
+
+        public int InternalOrderID { get; set; }
     }
 }


### PR DESCRIPTION
Several changes here.

Pre-cache the location loaders, as well as CelestialBodies on the fly. Should save 5-10ms per asteroid spawned.

The main obstacle to reducing the time taken for spawning new asteroids are now entirely functions that are part of base KSP code, which I have no interest in trying to dissect! For anyone brave enough to try and improve things further, the main culprits left are upon the creation of a new ProtoVessel object, and calling Load on that ProtoVessel. Everything else is of minimal performance impact.

Additionally, a longer minimum spawnInterval is set, and AsteroidDaemon now uses WaitForSecondsRealtime to avoid physical timewarp weirdness. Some slight jitter is also added to the wait time so that updates naturally spread out to avoid multiple spawns happening at once causing bad stuttering.

Unfortunately, for heavily modded playthroughs (currently doing BeyondHome+Galaxies Unbound, as an example), there is still noticeable stuttering even on a high-end machine. These changes have generally reduced how annoying those stutters are, though.

Also noticed the occasional NullReferenceException being thrown, and the culprit was an asteroid grouping that was missing the Size FloatCurve; Added a null check for this.