### PR TITLE
Delay PQS.ResetAndWaitCoroutine until the last scene is unloaded

### DIFF
--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -166,6 +166,8 @@
     <Publicize Include="Assembly-CSharp:PQSCity.planetRelativePosition" />
     <Publicize Include="Assembly-CSharp:PQS.PQSLandControl" />
     <Publicize Include="Assembly-CSharp:PQS.mods" />
+    <Publicize Include="Assembly-CSharp:PQS.Mod_OnSphereStart" />
+    <Publicize Include="Assembly-CSharp:PQS.StartSphere" />
     <Publicize Include="Assembly-CSharp:ModuleAsteroidInfo.baseMod" />
     <Publicize Include="Assembly-CSharp:ModuleAsteroidInfo.SetupAsteroidResources" />
 	<Publicize Include="Assembly-CSharp:ModuleCometInfo.baseMod" />

--- a/src/Kopernicus/Patches/PQS_ResetAndWait.cs
+++ b/src/Kopernicus/Patches/PQS_ResetAndWait.cs
@@ -1,0 +1,83 @@
+/**
+ * Kopernicus Planetary System Modifier
+ * -------------------------------------------------------------
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ *
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright of TakeTwo Interactive. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ *
+ * https://kerbalspaceprogram.com
+ */
+
+using System.Collections;
+using HarmonyLib;
+using Kopernicus.RuntimeUtility;
+using UnityEngine;
+
+namespace Kopernicus.Patches;
+
+// This delays ResetAndWaitCoroutine until after the current scene switch has
+// completed. The reason why we need to do this involves asset bundles and how
+// they are loaded.
+//
+// While the main thread is blocked loading an asset from an asset bundle unity
+// will opportunistically run other work while it is waiting. When switching
+// between vessels in flight mode the StartSphere called by ResetAndWaitCoroutine
+// is perfectly timed to have the entire scene load run in the middle.
+//
+// Doing this ends up breaking KSP pretty hard. A bunch of objects related to the
+// current scene haven't been destroyed yet, so the new singletons wake up, see
+// that there is still another live instance, and then destroy themselves. This
+// breaks a whole bunch of stuff, which makes it somewhat confusing to debug.
+//
+// By delaying the call to StartSphere until the scene switch is completed we
+// can avoid this problem.
+[HarmonyPatch(typeof(PQS), "ResetAndWaitCoroutine")]
+internal static class PQS_ResetAndWait
+{
+    static bool SceneSwitchInProgress => RuntimeUtility.RuntimeUtility.SceneSwitchInProgress;
+
+    static IEnumerator Postfix(IEnumerator __result, PQS __instance) =>
+        ResetAndWaitCoroutine(__instance, __result);
+
+    // This needs to be calleed ResetAndWaitCoroutine so that PQS calling
+    // StopCoroutine("ResetAndWaitCoroutine") works as expected.
+    static IEnumerator ResetAndWaitCoroutine(PQS pqs, IEnumerator coroutine)
+    {
+        pqs.Mod_OnSphereStart();
+        while (!pqs.isAlive && !pqs.isDisabled)
+        {
+            yield return null;
+            pqs.Mod_OnSphereStart();
+        }
+
+        if (SceneSwitchInProgress)
+        {
+            Debug.Log($"[Kopernicus] Delaying ResetAndWait of body {pqs.name} until scene switch is complete");
+            yield return WaitUntilSceneSwitchComplete.Instance;
+        }
+
+        pqs.StartSphere(force: false);
+    }
+
+    class WaitUntilSceneSwitchComplete : CustomYieldInstruction
+    {
+        public static readonly WaitUntilSceneSwitchComplete Instance = new();
+
+        public override bool keepWaiting => SceneSwitchInProgress;
+    }
+}

--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -45,6 +45,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
@@ -98,6 +99,7 @@ namespace Kopernicus.RuntimeUtility
         public static PQSCache.PQSPreset pqsLow;
         public static PQSCache.PQSPreset pqsDefault;
         public static PQSCache.PQSPreset pqsHigh;
+        public static bool SceneSwitchInProgress { get; private set; } = false;
 
         //old mockbody for compat
         public static CelestialBody mockBody = null;
@@ -138,7 +140,10 @@ namespace Kopernicus.RuntimeUtility
             GameEvents.onLevelWasLoaded.Add(s => OnLevelLoaded(s));
             GameEvents.onProtoVesselLoad.Add(d => TransformBodyReferencesOnLoad(d));
             GameEvents.onProtoVesselSave.Add(d => TransformBodyReferencesOnSave(d));
+            GameEvents.onGameSceneLoadRequested.Add(OnGameSceneLoadRequested);
             Events.OnMapSOLoad.Add(ActivateOnDemandStorage);
+
+            SceneManager.sceneLoaded += OnSceneLoaded;
 
             // Add Callback only if necessary
             if (KopernicusConfig.HandleHomeworldAtmosphericUnitDisplay)
@@ -1094,6 +1099,16 @@ namespace Kopernicus.RuntimeUtility
         private void ActivateOnDemandStorage(ILoadOnDemand map) =>
             OnDemandStorage.ActivateMap(map);
 
+        private void OnGameSceneLoadRequested(GameScenes _)
+        {
+            SceneSwitchInProgress = true;
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            SceneSwitchInProgress = false;
+        }
+
         // Remove the Handlers
         private void OnDestroy()
         {
@@ -1102,7 +1117,10 @@ namespace Kopernicus.RuntimeUtility
             GameEvents.onLevelWasLoaded.Remove(OnLevelLoaded);
             GameEvents.onProtoVesselLoad.Remove(TransformBodyReferencesOnLoad);
             GameEvents.onProtoVesselSave.Remove(TransformBodyReferencesOnSave);
+            GameEvents.onGameSceneLoadRequested.Remove(OnGameSceneLoadRequested);
             Events.OnMapSOLoad.Remove(ActivateOnDemandStorage);
+
+            SceneManager.sceneLoaded -= OnSceneLoaded;
         }
     }
 }


### PR DESCRIPTION
Synchronously loading textures while there is a pending LoadSceneAsync call will cause unity to load the entire new scene while the texture handle is blocking on an asset bundle internally. This breaks KSP.

To fix this on the kopernicus side this commit delays the call to PQS.StartSphere within PQS.ResetAndWaitCoroutine by one frame if there is a pending scene switch. This has proved to actually be rather difficult to test since you need to somehow get a ResetAndWait call that uses an unloaded asset bundle texture, but I'm pretty sure it is correct now.

Fixes #785 