### PR TITLE
Revert "Rewrite MapSOParsers to parse as KopernicusMapSO"

### DIFF
--- a/src/Kopernicus/Components/KopernicusMapSO.cs
+++ b/src/Kopernicus/Components/KopernicusMapSO.cs
@@ -117,11 +117,13 @@ public class KopernicusMapSO : MapSO
     /// <returns></returns>
     /// 
     /// <remarks>
-    /// This does not take ownership of the provided handle. You are responsible
-    /// for disposing of it yourself.
+    /// This takes ownership of the provided handle, so if you want to keep
+    /// using your handle then pass in <c>handle.Acquire()</c> instead.
     /// </remarks>
     public void CreateMap(MapDepth depth, TextureHandle<Texture2D> handle)
     {
+        using var guard = handle;
+
         // Unload ourselves if we are loaded.
         Unload();
 

--- a/src/Kopernicus/Configuration/Parsing/MapSOParser.cs
+++ b/src/Kopernicus/Configuration/Parsing/MapSOParser.cs
@@ -35,8 +35,10 @@ using UnityEngine;
 
 namespace Kopernicus.Configuration.Parsing;
 
-public abstract class MapSOParserCommon<T> : BaseLoader, IParsable, ITypeParser<T>
-    where T : MapSO
+// Parser for a MapSO
+[RequireConfigType(ConfigType.Value)]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public class MapSOParserGreyScale<T> : BaseLoader, IParsable, ITypeParser<T> where T : MapSO
 {
     /// <summary>
     /// The value that is being parsed
@@ -44,88 +46,62 @@ public abstract class MapSOParserCommon<T> : BaseLoader, IParsable, ITypeParser<
     public T Value { get; set; }
 
     /// <summary>
-    /// The <see cref="MapSO.MapDepth"/> that should be used for this map.
+    /// Parse the Value from a string
     /// </summary>
-    private protected abstract MapSO.MapDepth Depth { get; }
-
-    // This is an internal-only helper type for now.
-    private protected MapSOParserCommon() { }
-
-    private protected MapSOParserCommon(T value) { }
-
     public void SetFromString(string s)
     {
         // Should we use OnDemand?
         bool useOnDemand = OnDemandStorage.UseOnDemand;
 
-        T mapSO;
         if (s.StartsWith("BUILTIN/"))
         {
-            s = s.Substring("BUILTIN/".Length);
-            mapSO = Utility.FindMapSO<T>(s);
-        }
-        else if (
-            useOnDemand
-            && (typeof(MapSODemand).IsAssignableFrom(typeof(T)) || typeof(T) == typeof(MapSO))
-        )
-        {
-            s = Utility.ValidateOnDemandTexture(s);
-
-            if (typeof(T) == typeof(MapSO))
-                mapSO = (T)(MapSO)ScriptableObject.CreateInstance<MapSODemand>();
-            else
-                mapSO = ScriptableObject.CreateInstance<T>();
-            MapSODemand map = (MapSODemand)(MapSO)mapSO;
-
-            map.Path = s;
-            map.Depth = Depth;
-            map.AutoLoad = OnDemandStorage.OnDemandLoadOnMissing;
-
-            OnDemandStorage.AddMap(generatedBody.name, map);
+            s = s.Substring(8);
+            Value = Utility.FindMapSO<T>(s);
         }
         else
         {
-            var options = new TextureLoadOptions
+            // are we on-demand? Don't load now.
+            if (useOnDemand && typeof(T) == typeof(MapSO))
             {
-                Hint = TextureLoadHint.Synchronous,
-                Unreadable = false
-            };
-            using var handle = TextureLoader.LoadTexture<Texture2D>(s, options);
-            try
-            {
-                _ = handle.GetTexture();
+                s = Utility.ValidateOnDemandTexture(s);
+
+                MapSODemand map = ScriptableObject.CreateInstance<MapSODemand>();
+                map.Path = s;
+                map.Depth = MapSO.MapDepth.Greyscale;
+                map.AutoLoad = OnDemandStorage.OnDemandLoadOnMissing;
+                OnDemandStorage.AddMap(generatedBody.name, map);
+                Value = map as T;
             }
-            catch (Exception e)
+            else // Load the texture
             {
-                Logger.Active.Log($"Failed to load texture {s}");
-                Logger.Active.LogException(e);
-                return;
-            }
-
-            if (typeof(T) == typeof(MapSO))
-                mapSO = (T)(MapSO)ScriptableObject.CreateInstance<KopernicusMapSO>();
-            else
-                mapSO = ScriptableObject.CreateInstance<T>();
-
-            // Keep the handle alive after it is disposed of, since methods
-            // below need to take ownership of it.
-            handle.Acquire();
-
-            if (mapSO is KopernicusMapSO kmapSO)
-            {
-                kmapSO.CreateMap(Depth, handle);
-                if (!kmapSO.IsLoaded)
+                var options = new TextureLoadOptions
+                {
+                    Hint = TextureLoadHint.Synchronous,
+                    Unreadable = false
+                };
+                var handle = TextureLoader.LoadTexture<Texture2D>(s, options);
+                Texture2D map;
+                try
+                {
+                    map = handle.TakeTexture();
+                }
+                catch (Exception e)
+                {
+                    Logger.Active.Log($"Failed to load texture {s}");
+                    Logger.Active.LogException(e);
                     return;
-            }
-            else
-            {
-                mapSO.CreateMap(Depth, handle.GetTexture());
+                }
+
+                // Create a new map script object
+                Value = ScriptableObject.CreateInstance<T>();
+                Value.CreateMap(MapSO.MapDepth.Greyscale, map);
             }
         }
 
-        Value = mapSO;
         if (Value != null)
+        {
             Value.name = s;
+        }
     }
 
     /// <summary>
@@ -145,203 +121,404 @@ public abstract class MapSOParserCommon<T> : BaseLoader, IParsable, ITypeParser<
 
         return "BUILTIN/" + Value.name;
     }
-}
-
-// Parser for a MapSO
-[RequireConfigType(ConfigType.Value)]
-[SuppressMessage("ReSharper", "InconsistentNaming")]
-public class MapSOParserGreyScale<T> : MapSOParserCommon<T>
-    where T : MapSO
-{
-    /// <summary>
-    /// The value that is being parsed
-    /// </summary>
-    public new T Value
-    {
-        get => base.Value;
-        set => base.Value = value;
-    }
-
-    private protected override MapSO.MapDepth Depth => MapSO.MapDepth.Greyscale;
-
-    /// <summary>
-    /// Parse the Value from a string
-    /// </summary>
-    public new void SetFromString(string s) => base.SetFromString(s);
-
-    /// <summary>
-    /// Convert the value to a parsable String
-    /// </summary>
-    public new String ValueToString() => base.ValueToString();
 
     /// <summary>
     /// Create a new MapSOParser_GreyScale
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public MapSOParserGreyScale() { }
+    public MapSOParserGreyScale()
+    {
+
+    }
 
     /// <summary>
     /// Create a new MapSOParser_GreyScale from an already existing Texture
     /// </summary>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public MapSOParserGreyScale(T value) : base(value) { }
+    public MapSOParserGreyScale(T value)
+    {
+        Value = value;
+    }
 
     /// <summary>
     /// Convert Parser to Value
     /// </summary>
-    public static implicit operator T(MapSOParserGreyScale<T> parser) => parser.Value;
+    public static implicit operator T(MapSOParserGreyScale<T> parser)
+    {
+        return parser.Value;
+    }
 
     /// <summary>
     /// Convert Value to Parser
     /// </summary>
-    public static implicit operator MapSOParserGreyScale<T>(T value) => new(value);
+    public static implicit operator MapSOParserGreyScale<T>(T value)
+    {
+        return new MapSOParserGreyScale<T>(value);
+    }
 }
 
 // Parser for a MapSO
 [RequireConfigType(ConfigType.Value)]
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-public class MapSOParserHeightAlpha<T> : MapSOParserCommon<T>
-    where T : MapSO
+public class MapSOParserHeightAlpha<T> : BaseLoader, IParsable, ITypeParser<T> where T : MapSO
 {
     /// <summary>
     /// The value that is being parsed
     /// </summary>
-    public new T Value
-    {
-        get => base.Value;
-        set => base.Value = value;
-    }
-
-    private protected override MapSO.MapDepth Depth => MapSO.MapDepth.HeightAlpha;
+    public T Value { get; set; }
 
     /// <summary>
     /// Parse the Value from a string
     /// </summary>
-    public new void SetFromString(string s) => base.SetFromString(s);
+    public void SetFromString(String s)
+    {
+        // Should we use OnDemand?
+        Boolean useOnDemand = OnDemandStorage.UseOnDemand;
+
+        if (s.StartsWith("BUILTIN/"))
+        {
+            s = s.Substring(8);
+            Value = Utility.FindMapSO<T>(s);
+        }
+        else
+        {
+            // are we on-demand? Don't load now.
+            if (useOnDemand && typeof(T) == typeof(MapSO))
+            {
+                s = Utility.ValidateOnDemandTexture(s);
+
+                MapSODemand map = ScriptableObject.CreateInstance<MapSODemand>();
+                map.Path = s;
+                map.Depth = MapSO.MapDepth.HeightAlpha;
+                map.AutoLoad = OnDemandStorage.OnDemandLoadOnMissing;
+                OnDemandStorage.AddMap(generatedBody.name, map);
+                Value = map as T;
+            }
+            else // Load the texture
+            {
+                var options = new TextureLoadOptions
+                {
+                    Hint = TextureLoadHint.Synchronous,
+                    Unreadable = false
+                };
+                var handle = TextureLoader.LoadTexture<Texture2D>(s, options);
+                Texture2D map;
+                try
+                {
+                    map = handle.TakeTexture();
+                }
+                catch (Exception e)
+                {
+                    Logger.Active.Log($"Failed to load texture {s}");
+                    Logger.Active.LogException(e);
+                    return;
+                }
+
+                // Create a new map script object
+                Value = ScriptableObject.CreateInstance<T>();
+                Value.CreateMap(MapSO.MapDepth.HeightAlpha, map);
+            }
+        }
+
+        if (Value != null)
+        {
+            Value.name = s;
+        }
+    }
 
     /// <summary>
     /// Convert the value to a parsable String
     /// </summary>
-    public new String ValueToString() => base.ValueToString();
+    public String ValueToString()
+    {
+        if (Value == null)
+        {
+            return null;
+        }
+
+        if (GameDatabase.Instance.ExistsTexture(Value.name) || TextureLoader.TextureExists(Value.name))
+        {
+            return Value.name;
+        }
+
+        return "BUILTIN/" + Value.name;
+    }
 
     /// <summary>
     /// Create a new MapSOParser_GreyScale
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public MapSOParserHeightAlpha() { }
+    public MapSOParserHeightAlpha()
+    {
+
+    }
 
     /// <summary>
     /// Create a new MapSOParser_GreyScale from an already existing Texture
     /// </summary>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public MapSOParserHeightAlpha(T value) : base(value) { }
+    public MapSOParserHeightAlpha(T value)
+    {
+        Value = value;
+    }
+
     /// <summary>
     /// Convert Parser to Value
     /// </summary>
-    public static implicit operator T(MapSOParserHeightAlpha<T> parser) => parser.Value;
+    public static implicit operator T(MapSOParserHeightAlpha<T> parser)
+    {
+        return parser.Value;
+    }
 
     /// <summary>
     /// Convert Value to Parser
     /// </summary>
-    public static implicit operator MapSOParserHeightAlpha<T>(T value) => new(value);
+    public static implicit operator MapSOParserHeightAlpha<T>(T value)
+    {
+        return new MapSOParserHeightAlpha<T>(value);
+    }
 }
 
 // Parser for a MapSO RGB
 [RequireConfigType(ConfigType.Value)]
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-public class MapSOParserRGB<T> : MapSOParserCommon<T>
-    where T : MapSO
+public class MapSOParserRGB<T> : BaseLoader, IParsable, ITypeParser<T> where T : MapSO
 {
     /// <summary>
     /// The value that is being parsed
     /// </summary>
-    public new T Value
-    {
-        get => base.Value;
-        set => base.Value = value;
-    }
-
-    private protected override MapSO.MapDepth Depth => MapSO.MapDepth.RGB;
+    public T Value { get; set; }
 
     /// <summary>
     /// Parse the Value from a string
     /// </summary>
-    public new void SetFromString(string s) => base.SetFromString(s);
+    public void SetFromString(String s)
+    {
+        // Should we use OnDemand?
+        Boolean useOnDemand = OnDemandStorage.UseOnDemand;
+
+        if (s.StartsWith("BUILTIN/"))
+        {
+            s = s.Substring(8);
+            Value = Utility.FindMapSO<T>(s);
+        }
+        else
+        {
+            // check if OnDemand.
+            if (useOnDemand && typeof(T) == typeof(MapSO))
+            {
+                s = Utility.ValidateOnDemandTexture(s);
+
+                MapSODemand map = ScriptableObject.CreateInstance<MapSODemand>();
+                map.Path = s;
+                map.Depth = MapSO.MapDepth.RGB;
+                map.AutoLoad = OnDemandStorage.OnDemandLoadOnMissing;
+                OnDemandStorage.AddMap(generatedBody.name, map);
+                Value = map as T;
+            }
+            else
+            {
+                var options = new TextureLoadOptions
+                {
+                    Hint = TextureLoadHint.Synchronous,
+                    Unreadable = false
+                };
+                var handle = TextureLoader.LoadTexture<Texture2D>(s, options);
+                Texture2D map;
+                try
+                {
+                    map = handle.TakeTexture();
+                }
+                catch (Exception e)
+                {
+                    Logger.Active.Log($"Failed to load texture {s}");
+                    Logger.Active.LogException(e);
+                    return;
+                }
+
+                // Create a new map script object
+                Value = ScriptableObject.CreateInstance<T>();
+                Value.CreateMap(MapSO.MapDepth.RGB, map);
+            }
+        }
+
+        if (Value != null)
+        {
+            Value.name = s;
+        }
+    }
 
     /// <summary>
     /// Convert the value to a parsable String
     /// </summary>
-    public new String ValueToString() => base.ValueToString();
+    public String ValueToString()
+    {
+        if (Value == null)
+        {
+            return null;
+        }
+
+        if (GameDatabase.Instance.ExistsTexture(Value.name) || TextureLoader.TextureExists(Value.name))
+        {
+            return Value.name;
+        }
+
+        return "BUILTIN/" + Value.name;
+    }
 
     /// <summary>
     /// Create a new MapSOParser_RGB
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public MapSOParserRGB() { }
+    public MapSOParserRGB()
+    {
+
+    }
 
     /// <summary>
     /// Create a new MapSOParser_RGB from an already existing Texture
     /// </summary>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public MapSOParserRGB(T value) : base(value) { }
+    public MapSOParserRGB(T value)
+    {
+        Value = value;
+    }
 
     /// <summary>
     /// Convert Parser to Value
     /// </summary>
-    public static implicit operator T(MapSOParserRGB<T> parser) => parser.Value;
+    public static implicit operator T(MapSOParserRGB<T> parser)
+    {
+        return parser.Value;
+    }
 
     /// <summary>
     /// Convert Value to Parser
     /// </summary>
-    public static implicit operator MapSOParserRGB<T>(T value) => new(value);
+    public static implicit operator MapSOParserRGB<T>(T value)
+    {
+        return new MapSOParserRGB<T>(value);
+    }
 }
 
 // Parser for a MapSO RGBA
 [RequireConfigType(ConfigType.Value)]
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-public class MapSOParserRGBA<T> : MapSOParserCommon<T>
-    where T : MapSO
+public class MapSOParserRGBA<T> : BaseLoader, IParsable, ITypeParser<T> where T : MapSO
 {
     /// <summary>
     /// The value that is being parsed
     /// </summary>
-    public new T Value
-    {
-        get => base.Value;
-        set => base.Value = value;
-    }
-
-    private protected override MapSO.MapDepth Depth => MapSO.MapDepth.RGBA;
+    public T Value { get; set; }
 
     /// <summary>
     /// Parse the Value from a string
     /// </summary>
-    public new void SetFromString(string s) => base.SetFromString(s);
+    public void SetFromString(String s)
+    {
+        // Should we use OnDemand?
+        Boolean useOnDemand = OnDemandStorage.UseOnDemand;
+
+        if (s.StartsWith("BUILTIN/"))
+        {
+            s = s.Substring(8);
+            Value = Utility.FindMapSO<T>(s);
+        }
+        else
+        {
+            // check if OnDemand.
+            if (useOnDemand && typeof(T) == typeof(MapSO))
+            {
+                s = Utility.ValidateOnDemandTexture(s);
+
+                MapSODemand map = ScriptableObject.CreateInstance<MapSODemand>();
+                map.Path = s;
+                map.Depth = MapSO.MapDepth.RGBA;
+                map.AutoLoad = OnDemandStorage.OnDemandLoadOnMissing;
+                OnDemandStorage.AddMap(generatedBody.name, map);
+                Value = map as T;
+            }
+            else
+            {
+                var options = new TextureLoadOptions
+                {
+                    Hint = TextureLoadHint.Synchronous,
+                    Unreadable = false
+                };
+                var handle = TextureLoader.LoadTexture<Texture2D>(s, options);
+                Texture2D map;
+                try
+                {
+                    map = handle.TakeTexture();
+                }
+                catch (Exception e)
+                {
+                    Logger.Active.Log($"Failed to load texture {s}");
+                    Logger.Active.LogException(e);
+                    return;
+                }
+
+                // Create a new map script object
+                Value = ScriptableObject.CreateInstance<T>();
+                Value.CreateMap(MapSO.MapDepth.RGBA, map);
+            }
+        }
+
+        if (Value != null)
+        {
+            Value.name = s;
+        }
+    }
 
     /// <summary>
     /// Convert the value to a parsable String
     /// </summary>
-    public new String ValueToString() => base.ValueToString();
+    public String ValueToString()
+    {
+        if (Value == null)
+        {
+            return null;
+        }
+
+        if (GameDatabase.Instance.ExistsTexture(Value.name) || TextureLoader.TextureExists(Value.name))
+        {
+            return Value.name;
+        }
+
+        return "BUILTIN/" + Value.name;
+    }
 
     /// <summary>
     /// Create a new MapSOParser_RGBA
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public MapSOParserRGBA() { }
+    public MapSOParserRGBA()
+    {
+
+    }
 
     /// <summary>
     /// Create a new MapSOParser_RGB from an already existing Texture
     /// </summary>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public MapSOParserRGBA(T value) : base(value) { }
+    public MapSOParserRGBA(T value)
+    {
+        Value = value;
+    }
 
     /// <summary>
     /// Convert Parser to Value
     /// </summary>
-    public static implicit operator T(MapSOParserRGBA<T> parser) => parser.Value;
+    public static implicit operator T(MapSOParserRGBA<T> parser)
+    {
+        return parser.Value;
+    }
 
     /// <summary>
     /// Convert Value to Parser
     /// </summary>
-    public static implicit operator MapSOParserRGBA<T>(T value) => new(value);
+    public static implicit operator MapSOParserRGBA<T>(T value)
+    {
+        return new MapSOParserRGBA<T>(value);
+    }
 }


### PR DESCRIPTION
This reverts commit 555d6c94137620235536fd9a657bd175c64bf8ba.

This seems to be causing extreme memory usage. Better to revert and fix later.