### PR TITLE
Optimize `KopernicusCBAttributeMapSO.CreateMap` and `ConvertFromStockMap`

### DIFF
--- a/src/Kopernicus/Utility.cs
+++ b/src/Kopernicus/Utility.cs
@@ -31,10 +31,12 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.OnDemand;
 using Kopernicus.RuntimeUtility;
+using Unity.Jobs;
 using UnityEngine;
 using Object = System.Object;
 
@@ -1574,6 +1576,37 @@ namespace Kopernicus
         }
     }
 #pragma warning restore IDE0041 // Use 'is null' check
+
+    /// <summary>
+    /// A helper struct that allows you to pass managed objects to jobs.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal struct ObjectHandle<T> : IDisposable
+        where T : class
+    {
+        GCHandle handle;
+
+        public T Target => (T)handle.Target;
+
+        public ObjectHandle(T value)
+        {
+            handle = GCHandle.Alloc(value);
+        }
+
+        public void Dispose() => handle.Free();
+
+        public void Dispose(JobHandle job)
+        {
+            new DisposeJob { handle = this }.Schedule(job);
+        }
+
+        struct DisposeJob : IJob
+        {
+            public ObjectHandle<T> handle;
+
+            public void Execute() => handle.Dispose();
+        }
+    }
 }
 
 namespace Kopernicus.Components


### PR DESCRIPTION
This optimizes KopernicusCBAttributeMapSO.CreateMap and ConvertFromStockMap. By my profiling the result is about 4 times faster. With Sol this shaves about 5s off of the initial main menu freeze.

The two changes I have made here are:
* Convert `Parallel.For` loops into `IJobParallelFor`s
* Swap the iteration order so that the inner loop iterates over a row, not a column.

Basically all the improvement comes from the second change. The reason for this is that we are now iterating over items linearly in memory, instead of making giant jumps through memory that the CPU has a hard time predicting.

## Benchmarks
Here's what it looks like before (note that this is with #711 applied). The highlighted region is the call to `KopernicusCBAttributeMapSO.CreateMap` for Sol's `Earth_Biomes.truecolor`, which is a 16384x8192 png.

<img width="2002" height="768" alt="image" src="https://github.com/user-attachments/assets/e3a69dd3-eaa6-47b2-ac74-5cca00be1342" />

And here's the after (again with both this PR and #711 applied). The highlighted area is the same part of the call.

<img width="1930" height="707" alt="image" src="https://github.com/user-attachments/assets/ae9e41ab-1dc0-4a1b-b508-1869d4c92d13" />

