### PR TITLE
Update LangVersion to C# 13

### DIFF
--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Kopernicus</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>13</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
There's a few features that I'd like to use in the new language version so here's a PR to bump it up. This will allow us to use any of the new syntax features, but the compiled code will still run just fine. The compiler will spit out an error if you try to do something that is not actually supported by the runtime.

The actual feature I want this for is the ability to put `[Obsolete]` on a setter specifically. Other ones that I personally find incredibly useful are:
* File-scoped namespaces: `namespace Kopernicus;` at the start and then you don't need to indent the rest of the file
* `using var` statements: `using var x = blah` and then you it is disposed at the end of the scope without needing to add a block.
