### PR TITLE
LogAggregatorWorker: don't aggregate logs on every part destruction

### DIFF
--- a/src/Kopernicus/RuntimeUtility/LogAggregator.cs
+++ b/src/Kopernicus/RuntimeUtility/LogAggregator.cs
@@ -105,7 +105,6 @@ namespace Kopernicus.RuntimeUtility
 
             // Keep this behaviour alive
             DontDestroyOnLoad(this);
-            GameEvents.onCrash.Add(AggregateLogs);
         }
 
         private void OnApplicationQuit()


### PR DESCRIPTION
Hi,

I was profiling KSP with dotTrace and found a main-thread freeze that happens the first time any part is destroyed in flight. Tracked it down here.

In LogAggregatorWorker.Awake() there is:

GameEvents.onCrash.Add(AggregateLogs);

But in KSP onCrash is fired by Part.HandleCollision on every Part destruction, not on application crash. So every time a part breaks, AggregateLogs runs synchronously on the main thread - it deletes Logs/Logs-<mod>.zip, recreates it, copies every tracked file and re-streams them through DEFLATE (MonoPosixHelper). On a heavy modpack it takes around 600ms.

After the first call _files.Clear() runs, so only the very first part destruction stalls. That matches what I saw while debugging my BlastFX - game freezes once when something breaks for the first time, then it's fine.

dotTrace stack is attached below.

Fix is one line - drop the subscription. OnApplicationQuit() already calls AggregateLogs(null) at shutdown, which is the only place where building the archive really makes sense. Unity doesn't give us a real "app crashed" event we can hook from C# anyway, so the original onCrash line was probably added thinking onCrash means app crash, but in KSP it just means part broke.

Tested locally with a Harmony prefix doing the same thing (skip AggregateLogs when report is not null). Freeze is gone, quit-time archive still works.

Thanks!

<img width="1239" height="707" alt="изображение" src="https://github.com/user-attachments/assets/3da6dd27-cfc0-4217-b485-c92d690eb4d2" />