### PR TITLE
Add the start of a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Kopernicus Changelog
+
+## Unreleased
+
+## 235
+1. Major performance improvments in loading time and elsewhere courtesy of KSPTextureLoader.
+2. Fixed broken asteroid density rescaling facilities for stock and Kopernicus generator.
+3. R16 height maps are now natively supported by `MapSODemand`.
+
+## 234
+To see the changelog for previous versions you will need to look at the relevant github release.


### PR DESCRIPTION
This should at least give us a place to write down notes on what's been done as we do it, so that way it's easier to figure out what needs to be highlighted when the next release comes out.

Normally I like to follow the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, but none of the existing changelogs follow that format so I don't really think it's worth pushing for it. I'm mostly just mentioning it as an option.