### PR TITLE
Change various MapSO parsers to parse as the correct type

### DIFF
--- a/src/Kopernicus/Configuration/Parsing/BuiltinTypeParsers.cs
+++ b/src/Kopernicus/Configuration/Parsing/BuiltinTypeParsers.cs
@@ -255,7 +255,7 @@ namespace Kopernicus.Configuration.Parsing
 
                     // Create a new map script object
                     Value = ScriptableObject.CreateInstance<T>();
-                    Value.CreateMap(MapSO.MapDepth.RGBA, map);
+                    Value.CreateMap(MapSO.MapDepth.Greyscale, map);
                 }
             }
 
@@ -377,7 +377,7 @@ namespace Kopernicus.Configuration.Parsing
 
                     // Create a new map script object
                     Value = ScriptableObject.CreateInstance<T>();
-                    Value.CreateMap(MapSO.MapDepth.RGBA, map);
+                    Value.CreateMap(MapSO.MapDepth.HeightAlpha, map);
                 }
             }
 
@@ -499,7 +499,7 @@ namespace Kopernicus.Configuration.Parsing
 
                     // Create a new map script object
                     Value = ScriptableObject.CreateInstance<T>();
-                    Value.CreateMap(MapSO.MapDepth.RGBA, map);
+                    Value.CreateMap(MapSO.MapDepth.RGB, map);
                 }
             }
 


### PR DESCRIPTION
These were accidentally changed to be all RGBA instead of the correct types, this fixes that.

I have verified that this fixes the issue with MKRI but haven't tested it more broadly.