### PR TITLE
Material Overhaul: Add material loader framework

### DIFF
--- a/src/Kopernicus/Configuration/MaterialLoader/BaseMaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/BaseMaterialLoader.cs
@@ -1,0 +1,531 @@
+/**
+ * Kopernicus Planetary System Modifier
+ * -------------------------------------------------------------
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ *
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright of TakeTwo Interactive. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ *
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Kopernicus.ConfigParser;
+using Kopernicus.ConfigParser.Attributes;
+using Kopernicus.ConfigParser.BuiltinTypeParsers;
+using Kopernicus.ConfigParser.Interfaces;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
+using Kopernicus.Configuration.Parsing;
+using Kopernicus.OnDemand;
+using KSPTextureLoader;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Kopernicus.Configuration.MaterialLoader;
+
+/// <summary>
+/// The base class for all material loaders. It owns the live <see cref="Material"/>,
+/// the on-demand texture entry list, and a set of validated property accessors that
+/// both the raw <c>_X</c> key path (handled by <see cref="PostApply"/>) and the
+/// per-shader friendly aliases route through.
+/// </summary>
+public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
+{
+    /// <summary>
+    /// The material actually loaded by this loader.
+    /// </summary>
+    public Material Value { get; protected set; }
+
+    /// <summary>
+    /// A list of <see cref="OnDemandTextureEntry"/>s that need to be loaded
+    /// when this material is in use.
+    /// </summary>
+    public Dictionary<string, string> Entries { get; private set; } = [];
+
+    /// <summary>
+    /// The shader that will actually be loaded.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// If made into a <see cref="ParserTarget" /> then this should be marked
+    /// with <see cref="PreApply" /> because the material is created in
+    /// <see cref="Apply" />.
+    /// </remarks>
+    public abstract ShaderParser ShaderParser { get; set; }
+
+    /// <summary>
+    /// Whether this specific material should use on-demand textures. Defaults
+    /// to the global config but can be overridden if needed.
+    /// </summary>
+    public virtual NumericParser<bool> OnDemand { get; set; } = OnDemandStorage.UseOnDemand;
+
+    public virtual void Apply(ConfigNode node)
+    {
+        var shader = ShaderParser.Value;
+
+        if (shader is null)
+        {
+            Logger.Active.LogWarning("No shader specified for material. An error shader will be used instead.");
+            shader = UnityEngine.Shader.Find("Hidden/InternalErrorShader");
+        }
+
+        if (Value is null)
+            Value = new Material(shader);
+        else
+            Value.shader = shader;
+    }
+
+    public virtual void PostApply(ConfigNode node)
+    {
+        if (Value is null)
+            return;
+
+        var shader = Value.shader;
+        var values = node.values;
+        for (int i = 0; i < values.Count; ++i)
+        {
+            var entry = values[i];
+            if (!entry.name.StartsWith("_"))
+                continue;
+
+            LoadEntry(shader, entry.name, entry.value);
+        }
+    }
+
+    void LoadEntry(Shader shader, string name, string value)
+    {
+        var index = shader.FindPropertyIndex(name);
+        if (index == -1)
+        {
+            // *Scale and *Offset don't exist as standalone shader properties;
+            // they live alongside the underlying texture property. If the
+            // base name resolves to a texture, route to the appropriate
+            // setter instead.
+            if (name.EndsWith("Scale"))
+            {
+                var subname = name.Substring(0, name.Length - "Scale".Length);
+                if (shader.FindPropertyIndex(subname) != -1)
+                {
+                    var p = new Vector2Parser();
+                    p.SetFromString(value);
+                    SetTextureScale(subname, p.Value);
+                    return;
+                }
+            }
+
+            if (name.EndsWith("Offset"))
+            {
+                var subname = name.Substring(0, name.Length - "Offset".Length);
+                if (shader.FindPropertyIndex(subname) != -1)
+                {
+                    var p = new Vector2Parser();
+                    p.SetFromString(value);
+                    SetTextureOffset(subname, p.Value);
+                    return;
+                }
+            }
+
+            Logger.Active.LogWarning($"Property name `{name}` is not a property on the shader `{shader.name}` and will be ignored.");
+            return;
+        }
+
+        switch (shader.GetPropertyType(index))
+        {
+            case ShaderPropertyType.Color:
+                {
+                    var p = new ColorParser();
+                    p.SetFromString(value);
+                    SetColor(name, p.Value);
+                    break;
+                }
+            case ShaderPropertyType.Vector:
+                {
+                    var p = new Vector4Parser();
+                    p.SetFromString(value);
+                    SetVector(name, p.Value);
+                    break;
+                }
+            case ShaderPropertyType.Float:
+            case ShaderPropertyType.Range:
+                {
+                    var p = new NumericParser<float>();
+                    p.SetFromString(value);
+                    SetFloat(name, p.Value);
+                    break;
+                }
+            case ShaderPropertyType.Texture:
+                SetTexture(name, value);
+                break;
+        }
+    }
+
+    bool TryFindProperty(string key, ShaderPropertyType expected, string typeName, out int index)
+    {
+        index = -1;
+        if (Value is null)
+            return false;
+
+        var shader = Value.shader;
+        index = shader.FindPropertyIndex(key);
+        if (index == -1)
+        {
+            Logger.Active.LogWarning($"Shader property `{key}` does not exist on shader `{shader.name}`");
+            return false;
+        }
+
+        if (shader.GetPropertyType(index) != expected)
+        {
+            Logger.Active.LogWarning($"Shader property `{key}` on shader `{shader.name}` is not a {typeName} property");
+            return false;
+        }
+
+        return true;
+    }
+
+    // === Color ==============================================================
+
+    public Color GetColor(string key)
+    {
+        if (Value is null)
+            return default;
+        return Value.GetColor(key);
+    }
+
+    public void SetColor(string key, Color value)
+    {
+        if (!TryFindProperty(key, ShaderPropertyType.Color, "color", out _))
+            return;
+        Value.SetColor(key, value);
+    }
+
+    // === Float / Range ======================================================
+
+    public float GetFloat(string key)
+    {
+        if (Value is null)
+            return default;
+        return Value.GetFloat(key);
+    }
+
+    public void SetFloat(string key, float value)
+    {
+        if (Value is null)
+            return;
+
+        var shader = Value.shader;
+        var index = shader.FindPropertyIndex(key);
+        if (index == -1)
+        {
+            Logger.Active.LogWarning($"Shader property `{key}` does not exist on shader `{shader.name}`");
+            return;
+        }
+
+        var type = shader.GetPropertyType(index);
+        if (type != ShaderPropertyType.Float && type != ShaderPropertyType.Range)
+        {
+            Logger.Active.LogWarning($"Shader property `{key}` on shader `{shader.name}` is not a float or range property");
+            return;
+        }
+
+        if (type == ShaderPropertyType.Range)
+        {
+            var range = shader.GetPropertyRangeLimits(index);
+            value = Mathf.Clamp(value, range.x, range.y);
+        }
+
+        Value.SetFloat(key, value);
+    }
+
+    public int GetInt(string key)
+    {
+        if (Value is null)
+            return default;
+        return Value.GetInt(key);
+    }
+
+    public void SetInt(string key, int value)
+    {
+        if (Value is null)
+            return;
+
+        var shader = Value.shader;
+        var index = shader.FindPropertyIndex(key);
+        if (index == -1)
+        {
+            Logger.Active.LogWarning($"Shader property `{key}` does not exist on shader `{shader.name}`");
+            return;
+        }
+
+        var type = shader.GetPropertyType(index);
+        if (type != ShaderPropertyType.Float && type != ShaderPropertyType.Range)
+        {
+            Logger.Active.LogWarning($"Shader property `{key}` on shader `{shader.name}` is not a float property");
+            return;
+        }
+
+        Value.SetInt(key, value);
+    }
+
+    // === Vector =============================================================
+
+    public Vector4 GetVector(string key)
+    {
+        if (Value is null)
+            return default;
+        return Value.GetVector(key);
+    }
+
+    public void SetVector(string key, Vector4 value)
+    {
+        if (!TryFindProperty(key, ShaderPropertyType.Vector, "vector", out _))
+            return;
+        Value.SetVector(key, value);
+    }
+
+    // === Texture ============================================================
+
+    public Texture GetTexture(string key)
+    {
+        if (Value is null)
+            return null;
+        return Value.GetTexture(key);
+    }
+
+    public void SetTexture(string key, MaterialTextureParser path)
+    {
+        if (path is null)
+            return;
+        SetTexture(key, path.Path);
+    }
+
+    public void SetTexture(string key, string path)
+    {
+        if (!TryFindProperty(key, ShaderPropertyType.Texture, "texture", out var index))
+            return;
+
+        var dim = Value.shader.GetPropertyTextureDimension(index);
+        using var handle = LoadTextureForDim(dim, key, path);
+        if (handle is null)
+            return;
+
+        try
+        {
+            Value.SetTexture(key, handle.GetTexture());
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[Kopernicus] Failed to load texture {handle.Path}");
+            Logger.Active.LogWarning($"Failed to load texture {handle.Path}");
+            Logger.Active.LogException(e);
+            Utility.LogMissingTexture(CurrentBody, handle.Path);
+        }
+    }
+
+    public Vector2 GetTextureScale(string key)
+    {
+        if (Value is null)
+            return default;
+        return Value.GetTextureScale(key);
+    }
+
+    public void SetTextureScale(string key, Vector2 value)
+    {
+        if (!TryFindProperty(key, ShaderPropertyType.Texture, "texture", out _))
+            return;
+        Value.SetTextureScale(key, value);
+    }
+
+    public Vector2 GetTextureOffset(string key)
+    {
+        if (Value is null)
+            return default;
+        return Value.GetTextureOffset(key);
+    }
+
+    public void SetTextureOffset(string key, Vector2 value)
+    {
+        if (!TryFindProperty(key, ShaderPropertyType.Texture, "texture", out _))
+            return;
+        Value.SetTextureOffset(key, value);
+    }
+
+    // === Keyword ============================================================
+
+    public bool GetKeyword(string keyword)
+    {
+        if (Value is null)
+            return false;
+        return Value.IsKeywordEnabled(keyword);
+    }
+
+    public void SetKeyword(string keyword, bool enabled)
+    {
+        if (Value is null)
+            return;
+
+        if (enabled)
+            Value.EnableKeyword(keyword);
+        else
+            Value.DisableKeyword(keyword);
+    }
+
+    public string GetMultiKeyword(string[] keywords)
+    {
+        if (Value is null)
+            return null;
+
+        foreach (var k in keywords)
+        {
+            if (Value.IsKeywordEnabled(k))
+                return k;
+        }
+
+        return null;
+    }
+
+    public void SetMultiKeyword(string[] keywords, string selected)
+    {
+        if (Value is null || selected is null)
+            return;
+
+        if (!keywords.Contains(selected))
+        {
+            Logger.Active.LogWarning($"Shader keyword `{selected}` is not valid for this property. Expected one of {string.Join(", ", keywords)}");
+            return;
+        }
+
+        foreach (var k in keywords)
+        {
+            if (k != selected)
+                Value.DisableKeyword(k);
+        }
+
+        Value.EnableKeyword(selected);
+    }
+
+    // === Gradient (baked into a 1D ramp texture) ============================
+
+    public void SetGradient(string key, Configuration.Parsing.Gradient gradient)
+    {
+        if (gradient is null)
+            return;
+        if (!TryFindProperty(key, ShaderPropertyType.Texture, "texture", out _))
+            return;
+        Value.SetTexture(key, BakeRamp(gradient));
+    }
+
+    const int RAMP_WIDTH = 512;
+
+    static Texture2D BakeRamp(Configuration.Parsing.Gradient gradient)
+    {
+        var ramp = new Texture2D(RAMP_WIDTH, 1)
+        {
+            wrapMode = TextureWrapMode.Clamp,
+            mipMapBias = 0.0f,
+        };
+
+        var colors = ramp.GetPixels32(0);
+        for (var i = 0; i < colors.Length; i++)
+            colors[i] = gradient.ColorAt((float)i / colors.Length);
+
+        ramp.SetPixels32(colors, 0);
+        ramp.Apply(true, false);
+        return ramp;
+    }
+
+    // === Texture loading ====================================================
+
+    static PSystemBody CurrentBody =>
+        Parser.GetState<Body>("Kopernicus:currentBody")?.GeneratedBody;
+
+    TextureHandle<T> LoadTexture<T>(string key, string path)
+        where T : Texture
+    {
+        if (string.IsNullOrEmpty(path))
+            return null;
+
+        if (path.StartsWith("BUILTIN/"))
+        {
+            path = path.Substring("BUILTIN/".Length);
+            var texture = Resources
+                .FindObjectsOfTypeAll<T>()
+                .FirstOrDefault(tex => tex.name == path);
+            if (texture == null)
+            {
+                Debug.LogError($"[Kopernicus] Could not find built-in texture {path} of type {typeof(T).Name}");
+                Logger.Active.LogWarning($"Could not find built-in texture {path} of type {typeof(T).Name}");
+                Utility.LogMissingTexture(CurrentBody, path);
+                return null;
+            }
+
+            return TextureHandle.CreateExternalHandle<T>(texture);
+        }
+
+        if (typeof(T).IsAssignableFrom(typeof(Texture2D)))
+        {
+            if (GameDatabase.Instance.ExistsTexture(path))
+            {
+                return TextureHandle.CreateExternalHandle<T>(
+                    (T)(Texture)GameDatabase.Instance.GetTexture(path, false)
+                );
+            }
+        }
+
+        if (OnDemand.Value)
+        {
+            path = Utility.ValidateOnDemandTexture(path);
+            Entries[key] = path;
+            return null;
+        }
+        else
+        {
+            var options = new TextureLoadOptions
+            {
+                Hint = TextureLoadHint.BatchSynchronous,
+                Unreadable = true
+            };
+
+            Entries.Remove(key);
+            var handle = TextureLoader.LoadTexture<T>(path, options);
+            TextureHandleStorage.Instance.Store(handle.Acquire());
+            return handle;
+        }
+    }
+
+    TextureHandle LoadTextureForDim(TextureDimension dim, string key, string path)
+    {
+        switch (dim)
+        {
+            case TextureDimension.Tex2D:
+                return LoadTexture<Texture2D>(key, path);
+
+            case TextureDimension.Tex3D:
+                return LoadTexture<Texture3D>(key, path);
+
+            case TextureDimension.Tex2DArray:
+                return LoadTexture<Texture2DArray>(key, path);
+
+            case TextureDimension.CubeArray:
+                return LoadTexture<CubemapArray>(key, path);
+
+            default:
+                return LoadTexture<Texture>(key, path);
+        }
+    }
+}

--- a/src/Kopernicus/Configuration/MaterialLoader/CustomMaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/CustomMaterialLoader.cs
@@ -23,42 +23,45 @@
  * https://kerbalspaceprogram.com
  */
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using Kopernicus.ConfigParser;
+using Kopernicus.ConfigParser.Attributes;
+using Kopernicus.ConfigParser.BuiltinTypeParsers;
+using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.ConfigParser.Interfaces;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
+using Kopernicus.Configuration.Parsing;
+using Kopernicus.OnDemand;
 using KSPTextureLoader;
 using UnityEngine;
+using UnityEngine.Rendering;
 
-namespace Kopernicus.OnDemand;
+namespace Kopernicus.Configuration.MaterialLoader;
 
-/// <summary>
-/// A component attached to the __deactivator GameObject that keeps texture handles
-/// alive without resorting to GCHandle leaks. Handles stored here are retained for
-/// the lifetime of the game so that KSPTextureLoader's internal cache stays valid.
-/// </summary>
-internal class TextureHandleStorage : MonoBehaviour
+[RequireConfigType(ConfigType.Node)]
+public class CustomMaterialLoader : BaseMaterialLoader
 {
-    private static TextureHandleStorage _instance;
+    /// <summary>
+    /// The shader that will actually be loaded.
+    /// </summary>
+    [PreApply]
+    [ParserTarget("shader")]
+    public override ShaderParser ShaderParser { get; set; }
 
-    private readonly List<TextureHandle> textures = [];
-    private readonly List<CPUTextureHandle> cpuTextures = [];
+    /// <summary>
+    /// Whether this specific material should use on-demand textures. Defaults
+    /// to the global config but can be overridden if needed.
+    /// </summary>
+    [ParserTarget("onDemand")]
+    public override NumericParser<bool> OnDemand { get; set; } = OnDemandStorage.UseOnDemand;
 
-    public static TextureHandleStorage Instance
+    public override void PostApply(ConfigNode node)
     {
-        get
-        {
-            if (!_instance.IsNullOrDestroyed())
-                return _instance;
+        base.PostApply(node);
 
-            return _instance = Utility.Deactivator.gameObject.AddComponent<TextureHandleStorage>();
-        }
-    }
-
-    public void Store(TextureHandle handle)
-    {
-        textures.Add(handle);
-    }
-
-    public void Store(CPUTextureHandle handle)
-    {
-        cpuTextures.Add(handle);
+        foreach (var keyword in node.GetValues("keyword"))
+            SetKeyword(keyword, true);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialMultiKeywordParser.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialMultiKeywordParser.cs
@@ -23,42 +23,29 @@
  * https://kerbalspaceprogram.com
  */
 
-using System.Collections.Generic;
-using KSPTextureLoader;
-using UnityEngine;
+using Kopernicus.ConfigParser.Attributes;
+using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.ConfigParser.Interfaces;
 
-namespace Kopernicus.OnDemand;
+namespace Kopernicus.Configuration.MaterialLoader.Parsing;
 
 /// <summary>
-/// A component attached to the __deactivator GameObject that keeps texture handles
-/// alive without resorting to GCHandle leaks. Handles stored here are retained for
-/// the lifetime of the game so that KSPTextureLoader's internal cache stays valid.
+/// A value-holding parser for shader multi-keyword properties (one of N
+/// allowed string keywords). Validation against the allowed set lives on
+/// <see cref="BaseMaterialLoader.SetMultiKeyword"/> so the property setter
+/// only has to forward.
 /// </summary>
-internal class TextureHandleStorage : MonoBehaviour
+[RequireConfigType(ConfigType.Value)]
+public class MaterialMultiKeywordParser : IParsable
 {
-    private static TextureHandleStorage _instance;
+    public string Keyword { get; set; }
 
-    private readonly List<TextureHandle> textures = [];
-    private readonly List<CPUTextureHandle> cpuTextures = [];
+    public void SetFromString(string s) => Keyword = s;
+    public string ValueToString() => Keyword;
 
-    public static TextureHandleStorage Instance
-    {
-        get
-        {
-            if (!_instance.IsNullOrDestroyed())
-                return _instance;
+    public MaterialMultiKeywordParser() { }
+    public MaterialMultiKeywordParser(string keyword) => Keyword = keyword;
 
-            return _instance = Utility.Deactivator.gameObject.AddComponent<TextureHandleStorage>();
-        }
-    }
-
-    public void Store(TextureHandle handle)
-    {
-        textures.Add(handle);
-    }
-
-    public void Store(CPUTextureHandle handle)
-    {
-        cpuTextures.Add(handle);
-    }
+    public static implicit operator string(MaterialMultiKeywordParser parser) => parser?.Keyword;
+    public static implicit operator MaterialMultiKeywordParser(string keyword) => new(keyword);
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialTextureParser.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialTextureParser.cs
@@ -23,42 +23,29 @@
  * https://kerbalspaceprogram.com
  */
 
-using System.Collections.Generic;
-using KSPTextureLoader;
-using UnityEngine;
+using Kopernicus.ConfigParser.Attributes;
+using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.ConfigParser.Interfaces;
 
-namespace Kopernicus.OnDemand;
+namespace Kopernicus.Configuration.MaterialLoader.Parsing;
 
 /// <summary>
-/// A component attached to the __deactivator GameObject that keeps texture handles
-/// alive without resorting to GCHandle leaks. Handles stored here are retained for
-/// the lifetime of the game so that KSPTextureLoader's internal cache stays valid.
+/// A value-holding parser for shader texture properties. The parsed string
+/// path is preserved so <see cref="BaseMaterialLoader.SetTexture(string, MaterialTextureParser)"/>
+/// can route through the on-demand pipeline, BUILTIN/ lookups, or
+/// synchronous loading as needed.
 /// </summary>
-internal class TextureHandleStorage : MonoBehaviour
+[RequireConfigType(ConfigType.Value)]
+public class MaterialTextureParser : IParsable
 {
-    private static TextureHandleStorage _instance;
+    public string Path { get; set; }
 
-    private readonly List<TextureHandle> textures = [];
-    private readonly List<CPUTextureHandle> cpuTextures = [];
+    public void SetFromString(string s) => Path = s;
+    public string ValueToString() => Path;
 
-    public static TextureHandleStorage Instance
-    {
-        get
-        {
-            if (!_instance.IsNullOrDestroyed())
-                return _instance;
+    public MaterialTextureParser() { }
+    public MaterialTextureParser(string path) => Path = path;
 
-            return _instance = Utility.Deactivator.gameObject.AddComponent<TextureHandleStorage>();
-        }
-    }
-
-    public void Store(TextureHandle handle)
-    {
-        textures.Add(handle);
-    }
-
-    public void Store(CPUTextureHandle handle)
-    {
-        cpuTextures.Add(handle);
-    }
+    public static implicit operator string(MaterialTextureParser parser) => parser?.Path;
+    public static implicit operator MaterialTextureParser(string path) => new(path);
 }

--- a/src/Kopernicus/Configuration/Parsing/ShaderParser.cs
+++ b/src/Kopernicus/Configuration/Parsing/ShaderParser.cs
@@ -23,42 +23,34 @@
  * https://kerbalspaceprogram.com
  */
 
-using System.Collections.Generic;
-using KSPTextureLoader;
+using System;
+using Kopernicus.Components;
+using Kopernicus.ConfigParser.Attributes;
+using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.ConfigParser.Interfaces;
 using UnityEngine;
 
-namespace Kopernicus.OnDemand;
+namespace Kopernicus.Configuration.Parsing;
 
 /// <summary>
-/// A component attached to the __deactivator GameObject that keeps texture handles
-/// alive without resorting to GCHandle leaks. Handles stored here are retained for
-/// the lifetime of the game so that KSPTextureLoader's internal cache stays valid.
+/// Parser for a <see cref="Shader"/>.
 /// </summary>
-internal class TextureHandleStorage : MonoBehaviour
+[RequireConfigType(ConfigType.Value)]
+public class ShaderParser : IParsable, ITypeParser<Shader>
 {
-    private static TextureHandleStorage _instance;
+    public Shader Value { get; set; }
 
-    private readonly List<TextureHandle> textures = [];
-    private readonly List<CPUTextureHandle> cpuTextures = [];
-
-    public static TextureHandleStorage Instance
+    public void SetFromString(string s)
     {
-        get
-        {
-            if (!_instance.IsNullOrDestroyed())
-                return _instance;
+        var shader = Shader.Find(s);
+        if (shader == null)
+            throw new Exception($"Unable to find shader `{s}`");
 
-            return _instance = Utility.Deactivator.gameObject.AddComponent<TextureHandleStorage>();
-        }
+        Value = shader;
     }
 
-    public void Store(TextureHandle handle)
-    {
-        textures.Add(handle);
-    }
+    public string ValueToString() => Value?.name;
 
-    public void Store(CPUTextureHandle handle)
-    {
-        cpuTextures.Add(handle);
-    }
+    public static implicit operator Shader(ShaderParser parser) => parser.Value;
+    public static implicit operator ShaderParser(Shader shader) => new() { Value = shader };
 }

--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -13,7 +13,7 @@
 
     <!-- Other configuration -->
     <TargetFramework>net4.8</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/Kopernicus/Logger.cs
+++ b/src/Kopernicus/Logger.cs
@@ -97,6 +97,21 @@ namespace Kopernicus
         }
 
         // Write text to the log
+        public void LogWarning(Object o)
+        {
+            if (_loggerStream == null)
+            {
+                return;
+            }
+
+            _loggerStream.WriteLine("[WRN " + DateTime.Now.ToString("HH:mm:ss") + "]: " + o);
+            if (_autoFlush)
+            {
+                _loggerStream.Flush();
+            }
+        }
+
+        // Write text to the log
         public void LogException(Exception e)
         {
             if (_loggerStream == null)

--- a/src/Kopernicus/OnDemand/TextureEntry.cs
+++ b/src/Kopernicus/OnDemand/TextureEntry.cs
@@ -23,42 +23,25 @@
  * https://kerbalspaceprogram.com
  */
 
-using System.Collections.Generic;
-using KSPTextureLoader;
 using UnityEngine;
 
 namespace Kopernicus.OnDemand;
 
-/// <summary>
-/// A component attached to the __deactivator GameObject that keeps texture handles
-/// alive without resorting to GCHandle leaks. Handles stored here are retained for
-/// the lifetime of the game so that KSPTextureLoader's internal cache stays valid.
-/// </summary>
-internal class TextureHandleStorage : MonoBehaviour
+public struct OnDemandTextureEntry(string key, string path)
 {
-    private static TextureHandleStorage _instance;
+    /// <summary>
+    /// The name of the texture key on the shader itself. Will be something like
+    /// <c>_MainTex</c>.
+    /// </summary>
+    public string Key { get; } = key;
 
-    private readonly List<TextureHandle> textures = [];
-    private readonly List<CPUTextureHandle> cpuTextures = [];
+    /// <summary>
+    /// The property ID for <see cref="Key" />.
+    /// </summary>
+    public int Id { get; } = Shader.PropertyToID(key);
 
-    public static TextureHandleStorage Instance
-    {
-        get
-        {
-            if (!_instance.IsNullOrDestroyed())
-                return _instance;
-
-            return _instance = Utility.Deactivator.gameObject.AddComponent<TextureHandleStorage>();
-        }
-    }
-
-    public void Store(TextureHandle handle)
-    {
-        textures.Add(handle);
-    }
-
-    public void Store(CPUTextureHandle handle)
-    {
-        cpuTextures.Add(handle);
-    }
+    /// <summary>
+    /// The path at which this texture can be found.
+    /// </summary>
+    public string Path { get; } = path;
 }


### PR DESCRIPTION
I'm planning to do a broader overhaul of how Kopernicus loads shaders to allow more comprehensive on-demand loading and also to support custom shaders pretty much everywhere. This PR is the first bit and adds some of the groundwork.

Here's the changes:
* Add a new `BaseMaterialLoader` that explicitly parses property names (i.e. `_<name>`) with the appropriate parser by introspecting the shader itself. It automatically loads textures as on-demand if that is enabled.
* Add `CustomMaterialLoader`, which is `BaseMaterialLoader` + some other helpers for setting keywords
* Add a bunch of parsers that can be used by inherited types to provide nice names for texture properties. These will be used in follow-up PRs.
* Convert OnDemand to support arbitrary textures, not just 2d ones. This is not used yet.
* Add a new `Logger.LogWarning` method for stuff that should be warnings, but aren't errors.
* Bump `LangVersion` to 14 for some qol features.

None of this is really used yet, my next PR will migrate everything over to use the new material loaders.