### PR TITLE
Fix error message when scaled space normal map fails to load

### DIFF
--- a/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
+++ b/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
@@ -173,7 +173,7 @@ namespace Kopernicus.OnDemand
             }
             catch (Exception ex)
             {
-                Debug.LogError($"[OD] Failed to load texture {texture}");
+                Debug.LogError($"[OD] Failed to load texture {normals}");
                 Debug.LogException(ex);
             }
 


### PR DESCRIPTION
This should print the path to the normal map, but instead prints the path to the main texture.

This led me to a rather confusing debug session where I was trying to figure out why `Sarnus_color.dds` was failing to load.