### PR TITLE
Update the .user file location in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ To build Kopernicus from source, **don't edit the project file**.
 
 Instead, define a **Reference Path** pointing to the **root** of your local KSP install.
 
-In Visual Studio and Rider, this can be done within the IDE UI, by going to the project properties window and then in the `Reference Path` tab.
-If you want to set it manually, create a `Kopernicus.csproj.user` file next to the `src\Kopernicus\Kopernicus.csproj` file with the following content :
+In Visual Studio and Rider, this can be done within the IDE UI, by going to the project properties
+window and then in the `Reference Path` tab. If you want to set it manually, create a
+`Kopernicus.props.user` file next to the `Kopernicus.sln` file with the following content:
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">


### PR DESCRIPTION
With the update to KSPBuildTools the README is out of date here. The props file now needs to be next to the `.sln` file and be called `Kopernicus.props.user`. Otherwise everything else there remains the same.