### PR TITLE
Avoid changing the file extension in error messages

### DIFF
--- a/src/Kopernicus/Utility.cs
+++ b/src/Kopernicus/Utility.cs
@@ -913,27 +913,28 @@ namespace Kopernicus
         public static string ValidateOnDemandTexture(string path)
         {
             if (TextureLoader.TextureExists(path))
-            {
                 return path;
-            }
-            else if (path.EndsWith(".dds", StringComparison.OrdinalIgnoreCase))
+
+            var ext = Path.GetExtension(path);
+            var dir = Path.GetDirectoryName(path);
+            var basename = Path.GetFileNameWithoutExtension(path);
+
+            if (ext.Equals(".dds", StringComparison.OrdinalIgnoreCase))
             {
-                path = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path)) + ".png";
-                if (TextureLoader.TextureExists(path))
+                var altpath = Path.Combine(dir, basename + ".png");
+                if (TextureLoader.TextureExists(altpath))
                 {
-                    string warningpath = Path.GetFileNameWithoutExtension(path);
-                    UnityEngine.Debug.LogWarning($"[Kopernicus] {warningpath} config entry has inappropriate extension, .dds that is actually a .png on disk, this should be fixed by the planetpack author!");
-                    return path;
+                    Debug.LogWarning($"[Kopernicus] {path} config entry has inappropriate extension, .dds that is actually a .png on disk, this should be fixed by the planetpack author!");
+                    return altpath;
                 }
             }
-            else if (path.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
+            else if (ext.Equals(".png", StringComparison.OrdinalIgnoreCase))
             {
-                path = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path)) + ".dds";
-                if (TextureLoader.TextureExists(path))
+                var altpath = Path.Combine(dir, basename + ".dds");
+                if (TextureLoader.TextureExists(altpath))
                 {
-                    string warningpath = Path.GetFileNameWithoutExtension(path);
-                    UnityEngine.Debug.LogWarning($"[Kopernicus] {warningpath} config entry has inappropriate extension, .png that is actually a .dds on disk, this should be fixed by the planetpack author!");
-                    return path;
+                    Debug.LogWarning($"[Kopernicus] {path} config entry has inappropriate extension, .png that is actually a .dds on disk, this should be fixed by the planetpack author!");
+                    return altpath;
                 }
             }
 


### PR DESCRIPTION
The code here was switching the extension on `path` which meant that an error for `blah.dds` would instead report that it couldn't find `blah.png`. This changes it so that the error message instead reports the original path used in the config.

I haven't had a chance to test this yet. If you get a chance to do so before I do then go for it, it's likely I won't be able to get around to it until friday at the earliest.