### PR TITLE
Fix an off-by-1 error in KopernicusCBAttributeMapSO.CompileRGBA

### DIFF
--- a/src/Kopernicus/Components/KopernicusCBAttributeMapSO.cs
+++ b/src/Kopernicus/Components/KopernicusCBAttributeMapSO.cs
@@ -780,7 +780,7 @@ namespace Kopernicus.Components
             {
                 Color32* texData = (Color32*)textureData.GetUnsafePtr();
 
-                for (int i = _data.Length; i >= 0; --i)
+                for (int i = 0; i < _data.Length; ++i)
                     texData[i] = attributeColors[data[i]];
             }
 


### PR DESCRIPTION
This was counting down from `_data.Length`, instead of `_data.Length - 1`, so it would perform an OOB read and OOB write with every call.

I don't think this is actually used anywhere but better to fix it anyways.