### PR TITLE
Fix a couple of issues with R16 MapSODemand

### DIFF
--- a/src/Kopernicus/OnDemand/MapSODemand.cs
+++ b/src/Kopernicus/OnDemand/MapSODemand.cs
@@ -319,6 +319,7 @@ namespace Kopernicus.OnDemand
                 }
 
                 _rowWidth = _width * Stride;
+                _bpp = Stride;
                 _isCompiled = true;
 
                 // Clean up what we don't need anymore
@@ -676,7 +677,7 @@ namespace Kopernicus.OnDemand
                     return new Color(0f, 0f, 0f, a);
 
                 case MemoryFormat.R16:
-                    r = Ushort2Float * (Image[index] + Image[index + 1] << 8);
+                    r = Ushort2Float * (Image[index] + (Image[index + 1] << 8));
                     return new Color(r, r, r, 1f);
 
                 case MemoryFormat.RA16:
@@ -851,7 +852,7 @@ namespace Kopernicus.OnDemand
                     return Byte2Float * Image[index];
 
                 case MemoryFormat.R16:
-                    return Ushort2Float * (Image[index] + Image[index + 1] << 8);
+                    return Ushort2Float * (Image[index] + (Image[index + 1] << 8));
 
                 case MemoryFormat.RA16:
                     return (Byte2Float / 2f) * (Image[index] + Image[index + 1]);
@@ -928,7 +929,7 @@ namespace Kopernicus.OnDemand
                     return new ValueHeightAlpha(0f, Byte2Float * Image[index]);
 
                 case MemoryFormat.R16:
-                    return new ValueHeightAlpha(Ushort2Float * (Image[index] + Image[index + 1] << 8), 1f);
+                    return new ValueHeightAlpha(Ushort2Float * (Image[index] + (Image[index + 1] << 8)), 1f);
 
                 case MemoryFormat.RA16:
                     return new ValueHeightAlpha(Byte2Float * Image[index], Byte2Float * Image[index + 1]);
@@ -997,7 +998,7 @@ namespace Kopernicus.OnDemand
                     return Byte2Float * Image[index];
 
                 case MemoryFormat.R16:
-                    return Ushort2Float * (Image[index] + Image[index + 1] << 8);
+                    return Ushort2Float * (Image[index] + (Image[index + 1] << 8));
 
                 default:
                     return 0f;


### PR DESCRIPTION
There were two issues here:
- `x + y << 8` is not the same as `x + (y << 8)`.
- `_bpp` was being set wrongly for R16 (and other) textures.

All the existing formats happened to now hit these issues because nobody was using the raw formats other than R8, R8A8, RGB24, and RGBA32 all of which happened to work fine when used with the correct map depth.