### PR TITLE
Add HomeWorldFallback

### DIFF
--- a/build/KSP19PLUS/GameData/Kopernicus/Config/002_HomeWorldFallback.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Config/002_HomeWorldFallback.cfg
@@ -1,0 +1,4 @@
+@Kopernicus_config:FIRST
+{
+    %HomeWorldName = Kerbin
+}


### PR DESCRIPTION
This PR adds a config that, when no other planet packs currently use the HomeWorldName option, resets the HomeWorldName to Kerbin

Note: For a planet pack to be able to use this feature the config for the planet that becomes the new HomeWorldName would need to look similar to this:
```
@Kopernicus_config:BEFORE[ModName]:HAS[#ModSettings:HAS[#SettingName[value]]]
{
    @HomeWorldName = PlanetName
}
```
With ModName being the name of the mod this patch should be applied to, PlanetName being the internal name of the planet & ModSettings, SettingName and value being optional for if the patch should only be applied via a specific mod setting