### PR TITLE
perf: Optimize `KopernicusCBAttributeMapSO.CompileToTexture`

### DIFF
--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -102,6 +102,8 @@
   <!--Krafs.Publicizer items-->
   <ItemGroup>
     <Publicize Include="UnityEngine.CoreModule:UnityEngine.Object.m_CachedPtr" />
+    <Publicize Include="UnityEngine.CoreModule:UnityEngine.Texture.ValidateFormat" />
+    <Publicize Include="UnityEngine.CoreModule:UnityEngine.Texture2D.Internal_Create" />
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.cacheUnassigned" />
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.cacheAssigned" />
     <Publicize Include="Assembly-CSharp:PQSLandControl+LandClassScatter.sphere" />


### PR DESCRIPTION
In my profiles this one method accounts for 437ms during scene switch. With this commit it now takes ~190ms.

The specific changes made here are:
* Replace Math.Round call with an inlinable method that should be much faster over the target domain.
* Use unsafe code and pointers to avoid boundary check and function overhead associated with indexing into arrays and native arrays.
* Use the same trick I'm using in https://github.com/Gameslinx/Parallax-Continued/pull/79 to avoid texture initialization overhead when creating a new texture.

The new actual performance will vary quite a bit based on whether the internal texture copy that happens as part of `GetRawTextureData` ends up causing a bunch of page faults or not. It may be quite a bit faster than 190ms if it ends up reusing a previous texture allocation.

Before:
<img width="1700" height="393" alt="image" src="https://github.com/user-attachments/assets/7ea0ec27-e13f-4ce1-a2fb-61afd9239692" />

After:
<img width="1705" height="735" alt="image" src="https://github.com/user-attachments/assets/764782fa-16aa-40e7-a857-d3ba80c44784" />
