### PR TITLE
Adjust the message in the missing texture popup

### DIFF
--- a/build/KSP19PLUS/GameData/Kopernicus/Localization/en-us.cfg
+++ b/build/KSP19PLUS/GameData/Kopernicus/Localization/en-us.cfg
@@ -28,7 +28,7 @@ Localization
 
         // UI : Missing Textures Popup
         #Kopernicus_UI_MissingTextures_Title = Kopernicus - Missing Textures
-        #Kopernicus_UI_MissingTextures_Description = Some planet textures have failed to load. This usually means that you have installed a planet pack wrong, but might also mean that a planet pack has broken configs. The planets listed below will likely be broken in some way. Load your existing saves at your own risk.
+        #Kopernicus_UI_MissingTextures_Description = Some planet textures have failed to load. Often this means that a planet pack has broken configs, but it may also mean that you have installed it wrong. The planets listed below will likely be broken in some way. Depending on the textures involved this could be minor or the planets could be completely broken. Load your existing saves at your own risk.
         #Kopernicus_UI_MissingTextures_NoBody = <no body>
         #Kopernicus_UI_MissingTextures_Close = Close
     }


### PR DESCRIPTION
It seems like more often then not this popup is showing up due to broken mods, rather than user error. I don't really expect many people to actually read the error message, but this rewords the message to be less alarming.