### PR TITLE
Print error message in KSP.log if loading a body fails

### DIFF
--- a/src/Kopernicus/Configuration/Loader.cs
+++ b/src/Kopernicus/Configuration/Loader.cs
@@ -306,7 +306,7 @@ namespace Kopernicus.Configuration
                         logger.Close(); //implicit flush
                         Logger.Default.Log("[Kopernicus]: Configuration.Loader: Failed to load Body: " + name + ": " +
                                            e.Message);
-                        throw new Exception("Failed to load Body: " + name);
+                        throw new Exception($"Failed to load Body: {name}: {e.Message}");
                     }
                 }
 


### PR DESCRIPTION
I have run into a number of times where I have somebody's KSP.log but all I really need is this one error message from Kopernicus.log. This makes it so the cause gets printed out in the KSP log directly.

You will still need the kopernicus logs for some stuff, but this should hopefully make them less necessary in a lot of cases.