### PR TITLE
Expose Kopernicus version in KSPAssemblyVersion

### DIFF
--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -5,7 +5,7 @@
     <KopernicusRelease>238</KopernicusRelease>
 
     <!-- Assembly metadata -->
-    <Version>1.0.0</Version>
+    <Version>1.0.$(KopernicusRelease)</Version>
     <FileVersion>1.12.$(KopernicusRelease).0</FileVersion>
     <Description>Planetary System Modifier for Kerbal Space Program</Description>
     <Company>Kopernicus Project</Company>
@@ -186,6 +186,7 @@ namespace Kopernicus%3B
 
 internal static class BuildInfo
 {
+    internal const int KopernicusVersion = $(KopernicusRelease)%3B
     internal const string KopernicusRelease = "$(KopernicusRelease)"%3B
 }
       </BuildInfoFileContent>

--- a/src/Kopernicus/Properties/AssemblyInfo.cs
+++ b/src/Kopernicus/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using Kopernicus;
 using Kopernicus.Constants;
 using Kopernicus.RuntimeUtility;
 
-[assembly: KSPAssembly("Kopernicus", 1, 0)]
+[assembly: KSPAssembly("Kopernicus", 1, 0, BuildInfo.KopernicusVersion)]
 [assembly: KSPAssemblyDependency("Kopernicus.Parser", 1, 0)]
 [assembly: KSPAssemblyDependency("ModularFlightIntegrator", 1, 0)]
 [assembly: KSPAssemblyDependency("0Harmony", 0, 0)]


### PR DESCRIPTION
Now instead of the KSPAssemblyVersion always being 1.0.0 it is instead 1.0.$(KopernicusVersion). This should break anyone, but it should allow dependencies that want to constrain the kopernicus versions they work with to work correctly.

I figure I might want this for something in the near future, so better to start now.