### PR TITLE
More accurately track when MapSODemand instances are loaded

### DIFF
--- a/src/Kopernicus/OnDemand/MapSODemand.cs
+++ b/src/Kopernicus/OnDemand/MapSODemand.cs
@@ -431,7 +431,7 @@ namespace Kopernicus.OnDemand
             }
         }
 
-        private unsafe new void CreateGreyscaleFromRGB(Texture2D tex)
+        private new unsafe void CreateGreyscaleFromRGB(Texture2D tex)
         {
             Color32[] pixels32 = tex.GetPixels32();
             Image = new NativeArray<byte>(pixels32.Length, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);

--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -29,6 +29,7 @@ using Kopernicus.Components;
 using Kopernicus.ConfigParser;
 using Kopernicus.Configuration;
 using Kopernicus.Constants;
+using Kopernicus.OnDemand;
 using KSP.Localization;
 using KSP.UI;
 using KSP.UI.Screens;
@@ -137,6 +138,8 @@ namespace Kopernicus.RuntimeUtility
             GameEvents.onLevelWasLoaded.Add(s => OnLevelLoaded(s));
             GameEvents.onProtoVesselLoad.Add(d => TransformBodyReferencesOnLoad(d));
             GameEvents.onProtoVesselSave.Add(d => TransformBodyReferencesOnSave(d));
+            Events.OnMapSOLoad.Add(ActivateOnDemandStorage);
+
             // Add Callback only if necessary
             if (KopernicusConfig.HandleHomeworldAtmosphericUnitDisplay)
             {
@@ -1087,6 +1090,10 @@ namespace Kopernicus.RuntimeUtility
                 }
             }
         }
+
+        private void ActivateOnDemandStorage(ILoadOnDemand map) =>
+            OnDemandStorage.ActivateMap(map);
+
         // Remove the Handlers
         private void OnDestroy()
         {
@@ -1095,6 +1102,7 @@ namespace Kopernicus.RuntimeUtility
             GameEvents.onLevelWasLoaded.Remove(OnLevelLoaded);
             GameEvents.onProtoVesselLoad.Remove(TransformBodyReferencesOnLoad);
             GameEvents.onProtoVesselSave.Remove(TransformBodyReferencesOnSave);
+            Events.OnMapSOLoad.Remove(ActivateOnDemandStorage);
         }
     }
 }


### PR DESCRIPTION
There are a bunch of ways for MapSODemand instances to get loaded without PQSMod_OnDemandHandler finding out about it. (Anything that doesn't involve building a quad, really). This leads to loaded MapSODemand instances sticking around when they aren't needed, which can be quite expensive in terms of memory usage.

This commit plugs those holes so that textures will be properly unloaded if they aren't used frequently enough.

I have been prototyping a debugging tool for KSPTL to figure out what's holding a reference to a TextureHandle, getting this PR right has been a pretty good stress test of that tool.