### PR TITLE
Make another pass at improving `PQSMod_OnDemandHandler`

### DIFF
--- a/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
+++ b/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
@@ -126,7 +126,14 @@ namespace Kopernicus.OnDemand
 
                 // We will never unload ourselves while the PQS sphere is loaded.
                 if (sphere.isActive)
+                {
+                    // Make sure we periodically update the stats so that we don't
+                    // immediately unload the textures when the sphere goes inactive.
+                    if (_lastUpdateFrame + UpdateInterval < Time.frameCount)
+                        UpdateUnloadTime();
+
                     continue;
+                }
 
                 // If we are the currently active body, do not unload.
                 if (sphere.IsNotNullOrDestroyed() && FlightGlobals.ActiveVessel.IsNotNullOrDestroyed())


### PR DESCRIPTION
This gets `PQSMod_OnDemandHandler` to a point where I don't think there are any more issues with it.

Here's what I have changed:
* Instead of using LateUpdate we now have a coroutine does the check every frame. The coroutine exiting results in OnDemandHandler being considered unloaded. This means that OnDemandHandler instances that are not loaded have no per-frame overhead.
* The coroutine explicitly checks `sphere.active`. `OnSphereInactive` is not reliably emitted during scene switches which was leading to maps not being unloaded appropriately.
* We now track both `_unloadTime` and `_unloadFrame` so that long frames (i.e. scene switches) don't result in maps being unloaded.

I think I can stop making PRs for this after this point.