### PR TITLE
Harden OnDemandHandler against being called on an invalid GameObject

### DIFF
--- a/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
+++ b/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
@@ -113,8 +113,19 @@ namespace Kopernicus.OnDemand
 
         public override void OnQuadPreBuild(PQ quad) => Activate();
 
-        public override void OnVertexBuildHeight(PQS.VertexBuildData data) =>
+        public override void OnVertexBuildHeight(PQS.VertexBuildData data)
+        {
+            // Linx's texture exporter calls OnVertexBuildHeight on multiple
+            // and on invalid objects. We can't really handle that correctly,
+            // but what we can do is avoid throwing an exception in that case.
+            //
+            // It's already known not to be compatible with OnDemand, so this
+            // should make things (maybe?) work in the remaining cases.
+            if (this.IsDestroyed() || sphere.IsDestroyed())
+                return;
+
             Activate();
+        }
 
         IEnumerator UnloadWatcher()
         {


### PR DESCRIPTION
Linx's texture exporter calls `OnVertexBuildHeight` against spheres that don't seem to be valid game objects, this causes exceptions because it was not a use case I expected when updating `PQSMod_OnDemandHandler`. This is an attempt at fixing that.