### PR TITLE
Fix assigned format in CreateRgba

### DIFF
--- a/src/Kopernicus/OnDemand/MapSODemand.cs
+++ b/src/Kopernicus/OnDemand/MapSODemand.cs
@@ -556,7 +556,7 @@ namespace Kopernicus.OnDemand
         {
             Color32[] pixels32 = tex.GetPixels32();
             Image = new NativeArray<byte>(pixels32.Length * 4, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-            Format = MemoryFormat.RGB24;
+            Format = MemoryFormat.RGBA32;
 
             fixed (Color32* ppixels = pixels32)
             {


### PR DESCRIPTION
This was setting the format to RGB24 instead of RGBA32, which is wrong.