### PR TITLE
Avoid build errors when building project files individually

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!--
+        If $(SolutionDir) and $(SolutionName) are not set then KSPBuildTools is
+        unable to find the Kopernicus.props.user file. This doesn't become an
+        issue when you build the whole project using `dotnet build` but does
+        cause issues when your editor LSP tooling builds each project
+        individually, since building a project file doesn't set those variables.
+
+        We fix things up here by manually setting them if they are unset.
+    -->
+    <PropertyGroup>
+        <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MSBuildThisFileDirectory)</SolutionDir>
+        <SolutionName Condition=" '$(SolutionName)' == '' ">Kopernicus</SolutionName>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
See the comment in `Directory.Build.props` for the motivation behind this.