### PR TITLE
Enable OnDemand textures by default

### DIFF
--- a/src/Kopernicus/Configuration/ConfigReader.cs
+++ b/src/Kopernicus/Configuration/ConfigReader.cs
@@ -69,7 +69,7 @@ namespace Kopernicus.Configuration
         [Persistent]
         public bool UseStockMohoTemplate = true;
         [Persistent]
-        public bool UseOnDemandLoader = false;
+        public bool UseOnDemandLoader = true;
         [Persistent]
         public bool UseRealWorldDensity = false;
         [Persistent]


### PR DESCRIPTION
We said we should do this after release 233. We're only a few days away from making 235 so I think we might want to punt until that gets released but after that we should definitely enable this by default.