### PR TITLE
perf: Another pass at optimizing `KopernicusCBAttributeMapSO.CompileRGB`

### DIFF
--- a/src/Kopernicus/Components/KopernicusCBAttributeMapSO.cs
+++ b/src/Kopernicus/Components/KopernicusCBAttributeMapSO.cs
@@ -567,7 +567,7 @@ namespace Kopernicus.Components
 
             // By just allocating 256 entries we don't need to worry about
             // possibly accessing out of bounds.
-            RGB* attributeColors = stackalloc RGB[byte.MaxValue];
+            RGB* attributeColors = stackalloc RGB[256];
             for (int i = 0; i < Attributes.Length; ++i)
             {
                 Color pixelColor = Attributes[i].mapColor;
@@ -631,20 +631,25 @@ namespace Kopernicus.Components
             if (textureData.Length != _data.Length)
                 throw new IndexOutOfRangeException("texture length did not match data length");
 
+            Color32* attributeColors = stackalloc Color32[256];
+            for (int i = 0; i < Attributes.Length; ++i)
+            {
+                Color pixelColor = Attributes[i].mapColor;
+                attributeColors[i] = new Color32
+                {
+                    r = RoundToPixelValue(pixelColor.r),
+                    g = RoundToPixelValue(pixelColor.g),
+                    b = RoundToPixelValue(pixelColor.b),
+                    a = 255
+                };
+            }
+
             fixed(byte* data = _data)
             {
                 Color32* texData = (Color32*)textureData.GetUnsafePtr();
-                Color32 color = new Color32(0, 0, 0, 255);
 
                 for (int i = _data.Length; i >= 0; --i)
-                {
-                    Color pixelColor = Attributes[data[i]].mapColor;
-
-                    color.r = RoundToPixelValue(pixelColor.r);
-                    color.g = RoundToPixelValue(pixelColor.g);
-                    color.b = RoundToPixelValue(pixelColor.b);
-                    texData[i] = color;
-                }
+                    texData[i] = attributeColors[data[i]];
             }
 
             texture2D.Apply(updateMipmaps: false, makeNoLongerReadable: true);


### PR DESCRIPTION
I have been doing some work on Sol. This method takes about 0.2s for each scene switch in my original test setup, but with Sol it takes 2.8s (even with the last round of optimization). This is another round of optimization for CompileRGB and CompileRGBA.

In order, the 3 commits here do:
* b8bea7c7bf6fa4eb0afc3e1e5233e9419922090b - A straightforward optimization where I have hoisted the calls to `RoundToPixelValue` outside of the loop into a lookup table.
* fcd27eb62ff84247c6beea37e9edd29c742539a3 - The computation is then moved to a job so it can be run in parallel with `Texture2D.GetRawTextureData`
* c902ffc7faf7284e6d0ca4a6b6361a418377e671 - This then copies the simple optimization over to CompileRGBA.

With these optimizations the cost of calling `CompileRGB` is now basically just the cost of calling `GetRawTextureData`.

## Performance
### Parallax-Continued + Kopernicus
Before
<img width="1689" height="631" alt="image" src="https://github.com/user-attachments/assets/75ed758c-3662-43ae-851d-d0b00e7d8872" />

After
<img width="1698" height="660" alt="image" src="https://github.com/user-attachments/assets/b4ff6282-ed62-4485-961a-fced514af18d" />

Timings are pretty inconsistent with smaller textures. Parallelization speeds things up either way, but overall timings really depend on the memory allocator.

### Sol + Parallax-Continued + Kopernicus
Before
<img width="1692" height="481" alt="image" src="https://github.com/user-attachments/assets/731be7b3-49fa-4619-8f69-d603f8f6601f" />

After
<img width="1669" height="657" alt="image" src="https://github.com/user-attachments/assets/7ee49c33-4429-4781-91f8-499dd5dc9f70" />

Timeline view of after
<img width="1353" height="725" alt="image" src="https://github.com/user-attachments/assets/32da760f-d1c7-4dac-bd6f-256431fb2877" />

The overall improvement is about 1s for sol.