### PR TITLE
Fix an issue with the new biome code and cbNameLater

### DIFF
--- a/src/Kopernicus/Components/NameChanger.cs
+++ b/src/Kopernicus/Components/NameChanger.cs
@@ -47,6 +47,10 @@ namespace Kopernicus.Components
             {
                 OrbitRendererData data = PSystemManager.OrbitRendererDataCache[b];
                 PSystemManager.OrbitRendererDataCache.Remove(b);
+                // Before we make the change, we need to make sure FlightGlobals's bodyNames cache
+                // has the old name (for back-compat with older mods)
+                FlightGlobals.GetBodyByName(b.bodyName);
+                // Now we can change the name safely.
                 b.bodyName = newName;
                 PlanetariumCamera.fetch.targets.Find(t => t.name == oldName).name = newName;
                 data.cb = b;


### PR DESCRIPTION
Previously the old bodyName would work in FlightGlobals.GetBodyByName (which mods like RP-1 and Parallax relied on, when RSS was present) because an old bit of fast-biome code called FlightGlobals.GetBodyByName before the bodyName got changed. Now that is no longer true so FlightGlobals's bodyNames cache no longer has the old body name(s) present.