### PR TITLE
Update SolarPanels.cfg for compatibility with Kerbalism

### DIFF
--- a/build/KSP19PLUS/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -1,11 +1,11 @@
 // If any modder adds useKopernicusSolarPanels = false to a module instead of a part, add it to the part:
-@PART:HAS[@MODULE:HAS[#useKopernicusSolarPanels[?alse]]]:FINAL
+@PART:HAS[@MODULE:HAS[#useKopernicusSolarPanels[?alse]]]:NEEDS[!Kerbalism]:FINAL
 {
 	%useKopernicusSolarPanels = false
 }
 
 // Uses regular expressions to convert any case variants like FalSe to false
-@PART:HAS[#useKopernicusSolarPanels[*]]:FINAL
+@PART:HAS[#useKopernicusSolarPanels[*]]:NEEDS[!Kerbalism]:FINAL
 {
     // This cfg will enable KopernicusSolarPanels
     // to allow support for multiple lightsources
@@ -20,13 +20,13 @@
 }
 
 //First delete all old "KopernicusSolarPanels" fixers
-@PART:HAS[@MODULE[ModuleDeployableSolarPanel]]:FINAL
+@PART:HAS[@MODULE[ModuleDeployableSolarPanel]]:NEEDS[!Kerbalism]:FINAL
 {
 	!MODULE[KopernicusSolarPanels] {}
 }
 
 // Converts all ModuleDeployableSolarPanel modules within a part to KopernicusSolarPanels unless the part has useKopernicusSolarPanels = false
-@PART:HAS[@MODULE[ModuleDeployableSolarPanel],~useKopernicusSolarPanels[false]]:FINAL
+@PART:HAS[@MODULE[ModuleDeployableSolarPanel],~useKopernicusSolarPanels[false]]:NEEDS[!Kerbalism]:FINAL
 {
     @MODULE[ModuleDeployableSolarPanel],*
     {
@@ -35,7 +35,7 @@
 }
 
 //B9PartSwitch support, changes the identifier to a generic identifier, just to be safe, but only runs if the part does not have useKopernicusSolarPanels = false ... 
-@PART:HAS[@MODULE[ModuleB9PartSwitch],~useKopernicusSolarPanels[false]]:FINAL
+@PART:HAS[@MODULE[ModuleB9PartSwitch],~useKopernicusSolarPanels[false]]:NEEDS[!Kerbalism]:FINAL
 {
     @MODULE[ModuleB9PartSwitch],*
     {
@@ -53,12 +53,12 @@
 }
 
 // clean up
-@PART:HAS[#useKopernicusSolarPanels[*]]:FINAL
+@PART:HAS[#useKopernicusSolarPanels[*]]:NEEDS[!Kerbalism]:FINAL
 {
 	!useKopernicusSolarPanels = delete
 }
 
-@PART:HAS[@MODULE:HAS[#useKopernicusSolarPanels[*]]]:FINAL
+@PART:HAS[@MODULE:HAS[#useKopernicusSolarPanels[*]]]:NEEDS[!Kerbalism]:FINAL
 {
     @MODULE,*:HAS[#useKopernicusSolarPanels[*]]
 	{


### PR DESCRIPTION
Disable Kopernicus multistar when Kerbalism is detected.

Kerbalism does not recognize the KopernicusSolarPanels module as a solar generating source, and thus patched solar panels will not work with Kerbalism's background processing; as Kerbalism has its own multistar support, it would be simplest to disable the Kopernicus module.