### PR TITLE
Use burst to accelerate KopernicusCBAttributeMapSO creation

### DIFF
--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -436,6 +436,7 @@
     <Compile Include="Configuration\MaterialLoader\PQSProjectionFallbackLoader.cs" />
     <Compile Include="Configuration\MaterialLoader\PQSProjectionSurfaceQuadLoader.cs" />
     <Compile Include="Logger.cs" />
+    <Compile Include="MiniBurst.cs" />
     <Compile Include="Configuration\MaterialLoader\PQSMainShaderLoader.cs" />
     <Compile Include="Configuration\ModLoader\VertexColorMap.cs" />
     <Compile Include="Configuration\ModLoader\ModLoader.cs" />

--- a/src/Kopernicus/MiniBurst.cs
+++ b/src/Kopernicus/MiniBurst.cs
@@ -1,0 +1,123 @@
+using System;
+
+namespace Unity.Burst
+{
+    internal enum FloatMode
+    {
+        Default,
+        Strict,
+        Deterministic,
+        Fast,
+    }
+
+    internal enum FloatPrecision
+    {
+        Standard,
+        High,
+        Medium,
+        Low,
+    }
+
+    internal enum OptimizeFor
+    {
+        Default,
+        Performance,
+        Size,
+        FastCompilation,
+        Balanced,
+    }
+
+    [AttributeUsage(
+        AttributeTargets.Assembly
+            | AttributeTargets.Class
+            | AttributeTargets.Struct
+            | AttributeTargets.Method
+    )]
+    internal class BurstCompileAttribute : Attribute
+    {
+        internal bool? _compileSynchronously;
+
+        internal bool? _debug;
+
+        internal bool? _disableSafetyChecks;
+
+        internal bool? _disableDirectCall;
+
+        public FloatMode FloatMode { get; set; }
+
+        public FloatPrecision FloatPrecision { get; set; }
+
+        public bool CompileSynchronously
+        {
+            get
+            {
+                if (!_compileSynchronously.HasValue)
+                {
+                    return false;
+                }
+
+                return _compileSynchronously.Value;
+            }
+            set { _compileSynchronously = value; }
+        }
+
+        public bool Debug
+        {
+            get
+            {
+                if (!_debug.HasValue)
+                {
+                    return false;
+                }
+
+                return _debug.Value;
+            }
+            set { _debug = value; }
+        }
+
+        public bool DisableSafetyChecks
+        {
+            get
+            {
+                if (!_disableSafetyChecks.HasValue)
+                {
+                    return false;
+                }
+
+                return _disableSafetyChecks.Value;
+            }
+            set { _disableSafetyChecks = value; }
+        }
+
+        public bool DisableDirectCall
+        {
+            get
+            {
+                if (!_disableDirectCall.HasValue)
+                {
+                    return false;
+                }
+
+                return _disableDirectCall.Value;
+            }
+            set { _disableDirectCall = value; }
+        }
+
+        public OptimizeFor OptimizeFor { get; set; }
+
+        internal string[] Options { get; set; }
+
+        public BurstCompileAttribute() { }
+
+        public BurstCompileAttribute(FloatPrecision floatPrecision, FloatMode floatMode)
+        {
+            FloatMode = floatMode;
+            FloatPrecision = floatPrecision;
+        }
+
+        internal BurstCompileAttribute(string[] options)
+        {
+            Options = options;
+        }
+    }
+}


### PR DESCRIPTION
This is a little cheeky, but it turns out that you can just copy the BurstCompile attribute into your project and then use it to accelerate your jobs. Unity itself will take care of calling the correct job functions if the appropriate library is present, otherwise will just run the C# code as it normally would. This _does not add a dependency on KSPBurst_.

I have used that trick here to burst-compile the conversion job for KopernicusCBAttributeMapSO.

There should be no algorithmic changes. I had to switch some stuff to use `NativeArray` instead of managed arrays, but otherwise the everything else remains the same.

The performance difference from this is pretty extreme. It shaves 5s off the loading times for Sol, though I think that's a bit of an outlier because Sol's biome colors are wrong so it is hitting the slow path for every pixel.

Before:
<img width="1881" height="401" alt="image" src="https://github.com/user-attachments/assets/fa777a3c-07ed-462d-b241-cb6d1374bef5" />

After:
<img width="1606" height="610" alt="image" src="https://github.com/user-attachments/assets/b2dc7594-5463-4436-bbc6-ac0b2e540d36" />

For a concrete number, the time to convert Sol's `Earth_Biomes.png` goes from 1.5s to 250 ms.