### PR TITLE
Fixed various bugs in multi-star mode and some other issues

### DIFF
--- a/build/KSP18/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/KSP18/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -86,11 +86,10 @@
     %__kop_star_count = #$@Kopernicus_config/__kop_star_count$
 }
 
-
 //=======================================================================================================
 // Solar panels support
 //=======================================================================================================
-@PART:HAS[@MODULE[ModuleDeployableSolarPanel],#__kop_star_count[>1]]:NEEDS[!RealismOverhaul,!Kerbalism]:LAST[KOP_MULTI_STAR]
+@PART:HAS[@MODULE[ModuleDeployableSolarPanel]:HAS[#chargeRate[>0]],#__kop_star_count[>1]]:NEEDS[!RealismOverhaul,!Kerbalism]:LAST[KOP_MULTI_STAR]
 {
   // duplicate every ModuleDeployableSolarPanel
   // Some parts may use multiple MDSP modules,

--- a/build/KSP18/GameData/Kopernicus/Localization/en-us.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/en-us.cfg
@@ -6,12 +6,12 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Occluded by <<1>>
         #Kopernicus_SolarPanelFixer_energy = Energy Output
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Solar Panel Status
-        #Kopernicus_SolarPanelFixer_inshadow = In Shadow
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Occluded by terrain
+        //#Kopernicus_SolarPanelFixer_inshadow = In Shadow
+        #Kopernicus_SolarPanelFixer_notvisible = No Visible Light
         #Kopernicus_SolarPanelFixer_badorientation = Bad Orientation
         #Kopernicus_SolarPanelFixer_exposure = Exposure
         #Kopernicus_SolarPanelFixer_wear = Wear
-        #Kopernicus_SolarPanelFixer_sunDirect = Sun Direct
+        #Kopernicus_SolarPanelFixer_sunDirect = Direct Exposure
         #Kopernicus_SolarPanelFixer_Selecttrackedstar = Select Tracked Star
         #Kopernicus_SolarPanelFixer_SelectTrackingBody = Select Tracking Body
         #Kopernicus_SolarPanelFixer_SelectTrackedstar_msg = Select the star you want to track with this solar panel.

--- a/build/KSP18/GameData/Kopernicus/Localization/en-us.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/en-us.cfg
@@ -20,6 +20,7 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Extending
         #Kopernicus_SolarPanelFixer_retracting = Retracting
         #Kopernicus_SolarPanelFixer_broken = Broken
+        #Kopernicus_SolarPanelFixer_failure = Failure
         #Kopernicus_SolarPanelFixer_invalidstate = Invalid State
         #Kopernicus_SolarPanelFixer_Trackedstar = Tracked Star
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/en-us.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/en-us.cfg
@@ -20,7 +20,6 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Extending
         #Kopernicus_SolarPanelFixer_retracting = Retracting
         #Kopernicus_SolarPanelFixer_broken = Broken
-        #Kopernicus_SolarPanelFixer_failure = Failure
         #Kopernicus_SolarPanelFixer_invalidstate = Invalid State
         #Kopernicus_SolarPanelFixer_Trackedstar = Tracked Star
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/es-es.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/es-es.cfg
@@ -20,7 +20,6 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Ampliando
         #Kopernicus_SolarPanelFixer_retracting = Retráctil
         #Kopernicus_SolarPanelFixer_broken = Roto
-        #Kopernicus_SolarPanelFixer_failure = Fallo
         #Kopernicus_SolarPanelFixer_invalidstate = Estado inválido
         #Kopernicus_SolarPanelFixer_Trackedstar = Estrella de seguimiento
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/es-es.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/es-es.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Ocluido por <<1>>
         #Kopernicus_SolarPanelFixer_energy = Producción de energía
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Estado del panel solar
-        #Kopernicus_SolarPanelFixer_inshadow = En la sombra
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Ocluido por el terreno
+        //#Kopernicus_SolarPanelFixer_inshadow = En la sombra
+        #Kopernicus_SolarPanelFixer_notvisible = No Visible
         #Kopernicus_SolarPanelFixer_badorientation = Mala orientación
         #Kopernicus_SolarPanelFixer_exposure = Exposición
         #Kopernicus_SolarPanelFixer_wear = Desgaste

--- a/build/KSP18/GameData/Kopernicus/Localization/es-es.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/es-es.cfg
@@ -20,6 +20,7 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Ampliando
         #Kopernicus_SolarPanelFixer_retracting = Retráctil
         #Kopernicus_SolarPanelFixer_broken = Roto
+        #Kopernicus_SolarPanelFixer_failure = Fallo
         #Kopernicus_SolarPanelFixer_invalidstate = Estado inválido
         #Kopernicus_SolarPanelFixer_Trackedstar = Estrella de seguimiento
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/fr-fr.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/fr-fr.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Occlu par <<1>>
         #Kopernicus_SolarPanelFixer_energy = Production d'énergie
         #Kopernicus_SolarPanelFixer_solarPanelStatus = État du panneau solaire
-        #Kopernicus_SolarPanelFixer_inshadow = Dans l'ombre
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Occlu par le terrain
+        //#Kopernicus_SolarPanelFixer_inshadow = Dans l'ombre
+        #Kopernicus_SolarPanelFixer_notvisible = Invisible
         #Kopernicus_SolarPanelFixer_badorientation = Mauvaise orientation
         #Kopernicus_SolarPanelFixer_exposure = Exposition
         #Kopernicus_SolarPanelFixer_wear = Porter

--- a/build/KSP18/GameData/Kopernicus/Localization/fr-fr.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/fr-fr.cfg
@@ -20,6 +20,7 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Extension
         #Kopernicus_SolarPanelFixer_retracting = Rétractable
         #Kopernicus_SolarPanelFixer_broken = Cassée
+        #Kopernicus_SolarPanelFixer_failure = Échec
         #Kopernicus_SolarPanelFixer_invalidstate = Etat non valide
         #Kopernicus_SolarPanelFixer_Trackedstar = Étoile suivie
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/fr-fr.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/fr-fr.cfg
@@ -20,7 +20,6 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Extension
         #Kopernicus_SolarPanelFixer_retracting = Rétractable
         #Kopernicus_SolarPanelFixer_broken = Cassée
-        #Kopernicus_SolarPanelFixer_failure = Échec
         #Kopernicus_SolarPanelFixer_invalidstate = Etat non valide
         #Kopernicus_SolarPanelFixer_Trackedstar = Étoile suivie
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/it-it.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/it-it.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Occluso da <<1>>
         #Kopernicus_SolarPanelFixer_energy = Produzione di energia
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Stato del pannello solare
-        #Kopernicus_SolarPanelFixer_inshadow = Nell'ombra
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Occluso dal terreno
+        //#Kopernicus_SolarPanelFixer_inshadow = Non Visibile
+        #Kopernicus_SolarPanelFixer_notvisible = Occluso dal terreno
         #Kopernicus_SolarPanelFixer_badorientation = Cattivo orientamento
         #Kopernicus_SolarPanelFixer_exposure = Esposizione
         #Kopernicus_SolarPanelFixer_wear = Indossare

--- a/build/KSP18/GameData/Kopernicus/Localization/it-it.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/it-it.cfg
@@ -20,6 +20,7 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Estensione
         #Kopernicus_SolarPanelFixer_retracting = Ritraendo
         #Kopernicus_SolarPanelFixer_broken = Rotto
+        #Kopernicus_SolarPanelFixer_failure = Fallimento
         #Kopernicus_SolarPanelFixer_invalidstate = Stato non valido
         #Kopernicus_SolarPanelFixer_Trackedstar = Stella tracciata
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/it-it.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/it-it.cfg
@@ -20,7 +20,6 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = Estensione
         #Kopernicus_SolarPanelFixer_retracting = Ritraendo
         #Kopernicus_SolarPanelFixer_broken = Rotto
-        #Kopernicus_SolarPanelFixer_failure = Fallimento
         #Kopernicus_SolarPanelFixer_invalidstate = Stato non valido
         #Kopernicus_SolarPanelFixer_Trackedstar = Stella tracciata
         #Kopernicus_SolarPanelFixer_AutoTrack = [Auto] :

--- a/build/KSP18/GameData/Kopernicus/Localization/ru.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/ru.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = перекрыт <<1>>
         #Kopernicus_SolarPanelFixer_energy = Выход энергии
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Состояние солнечной панели
-        #Kopernicus_SolarPanelFixer_inshadow = в тени
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Закрыто рельефом местности
+        //#Kopernicus_SolarPanelFixer_inshadow = в тени
+        #Kopernicus_SolarPanelFixer_notvisible = невидимый
         #Kopernicus_SolarPanelFixer_badorientation = Плохая ориентация
         #Kopernicus_SolarPanelFixer_exposure = Световой диапазон
         #Kopernicus_SolarPanelFixer_wear = износ

--- a/build/KSP18/GameData/Kopernicus/Localization/ru.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/ru.cfg
@@ -20,7 +20,6 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = вытянутый
         #Kopernicus_SolarPanelFixer_retracting = втягивание
         #Kopernicus_SolarPanelFixer_broken = сломанный
-        #Kopernicus_SolarPanelFixer_failure = неудача
         #Kopernicus_SolarPanelFixer_invalidstate = Недопустимое состояние
         #Kopernicus_SolarPanelFixer_Trackedstar = Отслеживаемая звезда
         #Kopernicus_SolarPanelFixer_AutoTrack = [Автоавтоматический] :

--- a/build/KSP18/GameData/Kopernicus/Localization/ru.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/ru.cfg
@@ -20,6 +20,7 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = вытянутый
         #Kopernicus_SolarPanelFixer_retracting = втягивание
         #Kopernicus_SolarPanelFixer_broken = сломанный
+        #Kopernicus_SolarPanelFixer_failure = неудача
         #Kopernicus_SolarPanelFixer_invalidstate = Недопустимое состояние
         #Kopernicus_SolarPanelFixer_Trackedstar = Отслеживаемая звезда
         #Kopernicus_SolarPanelFixer_AutoTrack = [Автоавтоматический] :

--- a/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -20,7 +20,6 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = 展开中
         #Kopernicus_SolarPanelFixer_retracting = 收回中
         #Kopernicus_SolarPanelFixer_broken = 损坏
-        #Kopernicus_SolarPanelFixer_failure = 故障
         #Kopernicus_SolarPanelFixer_invalidstate = 无效状态
         #Kopernicus_SolarPanelFixer_Trackedstar = 恒星追踪
         #Kopernicus_SolarPanelFixer_AutoTrack = [自动] :

--- a/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -6,7 +6,7 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = 被<<1>>阻挡
         #Kopernicus_SolarPanelFixer_energy = 能量输出
         #Kopernicus_SolarPanelFixer_solarPanelStatus = 太阳能板状态
-        #Kopernicus_SolarPanelFixer_inshadow = 在暗面
+        #Kopernicus_SolarPanelFixer_inshadow = 在阴影处
         #Kopernicus_SolarPanelFixer_occludedbyterrain = 被地形阻挡
         #Kopernicus_SolarPanelFixer_badorientation = 不好的方向
         #Kopernicus_SolarPanelFixer_exposure = 光照范围

--- a/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -20,6 +20,7 @@ Localization
         #Kopernicus_SolarPanelFixer_extending = 展开中
         #Kopernicus_SolarPanelFixer_retracting = 收回中
         #Kopernicus_SolarPanelFixer_broken = 损坏
+        #Kopernicus_SolarPanelFixer_failure = 故障
         #Kopernicus_SolarPanelFixer_invalidstate = 无效状态
         #Kopernicus_SolarPanelFixer_Trackedstar = 恒星追踪
         #Kopernicus_SolarPanelFixer_AutoTrack = [自动] :

--- a/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = 被<<1>>阻挡
         #Kopernicus_SolarPanelFixer_energy = 能量输出
         #Kopernicus_SolarPanelFixer_solarPanelStatus = 太阳能板状态
-        #Kopernicus_SolarPanelFixer_inshadow = 在暗面
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = 被地形阻挡
+        //#Kopernicus_SolarPanelFixer_inshadow = 在暗面
+        #Kopernicus_SolarPanelFixer_notvisible = 不可见
         #Kopernicus_SolarPanelFixer_badorientation = 不好的方向
         #Kopernicus_SolarPanelFixer_exposure = 光照范围
         #Kopernicus_SolarPanelFixer_wear = 损耗

--- a/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP18/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -6,7 +6,7 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = 被<<1>>阻挡
         #Kopernicus_SolarPanelFixer_energy = 能量输出
         #Kopernicus_SolarPanelFixer_solarPanelStatus = 太阳能板状态
-        #Kopernicus_SolarPanelFixer_inshadow = 在阴影处
+        #Kopernicus_SolarPanelFixer_inshadow = 在暗面
         #Kopernicus_SolarPanelFixer_occludedbyterrain = 被地形阻挡
         #Kopernicus_SolarPanelFixer_badorientation = 不好的方向
         #Kopernicus_SolarPanelFixer_exposure = 光照范围

--- a/build/KSP19PLUS/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -86,11 +86,10 @@
     %__kop_star_count = #$@Kopernicus_config/__kop_star_count$
 }
 
-
 //=======================================================================================================
 // Solar panels support
 //=======================================================================================================
-@PART:HAS[@MODULE[ModuleDeployableSolarPanel],#__kop_star_count[>1]]:NEEDS[!RealismOverhaul,!Kerbalism]:LAST[KOP_MULTI_STAR]
+@PART:HAS[@MODULE[ModuleDeployableSolarPanel]:HAS[#chargeRate[>0]],#__kop_star_count[>1]]:NEEDS[!RealismOverhaul,!Kerbalism]:LAST[KOP_MULTI_STAR]
 {
   // duplicate every ModuleDeployableSolarPanel
   // Some parts may use multiple MDSP modules,

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/en-us.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/en-us.cfg
@@ -6,12 +6,12 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Occluded by <<1>>
         #Kopernicus_SolarPanelFixer_energy = Energy Output
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Solar Panel Status
-        #Kopernicus_SolarPanelFixer_inshadow = In Shadow
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Occluded by terrain
+        //#Kopernicus_SolarPanelFixer_inshadow = In Shadow
+        #Kopernicus_SolarPanelFixer_notvisible = No Visible Light
         #Kopernicus_SolarPanelFixer_badorientation = Bad Orientation
         #Kopernicus_SolarPanelFixer_exposure = Exposure
         #Kopernicus_SolarPanelFixer_wear = Wear
-        #Kopernicus_SolarPanelFixer_sunDirect = Sun Direct
+        #Kopernicus_SolarPanelFixer_sunDirect = Direct Exposure
         #Kopernicus_SolarPanelFixer_Selecttrackedstar = Select Tracked Star
         #Kopernicus_SolarPanelFixer_SelectTrackingBody = Select Tracking Body
         #Kopernicus_SolarPanelFixer_SelectTrackedstar_msg = Select the star you want to track with this solar panel.

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/es-es.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/es-es.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Ocluido por <<1>>
         #Kopernicus_SolarPanelFixer_energy = Producción de energía
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Estado del panel solar
-        #Kopernicus_SolarPanelFixer_inshadow = En la sombra
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Ocluido por el terreno
+        //#Kopernicus_SolarPanelFixer_inshadow = En la sombra
+        #Kopernicus_SolarPanelFixer_notvisible = No Visible
         #Kopernicus_SolarPanelFixer_badorientation = Mala orientación
         #Kopernicus_SolarPanelFixer_exposure = Exposición
         #Kopernicus_SolarPanelFixer_wear = Desgaste

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/fr-fr.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/fr-fr.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Occlu par <<1>>
         #Kopernicus_SolarPanelFixer_energy = Production d'énergie
         #Kopernicus_SolarPanelFixer_solarPanelStatus = État du panneau solaire
-        #Kopernicus_SolarPanelFixer_inshadow = Dans l'ombre
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Occlu par le terrain
+        //#Kopernicus_SolarPanelFixer_inshadow = Dans l'ombre
+        #Kopernicus_SolarPanelFixer_notvisible = Invisible
         #Kopernicus_SolarPanelFixer_badorientation = Mauvaise orientation
         #Kopernicus_SolarPanelFixer_exposure = Exposition
         #Kopernicus_SolarPanelFixer_wear = Porter

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/it-it.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/it-it.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = Occluso da <<1>>
         #Kopernicus_SolarPanelFixer_energy = Produzione di energia
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Stato del pannello solare
-        #Kopernicus_SolarPanelFixer_inshadow = Nell'ombra
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Occluso dal terreno
+        //#Kopernicus_SolarPanelFixer_inshadow = Non Visibile
+        #Kopernicus_SolarPanelFixer_notvisible = Occluso dal terreno
         #Kopernicus_SolarPanelFixer_badorientation = Cattivo orientamento
         #Kopernicus_SolarPanelFixer_exposure = Esposizione
         #Kopernicus_SolarPanelFixer_wear = Indossare

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/ru.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/ru.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = перекрыт <<1>>
         #Kopernicus_SolarPanelFixer_energy = Выход энергии
         #Kopernicus_SolarPanelFixer_solarPanelStatus = Состояние солнечной панели
-        #Kopernicus_SolarPanelFixer_inshadow = в тени
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = Закрыто рельефом местности
+        //#Kopernicus_SolarPanelFixer_inshadow = в тени
+        #Kopernicus_SolarPanelFixer_notvisible = невидимый
         #Kopernicus_SolarPanelFixer_badorientation = Плохая ориентация
         #Kopernicus_SolarPanelFixer_exposure = Световой диапазон
         #Kopernicus_SolarPanelFixer_wear = износ

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -6,7 +6,7 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = 被<<1>>阻挡
         #Kopernicus_SolarPanelFixer_energy = 能量输出
         #Kopernicus_SolarPanelFixer_solarPanelStatus = 太阳能板状态
-        #Kopernicus_SolarPanelFixer_inshadow = 在暗面
+        #Kopernicus_SolarPanelFixer_inshadow = 在阴影处
         #Kopernicus_SolarPanelFixer_occludedbyterrain = 被地形阻挡
         #Kopernicus_SolarPanelFixer_badorientation = 不好的方向
         #Kopernicus_SolarPanelFixer_exposure = 光照范围

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -6,8 +6,8 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = 被<<1>>阻挡
         #Kopernicus_SolarPanelFixer_energy = 能量输出
         #Kopernicus_SolarPanelFixer_solarPanelStatus = 太阳能板状态
-        #Kopernicus_SolarPanelFixer_inshadow = 在暗面
-        #Kopernicus_SolarPanelFixer_occludedbyterrain = 被地形阻挡
+        //#Kopernicus_SolarPanelFixer_inshadow = 在暗面
+        #Kopernicus_SolarPanelFixer_notvisible = 不可见
         #Kopernicus_SolarPanelFixer_badorientation = 不好的方向
         #Kopernicus_SolarPanelFixer_exposure = 光照范围
         #Kopernicus_SolarPanelFixer_wear = 损耗

--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/zh-cn.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/zh-cn.cfg
@@ -6,7 +6,7 @@ Localization
         #Kopernicus_SolarPanelFixer_occludedby = 被<<1>>阻挡
         #Kopernicus_SolarPanelFixer_energy = 能量输出
         #Kopernicus_SolarPanelFixer_solarPanelStatus = 太阳能板状态
-        #Kopernicus_SolarPanelFixer_inshadow = 在阴影处
+        #Kopernicus_SolarPanelFixer_inshadow = 在暗面
         #Kopernicus_SolarPanelFixer_occludedbyterrain = 被地形阻挡
         #Kopernicus_SolarPanelFixer_badorientation = 不好的方向
         #Kopernicus_SolarPanelFixer_exposure = 光照范围

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -568,7 +568,7 @@ namespace Kopernicus.Components
                 currentOutput = 0.0;
                 if (exposureStatus == ExposureState.OccludedPart)
                 {
-                    if (trackedSunVisiblefactor == 0)
+                    if (trackedSunVisiblefactor == 0 && KopernicusStar.UseMultiStarLogic)
                         exposureStatus = ExposureState.NotVisible;
                     exposureState = exposureStatus;
                 }

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -428,7 +428,6 @@ namespace Kopernicus.Components
 
             Vector3d direction;
             double distance;
-            //string trackedPart;
             for (Int32 s = 0; s < KopernicusStar.Stars.Count; s++)
             {
                 KopernicusStar starL=KopernicusStar.Stars[s];
@@ -853,7 +852,6 @@ namespace Kopernicus.Components
             exposureStats = exposureStatus;
             // Get the cosine factor (alignement between the sun and the panel surface)
             sunCosineFactor = SolarPanel.GetCosineFactor(sunDirection);
-
             if (sunCosineFactor == 0.0)
             {
                 // If this is the tracked sun and the panel is not oriented toward the sun, update the gui info string.
@@ -866,7 +864,6 @@ namespace Kopernicus.Components
             {
                 // The panel is oriented toward the sun, do a physic raycast to check occlusion from parts, terrain, buildings...
                 sunOccludedFactor = SolarPanel.GetOccludedFactor(sunDirection, out occludingPart);
-
                 // If this is the tracked sun and the panel is occluded, update the gui info string. 
                 if (star.sun == trackedSun)
                 {
@@ -1244,7 +1241,8 @@ namespace Kopernicus.Components
 
                                 occludingPart = blockingPart.partInfo.title;
                             }
-                            occludedFactor -= 1.0 / sunCatchers.Length;
+                            //occludedFactor -= 1.0 / sunCatchers.Length;
+                            occludedFactor = 0;
                         }
                     }
                 }
@@ -1401,7 +1399,8 @@ namespace Kopernicus.Components
 
                                 occludingPart = blockingPart.partInfo.title;
                             }
-                            occludedFactor -= 1.0 / sunCatchers.Length;
+                            //occludedFactor -= 1.0 / sunCatchers.Length;
+                            occludedFactor = 0;
                         }
                     }
                 }
@@ -1621,7 +1620,8 @@ namespace Kopernicus.Components
                     }
                 }
                 occludingFactor = 1.0 - (occludingFactor / suncatcherTotalCount);
-                if (occludingFactor < 0.01) occludingFactor = 0.0; // avoid precison issues
+                //if (occludingFactor < 0.01) occludingFactor = 0.0; // avoid precison issues
+                if (occludingFactor > 0.0 && occludingFactor < 1.0) occludingFactor = 0.0; // avoid precison issues
                 return occludingFactor;
             }
 

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -142,7 +142,6 @@ namespace Kopernicus.Components
         private static string SolarPanelFixer_extending = GetLoc("SolarPanelFixer_extending"); // "extending"
         private static string SolarPanelFixer_retracting = GetLoc("SolarPanelFixer_retracting"); // "retracting"
         private static string SolarPanelFixer_broken = GetLoc("SolarPanelFixer_broken"); // "broken"
-        private static string SolarPanelFixer_failure = GetLoc("SolarPanelFixer_failure"); // "failure"
         private static string SolarPanelFixer_invalidstate = GetLoc("SolarPanelFixer_invalidstate"); // "invalid state"
         private static string SolarPanelFixer_Trackedstar = GetLoc("SolarPanelFixer_Trackedstar"); // "Tracked star"
         private static string SolarPanelFixer_AutoTrack = GetLoc("SolarPanelFixer_AutoTrack"); // "[Auto] : "
@@ -347,7 +346,6 @@ namespace Kopernicus.Components
                         case PanelState.Extending: panelStatus = SolarPanelFixer_extending; break;//"extending"
                         case PanelState.Retracting: panelStatus = SolarPanelFixer_retracting; break;//"retracting"
                         case PanelState.Broken: panelStatus = SolarPanelFixer_broken; break;//"broken"
-                        case PanelState.Failure: panelStatus = SolarPanelFixer_failure; break;//"failure"
                         case PanelState.Unknown: panelStatus = SolarPanelFixer_invalidstate; break;//"invalid state"
                     }
                     break;
@@ -575,6 +573,12 @@ namespace Kopernicus.Components
                 else
                 {
                     exposureState = ExposureState.NotVisible;
+                }
+                if (wearFactor == 0)
+                {
+                    state = PanelState.Broken;
+                    Fields["panelStatusEnergy"].guiActive = false;
+                    Fields["panelStatusSunAOA"].guiActive = false;
                 }
             }
             else

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -568,7 +568,7 @@ namespace Kopernicus.Components
                 currentOutput = 0.0;
                 if (exposureStatus == ExposureState.OccludedPart)
                 {
-                    if (trackedSunVisiblefactor == 0 && KopernicusStar.UseMultiStarLogic)
+                    if (trackedSunVisiblefactor == 0)
                         exposureStatus = ExposureState.NotVisible;
                     exposureState = exposureStatus;
                 }

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -578,7 +578,8 @@ namespace Kopernicus.Components
                 }
                 if (wearFactor == 0)
                 {
-                    state = PanelState.Broken;
+                    exposureState = ExposureState.Disabled;
+                    state = PanelState.Failure;
                     Fields["panelStatusEnergy"].guiActive = false;
                     Fields["panelStatusSunAOA"].guiActive = false;
                 }

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -129,7 +129,7 @@ namespace Kopernicus.Components
         private const string prefix = "#Kopernicus_";
         public static string GetLoc(string template) => Localizer.Format(prefix + template);
         private static string SolarPanelFixer_occludedby = GetLoc("SolarPanelFixer_occludedby"); // "occluded by <<1>>"
-        private static string SolarPanelFixer_notvisible  = GetLoc("SolarPanelFixer_notvisible"); // "No Visible Light"
+        private static string SolarPanelFixer_notvisible  = GetLoc("SolarPanelFixer_notvisible"); // "Not Visible"
         private static string SolarPanelFixer_badorientation = GetLoc("SolarPanelFixer_badorientation"); // "bad orientation"
         private static string SolarPanelFixer_exposure = GetLoc("SolarPanelFixer_exposure"); // "exposure"
         private static string SolarPanelFixer_wear = GetLoc("SolarPanelFixer_wear"); // "wear"
@@ -332,7 +332,7 @@ namespace Kopernicus.Components
             switch (exposureState)
             {
                 case ExposureState.NotVisible:
-                    panelStatus = "<color=#ff2222>" + SolarPanelFixer_notvisible + "</color>";//occluded by terrain
+                    panelStatus = "<color=#ff2222>" + SolarPanelFixer_notvisible + "</color>";//not visible
                     break;
                 case ExposureState.OccludedPart:
                     panelStatus = BuildString("<color=#ff2222>", Localizer.Format(SolarPanelFixer_occludedby, mainOccludingPart), "</color>");//occluded by 

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -142,6 +142,7 @@ namespace Kopernicus.Components
         private static string SolarPanelFixer_extending = GetLoc("SolarPanelFixer_extending"); // "extending"
         private static string SolarPanelFixer_retracting = GetLoc("SolarPanelFixer_retracting"); // "retracting"
         private static string SolarPanelFixer_broken = GetLoc("SolarPanelFixer_broken"); // "broken"
+        private static string SolarPanelFixer_failure = GetLoc("SolarPanelFixer_failure"); // "failure"
         private static string SolarPanelFixer_invalidstate = GetLoc("SolarPanelFixer_invalidstate"); // "invalid state"
         private static string SolarPanelFixer_Trackedstar = GetLoc("SolarPanelFixer_Trackedstar"); // "Tracked star"
         private static string SolarPanelFixer_AutoTrack = GetLoc("SolarPanelFixer_AutoTrack"); // "[Auto] : "
@@ -346,6 +347,7 @@ namespace Kopernicus.Components
                         case PanelState.Extending: panelStatus = SolarPanelFixer_extending; break;//"extending"
                         case PanelState.Retracting: panelStatus = SolarPanelFixer_retracting; break;//"retracting"
                         case PanelState.Broken: panelStatus = SolarPanelFixer_broken; break;//"broken"
+                        case PanelState.Failure: panelStatus = SolarPanelFixer_failure; break;//"failure"
                         case PanelState.Unknown: panelStatus = SolarPanelFixer_invalidstate; break;//"invalid state"
                     }
                     break;

--- a/src/Kopernicus/Components/KopernicusStar.cs
+++ b/src/Kopernicus/Components/KopernicusStar.cs
@@ -170,12 +170,11 @@ namespace Kopernicus.Components
         {
             if (UseMultiStarLogic)
             {
-
                 double greatestLuminosity = 0;
-                KopernicusStar BrightestStar = null;
+                KopernicusStar BrightestStar = starList[0];
                 for (Int32 i = 0; i < starList.Count; i++)
                 {
-                    KopernicusStar star = Stars[i];
+                    KopernicusStar star = starList[i];
                     double aparentLuminosity = 0;
                     if ((star.shifter.givesOffLight) && (star.shifter.solarLuminosity > 0))
                     {


### PR DESCRIPTION
1. The bug that EC still generates when switching tracking targets has been fixed. This time it is smoother.
2. Change the automatic tracking program from the maximum brightness of all stars to the maximum brightness of the visible stars or automatically select the nearest star
3. Change the EC display unit to display three decimal places
4. The occlusion factor returned by the static board is adjusted to 0 or 1