### PR TITLE
Convert PQS_ResetAndWait to a transpiler patch on the state machine

### DIFF
--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -168,6 +168,7 @@
     <Publicize Include="Assembly-CSharp:PQS.mods" />
     <Publicize Include="Assembly-CSharp:PQS.Mod_OnSphereStart" />
     <Publicize Include="Assembly-CSharp:PQS.StartSphere" />
+    <Publicize Include="Assembly-CSharp:PQS.ResetAndWaitCoroutine" />
     <Publicize Include="Assembly-CSharp:ModuleAsteroidInfo.baseMod" />
     <Publicize Include="Assembly-CSharp:ModuleAsteroidInfo.SetupAsteroidResources" />
 	<Publicize Include="Assembly-CSharp:ModuleCometInfo.baseMod" />

--- a/src/Kopernicus/Patches/PQS_ResetAndWait.cs
+++ b/src/Kopernicus/Patches/PQS_ResetAndWait.cs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -23,7 +23,12 @@
  * https://kerbalspaceprogram.com
  */
 
+using System.CodeDom.Compiler;
 using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
 using HarmonyLib;
 using Kopernicus.RuntimeUtility;
 using UnityEngine;
@@ -46,32 +51,96 @@ namespace Kopernicus.Patches;
 //
 // By delaying the call to StartSphere until the scene switch is completed we
 // can avoid this problem.
-[HarmonyPatch(typeof(PQS), "ResetAndWaitCoroutine")]
+[HarmonyPatch]
 internal static class PQS_ResetAndWait
 {
     static bool SceneSwitchInProgress => RuntimeUtility.RuntimeUtility.SceneSwitchInProgress;
+    const int CustomState = 12331;
 
-    static IEnumerator Postfix(IEnumerator __result, PQS __instance) =>
-        ResetAndWaitCoroutine(__instance, __result);
+    static MethodBase TargetMethod() =>
+        AccessTools.EnumeratorMoveNext(SymbolExtensions.GetMethodInfo<PQS>(pqs => pqs.ResetAndWaitCoroutine()));
 
-    // This needs to be calleed ResetAndWaitCoroutine so that PQS calling
-    // StopCoroutine("ResetAndWaitCoroutine") works as expected.
-    static IEnumerator ResetAndWaitCoroutine(PQS pqs, IEnumerator coroutine)
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator gen)
     {
-        pqs.Mod_OnSphereStart();
-        while (!pqs.isAlive && !pqs.isDisabled)
+        // KSPCF patches ResetAndWait to start the coroutine by its string name.
+        // As far as I can tell this actually makes it so our patch is never
+        // called. Instead of trying to debug this too hard we just take the
+        // approach here of patching a new state into the state machine for the
+        // returned enumerator. Nobody else is crazy enough to actually do that
+        // so we can know we're safe from being tampered with here.
+
+        var moveNext = AccessTools.EnumeratorMoveNext(SymbolExtensions.GetMethodInfo<PQS>(pqs => pqs.ResetAndWaitCoroutine()));
+        var type = moveNext.DeclaringType;
+
+        var state = AccessTools.Field(type, "<>1__state");
+        var current = AccessTools.Field(type, "<>2__current");
+        var pqs = AccessTools.Field(type, "<>4__this");
+
+        var currentLocal = gen.DeclareLocal(typeof(object));
+        var customResumeLabel = gen.DefineLabel();
+        var skipYieldLabel = gen.DefineLabel();
+
+        var matcher = new CodeMatcher(instructions, gen);
+
+        // Add CustomState to the state dispatch.
+        // Find the first ldc.i4.0 + ret (the default "return false" for unknown states).
+        matcher.MatchStartForward(
+            new CodeMatch(OpCodes.Ldc_I4_0),
+            new CodeMatch(OpCodes.Ret));
+
+        matcher.Insert(
+            new CodeInstruction(OpCodes.Ldloc_0),
+            new CodeInstruction(OpCodes.Ldc_I4, CustomState),
+            new CodeInstruction(OpCodes.Beq, customResumeLabel));
+
+        // Insert scene switch check before StartSphere.
+        matcher.MatchStartForward(
+            new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(PQS), "StartSphere")));
+
+        matcher.Advance(-2);
+
+        var existingLabels = new List<Label>(matcher.Labels);
+        matcher.Labels.Clear();
+        matcher.AddLabels(new[] { skipYieldLabel });
+
+        matcher.InsertAndAdvance([
+            // CheckSceneSwitch(pqs, out current)
+            new CodeInstruction(OpCodes.Ldarg_0).WithLabels(existingLabels),
+            new CodeInstruction(OpCodes.Ldfld, pqs),
+            new CodeInstruction(OpCodes.Ldloca, currentLocal),
+            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PQS_ResetAndWait), nameof(CheckSceneSwitch))),
+            new CodeInstruction(OpCodes.Brfalse, skipYieldLabel),
+
+            // yield return current
+            new CodeInstruction(OpCodes.Ldarg_0),
+            new CodeInstruction(OpCodes.Ldloc, currentLocal),
+            new CodeInstruction(OpCodes.Stfld, current),
+            new CodeInstruction(OpCodes.Ldarg_0),
+            new CodeInstruction(OpCodes.Ldc_I4, CustomState),
+            new CodeInstruction(OpCodes.Stfld, state),
+            new CodeInstruction(OpCodes.Ldc_I4_1),
+            new CodeInstruction(OpCodes.Ret),
+
+            // Resume from CustomState: set state to -1 and fall through to StartSphere
+            new CodeInstruction(OpCodes.Ldarg_0).WithLabels(customResumeLabel),
+            new CodeInstruction(OpCodes.Ldc_I4_M1),
+            new CodeInstruction(OpCodes.Stfld, state)
+        ]);
+
+        return matcher.Instructions();
+    }
+
+    static bool CheckSceneSwitch(PQS pqs, out object current)
+    {
+        if (!SceneSwitchInProgress)
         {
-            yield return null;
-            pqs.Mod_OnSphereStart();
+            current = null;
+            return false;
         }
 
-        if (SceneSwitchInProgress)
-        {
-            Debug.Log($"[Kopernicus] Delaying ResetAndWait of body {pqs.name} until scene switch is complete");
-            yield return WaitUntilSceneSwitchComplete.Instance;
-        }
-
-        pqs.StartSphere(force: false);
+        Debug.Log($"[Kopernicus] Delaying ResetAndWait of body {pqs.name} until scene switch is complete");
+        current = WaitUntilSceneSwitchComplete.Instance;
+        return true;
     }
 
     class WaitUntilSceneSwitchComplete : CustomYieldInstruction


### PR DESCRIPTION
I had a hard time confirming that the previous patch actually worked and whether it conflicted with another patch from KSPCF. This one I can verify works and it won't conflict with any other patches since nobody else is willing to attempt to patch coroutine state machines.