### PR TITLE
Fix #644: Performance issue with Utility.GetMod

### DIFF
--- a/src/Kopernicus/Configuration/OceanLoader.cs
+++ b/src/Kopernicus/Configuration/OceanLoader.cs
@@ -333,7 +333,7 @@ namespace Kopernicus.Configuration
             }
 
             // Load existing mods
-            PQSMod[] mods = Utility.GetMods<PQSMod>(Value);
+            PQSMod[] mods = Utility.GetMods(Value);
             for (Int32 i = 0; i < mods.Length; i++)
             {
                 Type modType = mods[i].GetType();
@@ -419,7 +419,7 @@ namespace Kopernicus.Configuration
             }
 
             // Load existing mods
-            PQSMod[] mods = Utility.GetMods<PQSMod>(Value);
+            PQSMod[] mods = Utility.GetMods(Value);
             for (Int32 i = 0; i < mods.Length; i++)
             {
                 Type modType = mods[i].GetType();

--- a/src/Kopernicus/Configuration/PQSLoader.cs
+++ b/src/Kopernicus/Configuration/PQSLoader.cs
@@ -696,7 +696,7 @@ namespace Kopernicus.Configuration
             }
 
             // Load existing mods
-            PQSMod[] mods = Utility.GetMods<PQSMod>(Value);
+            PQSMod[] mods = Utility.GetMods(Value);
             List<PQSCity> specialPQSCitys = new List<PQSCity>();
             for (Int32 i = 0; i < mods.Length; i++)
             {
@@ -820,7 +820,7 @@ namespace Kopernicus.Configuration
             }
 
             // Load existing mods
-            PQSMod[] mods = Utility.GetMods<PQSMod>(Value);
+            PQSMod[] mods = Utility.GetMods(Value);
             List<PQSCity> specialPQSCitys = new List<PQSCity>();
             for (Int32 i = 0; i < mods.Length; i++)
             {

--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -150,6 +150,7 @@
     <Publicize Include="Assembly-CSharp:SpaceCenterCamera2.srfPivot" />
     <Publicize Include="Assembly-CSharp:PQSCity.planetRelativePosition" />
     <Publicize Include="Assembly-CSharp:PQS.PQSLandControl" />
+    <Publicize Include="Assembly-CSharp:PQS.mods" />
   </ItemGroup>
   <!--Source-->
   <ItemGroup>

--- a/src/Kopernicus/Utility.cs
+++ b/src/Kopernicus/Utility.cs
@@ -279,14 +279,31 @@ namespace Kopernicus
             }
         }
 
-        public static T[] GetMods<T>(PQS sphere) where T : PQSMod
+        public static PQSMod[] GetMods(PQS sphere)
         {
-            return sphere.GetComponentsInChildren<T>(true).Where(m => m.transform.parent == sphere.transform).ToArray();
+            // if the PQS has not been started, the mods array will be empty.  Do the slow thing.
+            // we COULD cache that list of mods, but I don't know if new ones may be created and missed
+            if (sphere?.mods == null)
+            {
+                // why doesn't this just iterate over the immmediate children?
+                // is it because we need to include inactive components?
+                return sphere.GetComponentsInChildren<PQSMod>(true).Where(m => m.transform.parent == sphere.transform).ToArray();
+            }
+            
+            return sphere.mods;
         }
 
         public static T GetMod<T>(PQS sphere) where T : PQSMod
         {
-            return GetMods<T>(sphere).FirstOrDefault();
+            var mods = GetMods(sphere);
+            for (int i = mods.Length; i-- > 0;)
+            {
+                if (mods[i] is T mod)
+                {
+                    return mod;
+                }
+            }
+            return null;
         }
 
         public static Boolean HasMod<T>(PQS sphere) where T : PQSMod


### PR DESCRIPTION
-VertexOblateHeight calls this many times every frame, and the old implementation does a full traversal of the PQS transforms (can be thousands of game objects) 
-The PQS already has a list of mods (though it's private).  Just use that instead.