### PR TITLE
Allow modification of ring shadow radius

### DIFF
--- a/src/Kopernicus/Components/Ring.cs
+++ b/src/Kopernicus/Components/Ring.cs
@@ -84,6 +84,8 @@ namespace Kopernicus.Components
         public Single anisotropy = 0.95F;
         public Texture2D backlitTexture;
 
+        public Single radiusMultiplier = 1.0F;
+
         public Int32 steps = 128;
 
         /// <summary>
@@ -237,7 +239,7 @@ namespace Kopernicus.Components
 
             if (useNewShader)
             {
-                ringMr.sharedMaterial.SetFloat(PlanetRadius, planetRadius);
+                ringMr.sharedMaterial.SetFloat(PlanetRadius, planetRadius * radiusMultiplier);
                 ringMr.sharedMaterial.SetFloat(PenumbraMultiplier, penumbraMultiplier);
 
                 if (innerShadeTexture != null)

--- a/src/Kopernicus/Configuration/RingLoader.cs
+++ b/src/Kopernicus/Configuration/RingLoader.cs
@@ -210,6 +210,15 @@ namespace Kopernicus.Configuration
             set { Value.backlitTexture = value; }
         }
 
+        // Radius multiplier for shadow casting
+        [ParserTarget("radiusMultiplier")]
+        [KittopiaDescription("Multiplier to planet radius for the shadow cast on the rings")]
+        public NumericParser<Single> radiusMultiplier
+        {
+            get { return Value.radiusMultiplier; }
+            set { Value.radiusMultiplier = value; }
+        }
+
         // Penumbra multiplier for new shader
         [ParserTarget("penumbraMultiplier")]
         public NumericParser<Single> PenumbraMultiplier


### PR DESCRIPTION
Just provides a config-facing radius multiplier value that is multiplied with the planet radius as its being passed to the ring shader so that planet pack authors can scale the shadows to match things like oblate objects