### PR TITLE
Put MapSODemand in unloaded state after checking if it is loaded

### DIFF
--- a/src/Kopernicus/OnDemand/MapSODemand.cs
+++ b/src/Kopernicus/OnDemand/MapSODemand.cs
@@ -201,15 +201,16 @@ namespace Kopernicus.OnDemand
             // Clear the texture handle regardless of whether we are loaded or not.
             Handle?.Dispose();
             Handle = null;
-            State = MapState.Unloaded;
 
             // We can only destroy the map, if it is loaded
             if (!IsLoaded)
             {
+                State = MapState.Unloaded;
                 return;
             }
 
             // Set flags
+            State = MapState.Unloaded;
             Format = MemoryFormat.None;
 
             // Event


### PR DESCRIPTION
I noticed this when I was debugging some other stuff. The texture data still gets unloaded, but the log message is never emitted and the event is never fired.

I'm unsure if anything actually uses the event, but this is a bug anyways.