### PR TITLE
Migrate existing shaders and call sites to the new material loader

### DIFF
--- a/src/Kopernicus/Components/MaterialWrapper/AerialTransCutout.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/AerialTransCutout.cs
@@ -74,16 +74,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.AerialTransCutoutLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/AlphaTestDiffuse.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/AlphaTestDiffuse.cs
@@ -54,16 +54,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.AlphaTestDiffuseLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/DiffuseWrap.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/DiffuseWrap.cs
@@ -57,16 +57,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.DiffuseWrapLoader.UsesSameShader(m);
 
         // Texture, default = "white" { }
         public Texture2D MainTex

--- a/src/Kopernicus/Components/MaterialWrapper/EmissiveMultiRampSunspots.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/EmissiveMultiRampSunspots.cs
@@ -89,16 +89,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.EmissiveMultiRampSunspotsLoader.UsesSameShader(m);
 
         // Ramp Map (RGBA), default = "white" { }
         public Texture2D RampMap

--- a/src/Kopernicus/Components/MaterialWrapper/KSPBumped.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/KSPBumped.cs
@@ -84,16 +84,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.KSPBumpedLoader.UsesSameShader(m);
 
         // Base (RGB), default = "white" { }
         public Texture2D MainTex

--- a/src/Kopernicus/Components/MaterialWrapper/KSPBumpedSpecular.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/KSPBumpedSpecular.cs
@@ -94,16 +94,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.KSPBumpedSpecularLoader.UsesSameShader(m);
 
         // Base (RGB), default = "white" { }
         public Texture2D MainTex

--- a/src/Kopernicus/Components/MaterialWrapper/NormalBumped.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/NormalBumped.cs
@@ -54,16 +54,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.NormalBumpedLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/NormalDiffuse.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/NormalDiffuse.cs
@@ -53,16 +53,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return ((m.shader.name == Properties.Shader.name) && (!(m.shader.name.Contains("Wrap"))));
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.NormalDiffuseLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/NormalDiffuseDetail.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/NormalDiffuseDetail.cs
@@ -54,16 +54,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.NormalDiffuseDetailLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/PQSMainExtras.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSMainExtras.cs
@@ -240,15 +240,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSMainExtrasLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSMainFastBlend.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSMainFastBlend.cs
@@ -235,15 +235,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSMainFastBlendLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSMainOptimised.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSMainOptimised.cs
@@ -205,15 +205,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSMainOptimisedLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSMainOptimisedFastBlend.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSMainOptimisedFastBlend.cs
@@ -205,15 +205,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSMainOptimisedFastBlendLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSMainShader.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSMainShader.cs
@@ -235,15 +235,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSMainShaderLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSOceanSurfaceQuad.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSOceanSurfaceQuad.cs
@@ -175,17 +175,9 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
+        // Is some random material this material
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSOceanSurfaceQuadLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/PQSOceanSurfaceQuadFallback.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSOceanSurfaceQuadFallback.cs
@@ -96,16 +96,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSOceanSurfaceQuadFallbackLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/PQSProjectionAerialQuadRelative.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSProjectionAerialQuadRelative.cs
@@ -255,16 +255,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSProjectionAerialQuadRelativeLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSProjectionFallback.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSProjectionFallback.cs
@@ -95,17 +95,9 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
+        // Is some random material this material
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSProjectionFallbackLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSProjectionSurfaceQuad.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSProjectionSurfaceQuad.cs
@@ -230,16 +230,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSProjectionSurfaceQuadLoader.UsesSameShader(m);
 
         // Saturation, default = 1
         public Single Saturation

--- a/src/Kopernicus/Components/MaterialWrapper/PQSTriplanarZoomRotation.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSTriplanarZoomRotation.cs
@@ -195,15 +195,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSTriplanarZoomRotationLoader.UsesSameShader(m);
 
         // Factor, default = 10
         public Single Factor

--- a/src/Kopernicus/Components/MaterialWrapper/PQSTriplanarZoomRotationTextureArray.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/PQSTriplanarZoomRotationTextureArray.cs
@@ -160,19 +160,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            // Avoid allocating a name string if we don't have to.
-            if (m.shader.GetInstanceID() == Properties.Shader.GetInstanceID())
-                return true;
-
-            return m.shader.name == Properties.SHADER_NAME;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.PQSTriplanarZoomRotationTextureArrayLoader.UsesSameShader(m);
 
         // Color Lerp Modifier, default = 1
         public Single ColorLerpModifier
@@ -392,8 +380,10 @@ namespace Kopernicus.Components.MaterialWrapper
 
         public PQSTriplanarZoomRotationTextureArray(Material material) : base(material)
         {
-            // Throw exception if this material was not the proper material
-            if (material.shader.name != Properties.Shader.name)
+            // Throw exception if this material was not the proper material. The texture-atlas
+            // mod swaps in "- 1/2/3/4 Blend" permutations at runtime; those share the property
+            // layout and are accepted here too.
+            if (!Configuration.MaterialLoader.PQSTriplanarZoomRotationTextureArrayLoader.UsesSameShader(material))
                 throw new InvalidOperationException(
                     "Type Mismatch: Terrain/PQS/PQS Triplanar Zoom Rotation Texture Array shader required");
         }

--- a/src/Kopernicus/Components/MaterialWrapper/ParticleAddSmooth.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/ParticleAddSmooth.cs
@@ -49,17 +49,9 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
+        // Is some random material this material
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.ParticleAddSmoothLoader.UsesSameShader(m);
 
         // Particle Texture, default = "white" { }
         public Texture2D MainTex

--- a/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetRimAerial.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetRimAerial.cs
@@ -94,16 +94,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.ScaledPlanetRimAerialLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetRimAerialStandard.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetRimAerialStandard.cs
@@ -93,16 +93,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.ScaledPlanetRimAerialStandardLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetRimLight.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetRimLight.cs
@@ -84,15 +84,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.ScaledPlanetRimLightLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetSimple.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/ScaledPlanetSimple.cs
@@ -74,16 +74,8 @@ namespace Kopernicus.Components.MaterialWrapper
             }
         }
 
-        // Is some random material this material 
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        // Is some random material this material
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.ScaledPlanetSimpleLoader.UsesSameShader(m);
 
         // Main Color, default = (1,1,1,1)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/Standard.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/Standard.cs
@@ -193,15 +193,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.StandardLoader.UsesSameShader(m);
 
         // Color, default = (1.000000,1.000000,1.000000,1.000000)
         public Color Color

--- a/src/Kopernicus/Components/MaterialWrapper/StandardSpecular.cs
+++ b/src/Kopernicus/Components/MaterialWrapper/StandardSpecular.cs
@@ -193,15 +193,7 @@ namespace Kopernicus.Components.MaterialWrapper
         }
 
         // Is some random material this material
-        public static Boolean UsesSameShader(Material m)
-        {
-            if (m == null)
-            {
-                return false;
-            }
-
-            return m.shader.name == Properties.Shader.name;
-        }
+        public static Boolean UsesSameShader(Material m) => Configuration.MaterialLoader.StandardSpecularLoader.UsesSameShader(m);
 
         // Color, default = (1.000000,1.000000,1.000000,1.000000)
         public Color Color

--- a/src/Kopernicus/Configuration/CoronaLoader.cs
+++ b/src/Kopernicus/Configuration/CoronaLoader.cs
@@ -87,12 +87,14 @@ namespace Kopernicus.Configuration
             set { Value.Rotation = value; }
         }
 
+        private ParticleAddSmoothLoader _material;
+
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         public ParticleAddSmoothLoader Material
         {
-            get { return (ParticleAddSmoothLoader)Value.GetComponent<Renderer>().sharedMaterial; }
-            set { Value.GetComponent<Renderer>().sharedMaterial = value; }
+            get { return _material ??= new ParticleAddSmoothLoader(Value.GetComponent<Renderer>().sharedMaterial); }
+            set { _material = value; }
         }
 
         [KittopiaDestructor]
@@ -110,6 +112,9 @@ namespace Kopernicus.Configuration
         // Parser post apply event
         void IParserEventSubscriber.PostApply(ConfigNode node)
         {
+            if (_material != null)
+                Value.GetComponent<Renderer>().sharedMaterial = _material.Value;
+
             Events.OnCoronaLoaderPostApply.Fire(this, node);
         }
 
@@ -149,10 +154,9 @@ namespace Kopernicus.Configuration
             Value = corona.GetComponent<SunCoronas>();
 
             // Setup the material loader
-            Material = new ParticleAddSmoothLoader(corona.GetComponent<Renderer>().sharedMaterial)
-            {
-                name = Guid.NewGuid().ToString()
-            };
+            Material = new ParticleAddSmoothLoader(corona.GetComponent<Renderer>().sharedMaterial);
+            Material.Value.name = Guid.NewGuid().ToString();
+            corona.GetComponent<Renderer>().sharedMaterial = Material.Value;
         }
 
         /// <summary>
@@ -192,10 +196,9 @@ namespace Kopernicus.Configuration
             Value = corona.GetComponent<SunCoronas>();
 
             // Setup the material loader
-            Material = new ParticleAddSmoothLoader(corona.GetComponent<Renderer>().sharedMaterial)
-            {
-                name = Guid.NewGuid().ToString()
-            };
+            Material = new ParticleAddSmoothLoader(corona.GetComponent<Renderer>().sharedMaterial);
+            Material.Value.name = Guid.NewGuid().ToString();
+            corona.GetComponent<Renderer>().sharedMaterial = Material.Value;
         }
 
         /// <summary>
@@ -204,10 +207,7 @@ namespace Kopernicus.Configuration
         public CoronaLoader(SunCoronas component)
         {
             Value = component;
-            if (!(Value.GetComponent<Renderer>().sharedMaterial is ParticleAddSmoothLoader))
-            {
-                Material = new ParticleAddSmoothLoader(Value.GetComponent<Renderer>().sharedMaterial);
-            }
+            Material = new ParticleAddSmoothLoader(Value.GetComponent<Renderer>().sharedMaterial);
         }
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
@@ -24,102 +24,97 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class AerialTransCutoutLoader : AerialTransCutout
+    public class AerialTransCutoutLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/Aerial Cutout";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Base (RGB) Trans (A), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Alpha cutoff, default = 0.5
         [ParserTarget("texCutoff")]
-        public NumericParser<Single> TexCutoffSetter
+        public NumericParser<float> TexCutoffSetter
         {
-            get { return TexCutoff; }
-            set { TexCutoff = value; }
+            get => GetFloat("_texCutoff");
+            set => SetFloat("_texCutoff", value);
         }
 
         // AP Fog Color, default = (0,0,1,1)
         [ParserTarget("fogColor")]
         public ColorParser FogColorSetter
         {
-            get { return FogColor; }
-            set { FogColor = value; }
+            get => GetColor("_fogColor");
+            set => SetColor("_fogColor", value);
         }
 
         // AP Height Fall Off, default = 1
         [ParserTarget("heightFallOff")]
-        public NumericParser<Single> HeightFallOffSetter
+        public NumericParser<float> HeightFallOffSetter
         {
-            get { return HeightFallOff; }
-            set { HeightFallOff = value; }
+            get => GetFloat("_heightFallOff");
+            set => SetFloat("_heightFallOff", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // AP Atmosphere Depth, default = 1
         [ParserTarget("atmosphereDepth")]
-        public NumericParser<Single> AtmosphereDepthSetter
+        public NumericParser<float> AtmosphereDepthSetter
         {
-            get { return AtmosphereDepth; }
-            set { AtmosphereDepth = value; }
+            get => GetFloat("_atmosphereDepth");
+            set => SetFloat("_atmosphereDepth", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public AerialTransCutoutLoader()
-        {
-        }
+        public AerialTransCutoutLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public AerialTransCutoutLoader(String contents) : base(contents)
-        {
-        }
-
-        public AerialTransCutoutLoader(Material material) : base(material)
-        {
-        }
+        public AerialTransCutoutLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
@@ -24,70 +24,65 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class AlphaTestDiffuseLoader : AlphaTestDiffuse
+    public class AlphaTestDiffuseLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Legacy Shaders/Transparent/Cutout/Diffuse";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Base (RGB) Trans (A), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Alpha cutoff, default = 0.5
         [ParserTarget("cutoff")]
-        public NumericParser<Single> CutoffSetter
+        public NumericParser<float> CutoffSetter
         {
-            get { return Cutoff; }
-            set { Cutoff = value; }
+            get => GetFloat("_Cutoff");
+            set => SetFloat("_Cutoff", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public AlphaTestDiffuseLoader()
-        {
-        }
+        public AlphaTestDiffuseLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public AlphaTestDiffuseLoader(String contents) : base(contents)
-        {
-        }
-
-        public AlphaTestDiffuseLoader(Material material) : base(material)
-        {
-        }
+        public AlphaTestDiffuseLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
@@ -24,70 +24,65 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class DiffuseWrapLoader : DiffuseWrap
+    public class DiffuseWrapLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Diffuse Wrapped";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Diffuse, default = 2
         [ParserTarget("diff")]
-        public NumericParser<Single> DiffSetter
+        public NumericParser<float> DiffSetter
         {
-            get { return Diff; }
-            set { Diff = value; }
+            get => GetFloat("_Diff");
+            set => SetFloat("_Diff", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public DiffuseWrapLoader()
-        {
-        }
+        public DiffuseWrapLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public DiffuseWrapLoader(String contents) : base(contents)
-        {
-        }
-
-        public DiffuseWrapLoader(Material material) : base(material)
-        {
-        }
+        public DiffuseWrapLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
@@ -24,154 +24,149 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class EmissiveMultiRampSunspotsLoader : EmissiveMultiRampSunspots
+    public class EmissiveMultiRampSunspotsLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Emissive Multi Ramp Sunspots";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Ramp Map (RGBA), default = "white" { }
         [ParserTarget("rampMap")]
-        public Texture2DParser RampMapSetter
+        public MaterialTextureParser RampMapSetter
         {
-            get { return RampMap; }
-            set { RampMap = value; }
+            get => null;
+            set => SetTexture("_RampMap", value);
         }
 
         [ParserTarget("rampMapScale")]
         public Vector2Parser RampMapScaleSetter
         {
-            get { return RampMapScale; }
-            set { RampMapScale = value; }
+            get => GetTextureScale("_RampMap");
+            set => SetTextureScale("_RampMap", value);
         }
 
         [ParserTarget("rampMapOffset")]
         public Vector2Parser RampMapOffsetSetter
         {
-            get { return RampMapOffset; }
-            set { RampMapOffset = value; }
+            get => GetTextureOffset("_RampMap");
+            set => SetTextureOffset("_RampMap", value);
         }
 
         // Noise Map (RGBA), default = "white" { }
         [ParserTarget("noiseMap")]
-        public Texture2DParser NoiseMapSetter
+        public MaterialTextureParser NoiseMapSetter
         {
-            get { return NoiseMap; }
-            set { NoiseMap = value; }
+            get => null;
+            set => SetTexture("_NoiseMap", value);
         }
 
         [ParserTarget("noiseMapScale")]
         public Vector2Parser NoiseMapScaleSetter
         {
-            get { return NoiseMapScale; }
-            set { NoiseMapScale = value; }
+            get => GetTextureScale("_NoiseMap");
+            set => SetTextureScale("_NoiseMap", value);
         }
 
         [ParserTarget("noiseMapOffset")]
         public Vector2Parser NoiseMapOffsetSetter
         {
-            get { return NoiseMapOffset; }
-            set { NoiseMapOffset = value; }
+            get => GetTextureOffset("_NoiseMap");
+            set => SetTextureOffset("_NoiseMap", value);
         }
 
         // Emission Color 0, default = (1,1,1,1)
         [ParserTarget("emitColor0")]
         public ColorParser EmitColor0Setter
         {
-            get { return EmitColor0; }
-            set { EmitColor0 = value; }
+            get => GetColor("_EmitColor0");
+            set => SetColor("_EmitColor0", value);
         }
 
         // Emission Color 1, default = (1,1,1,1)
         [ParserTarget("emitColor1")]
         public ColorParser EmitColor1Setter
         {
-            get { return EmitColor1; }
-            set { EmitColor1 = value; }
+            get => GetColor("_EmitColor1");
+            set => SetColor("_EmitColor1", value);
         }
 
         // Sunspot Map (R), default = "white" { }
         [ParserTarget("sunspotTex")]
-        public Texture2DParser SunspotTexSetter
+        public MaterialTextureParser SunspotTexSetter
         {
-            get { return SunspotTex; }
-            set { SunspotTex = value; }
+            get => null;
+            set => SetTexture("_SunspotTex", value);
         }
 
         [ParserTarget("sunspotTexScale")]
         public Vector2Parser SunspotTexScaleSetter
         {
-            get { return SunspotTexScale; }
-            set { SunspotTexScale = value; }
+            get => GetTextureScale("_SunspotTex");
+            set => SetTextureScale("_SunspotTex", value);
         }
 
         [ParserTarget("sunspotTexOffset")]
         public Vector2Parser SunspotTexOffsetSetter
         {
-            get { return SunspotTexOffset; }
-            set { SunspotTexOffset = value; }
+            get => GetTextureOffset("_SunspotTex");
+            set => SetTextureOffset("_SunspotTex", value);
         }
 
         // Sunspot Power, default = 1
         [ParserTarget("sunspotPower")]
-        public NumericParser<Single> SunspotPowerSetter
+        public NumericParser<float> SunspotPowerSetter
         {
-            get { return SunspotPower; }
-            set { SunspotPower = value; }
+            get => GetFloat("_SunspotPower");
+            set => SetFloat("_SunspotPower", value);
         }
 
         // Sunspot Color, default = (0,0,0,0)
         [ParserTarget("sunspotColor")]
         public ColorParser SunspotColorSetter
         {
-            get { return SunspotColor; }
-            set { SunspotColor = value; }
+            get => GetColor("_SunspotColor");
+            set => SetColor("_SunspotColor", value);
         }
 
         // Rimlight Color, default = (1,1,1,1)
         [ParserTarget("rimColor")]
         public ColorParser RimColorSetter
         {
-            get { return RimColor; }
-            set { RimColor = value; }
+            get => GetColor("_RimColor");
+            set => SetColor("_RimColor", value);
         }
 
         // Rimlight Power, default = 0.2
         [ParserTarget("rimPower")]
-        public NumericParser<Single> RimPowerSetter
+        public NumericParser<float> RimPowerSetter
         {
-            get { return RimPower; }
-            set { RimPower = value; }
+            get => GetFloat("_RimPower");
+            set => SetFloat("_RimPower", value);
         }
 
         // Rimlight Blend, default = 0.2
         [ParserTarget("rimBlend")]
-        public NumericParser<Single> RimBlendSetter
+        public NumericParser<float> RimBlendSetter
         {
-            get { return RimBlend; }
-            set { RimBlend = value; }
+            get => GetFloat("_RimBlend");
+            set => SetFloat("_RimBlend", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public EmissiveMultiRampSunspotsLoader()
-        {
-        }
+        public EmissiveMultiRampSunspotsLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public EmissiveMultiRampSunspotsLoader(String contents) : base(contents)
-        {
-        }
-
-        public EmissiveMultiRampSunspotsLoader(Material material) : base(material)
-        {
-        }
+        public EmissiveMultiRampSunspotsLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
@@ -24,133 +24,127 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class KSPBumpedLoader : KSPBumped
+    public class KSPBumpedLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "KSP/Bumped";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // _Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<Single> OpacitySetter
+        public NumericParser<float> OpacitySetter
         {
-            get { return Opacity; }
-            set { Opacity = value; }
+            get => GetFloat("_Opacity");
+            set => SetFloat("_Opacity", value);
         }
 
         // _RimFalloff, default = 0.1
         [ParserTarget("rimFalloff")]
-        public NumericParser<Single> RimFalloffSetter
+        public NumericParser<float> RimFalloffSetter
         {
-            get { return RimFalloff; }
-            set { RimFalloff = value; }
+            get => GetFloat("_RimFalloff");
+            set => SetFloat("_RimFalloff", value);
         }
 
         // _RimColor, default = (0,0,0,0)
         [ParserTarget("rimColor")]
         public ColorParser RimColorSetter
         {
-            get { return RimColor; }
-            set { RimColor = value; }
+            get => GetColor("_RimColor");
+            set => SetColor("_RimColor", value);
         }
 
         // _TemperatureColor, default = (0,0,0,0)
         [ParserTarget("temperatureColor")]
         public ColorParser TemperatureColorSetter
         {
-            get { return TemperatureColor; }
-            set { TemperatureColor = value; }
+            get => GetColor("_TemperatureColor");
+            set => SetColor("_TemperatureColor", value);
         }
 
         // Burn Color, default = (1,1,1,1)
         [ParserTarget("burnColor")]
         public ColorParser BurnColorSetter
         {
-            get { return BurnColor; }
-            set { BurnColor = value; }
+            get => GetColor("_BurnColor");
+            set => SetColor("_BurnColor", value);
         }
 
         // Underwater Fog Factor, default = 0
         [ParserTarget("underwaterFogFactor")]
-        public NumericParser<Single> UnderwaterFogFactorSetter
+        public NumericParser<float> UnderwaterFogFactorSetter
         {
-            get { return UnderwaterFogFactor; }
-            set { UnderwaterFogFactor = value; }
+            get => GetFloat("_UnderwaterFogFactor");
+            set => SetFloat("_UnderwaterFogFactor", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public KSPBumpedLoader()
-        {
-        }
+        public KSPBumpedLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public KSPBumpedLoader(String contents) : base(contents)
-        {
-        }
-
-        public KSPBumpedLoader(Material material) : base(material)
-        {
-        }
+        public KSPBumpedLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
@@ -24,149 +24,143 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class KSPBumpedSpecularLoader : KSPBumpedSpecular
+    public class KSPBumpedSpecularLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "KSP/Bumped Specular";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // _SpecColor, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
         public ColorParser SpecColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // _Shininess, default = 1
         [ParserTarget("shininess")]
-        public NumericParser<Single> ShininessSetter
+        public NumericParser<float> ShininessSetter
         {
-            get { return Shininess; }
-            set { Shininess = value; }
+            get => GetFloat("_Shininess");
+            set => SetFloat("_Shininess", value);
         }
 
         // _Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<Single> OpacitySetter
+        public NumericParser<float> OpacitySetter
         {
-            get { return Opacity; }
-            set { Opacity = value; }
+            get => GetFloat("_Opacity");
+            set => SetFloat("_Opacity", value);
         }
 
         // _RimFalloff, default = 0.1
         [ParserTarget("rimFalloff")]
-        public NumericParser<Single> RimFalloffSetter
+        public NumericParser<float> RimFalloffSetter
         {
-            get { return RimFalloff; }
-            set { RimFalloff = value; }
+            get => GetFloat("_RimFalloff");
+            set => SetFloat("_RimFalloff", value);
         }
 
         // _RimColor, default = (0,0,0,0)
         [ParserTarget("rimColor")]
         public ColorParser RimColorSetter
         {
-            get { return RimColor; }
-            set { RimColor = value; }
+            get => GetColor("_RimColor");
+            set => SetColor("_RimColor", value);
         }
 
         // _TemperatureColor, default = (0,0,0,0)
         [ParserTarget("temperatureColor")]
         public ColorParser TemperatureColorSetter
         {
-            get { return TemperatureColor; }
-            set { TemperatureColor = value; }
+            get => GetColor("_TemperatureColor");
+            set => SetColor("_TemperatureColor", value);
         }
 
         // Burn Color, default = (1,1,1,1)
         [ParserTarget("burnColor")]
         public ColorParser BurnColorSetter
         {
-            get { return BurnColor; }
-            set { BurnColor = value; }
+            get => GetColor("_BurnColor");
+            set => SetColor("_BurnColor", value);
         }
 
         // Underwater Fog Factor, default = 0
         [ParserTarget("underwaterFogFactor")]
-        public NumericParser<Single> UnderwaterFogFactorSetter
+        public NumericParser<float> UnderwaterFogFactorSetter
         {
-            get { return UnderwaterFogFactor; }
-            set { UnderwaterFogFactor = value; }
+            get => GetFloat("_UnderwaterFogFactor");
+            set => SetFloat("_UnderwaterFogFactor", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public KSPBumpedSpecularLoader()
-        {
-        }
+        public KSPBumpedSpecularLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public KSPBumpedSpecularLoader(String contents) : base(contents)
-        {
-        }
-
-        public KSPBumpedSpecularLoader(Material material) : base(material)
-        {
-        }
+        public KSPBumpedSpecularLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
@@ -24,84 +24,79 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class NormalBumpedLoader : NormalBumped
+    public class NormalBumpedLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Legacy Shaders/Bumped Diffuse";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public NormalBumpedLoader()
-        {
-        }
+        public NormalBumpedLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public NormalBumpedLoader(String contents) : base(contents)
-        {
-        }
-
-        public NormalBumpedLoader(Material material) : base(material)
-        {
-        }
+        public NormalBumpedLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
@@ -24,84 +24,79 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class NormalDiffuseDetailLoader : NormalDiffuseDetail
+    public class NormalDiffuseDetailLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Legacy Shaders/Diffuse Detail";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Detail (RGB), default = "gray" { }
         [ParserTarget("detail")]
-        public Texture2DParser DetailSetter
+        public MaterialTextureParser DetailSetter
         {
-            get { return Detail; }
-            set { Detail = value; }
+            get => null;
+            set => SetTexture("_Detail", value);
         }
 
         [ParserTarget("detailScale")]
         public Vector2Parser DetailScaleSetter
         {
-            get { return DetailScale; }
-            set { DetailScale = value; }
+            get => GetTextureScale("_Detail");
+            set => SetTextureScale("_Detail", value);
         }
 
         [ParserTarget("detailOffset")]
         public Vector2Parser DetailOffsetSetter
         {
-            get { return DetailOffset; }
-            set { DetailOffset = value; }
+            get => GetTextureOffset("_Detail");
+            set => SetTextureOffset("_Detail", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public NormalDiffuseDetailLoader()
-        {
-        }
+        public NormalDiffuseDetailLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public NormalDiffuseDetailLoader(String contents) : base(contents)
-        {
-        }
-
-        public NormalDiffuseDetailLoader(Material material) : base(material)
-        {
-        }
+        public NormalDiffuseDetailLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
@@ -24,62 +24,57 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class NormalDiffuseLoader : NormalDiffuse
+    public class NormalDiffuseLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Legacy Shaders/Diffuse";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public NormalDiffuseLoader()
-        {
-        }
+        public NormalDiffuseLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public NormalDiffuseLoader(String contents) : base(contents)
-        {
-        }
-
-        public NormalDiffuseLoader(Material material) : base(material)
-        {
-        }
+        public NormalDiffuseLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -24,11 +24,10 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
@@ -37,424 +36,426 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSMainExtrasLoader : PQSMainExtras
+    public class PQSMainExtrasLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/PQS Main - Extras";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<Single> PowerNearSetter
+        public NumericParser<float> PowerNearSetter
         {
-            get { return PowerNear; }
-            set { PowerNear = value; }
+            get => GetFloat("_powerNear");
+            set => SetFloat("_powerNear", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<Single> PowerFarSetter
+        public NumericParser<float> PowerFarSetter
         {
-            get { return PowerFar; }
-            set { PowerFar = value; }
+            get => GetFloat("_powerFar");
+            set => SetFloat("_powerFar", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Steep Texture, default = "white" {}
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Steep Bump Map, default = "bump" {}
         [ParserTarget("steepBumpMap")]
-        public Texture2DParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMapSetter
         {
-            get { return SteepBumpMap; }
-            set { SteepBumpMap = value; }
+            get => null;
+            set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
         public Vector2Parser SteepBumpMapScaleSetter
         {
-            get { return SteepBumpMapScale; }
-            set { SteepBumpMapScale = value; }
+            get => GetTextureScale("_steepBumpMap");
+            set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
         public Vector2Parser SteepBumpMapOffsetSetter
         {
-            get { return SteepBumpMapOffset; }
-            set { SteepBumpMapOffset = value; }
+            get => GetTextureOffset("_steepBumpMap");
+            set => SetTextureOffset("_steepBumpMap", value);
         }
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<Single> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTilingSetter
         {
-            get { return SteepNearTiling; }
-            set { SteepNearTiling = value; }
+            get => GetFloat("_steepNearTiling");
+            set => SetFloat("_steepNearTiling", value);
         }
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Low Texture, default = "white" {}
         [ParserTarget("lowTex")]
-        public Texture2DParser LowTexSetter
+        public MaterialTextureParser LowTexSetter
         {
-            get { return LowTex; }
-            set { LowTex = value; }
+            get => null;
+            set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
         public Vector2Parser LowTexScaleSetter
         {
-            get { return LowTexScale; }
-            set { LowTexScale = value; }
+            get => GetTextureScale("_lowTex");
+            set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
         public Vector2Parser LowTexOffsetSetter
         {
-            get { return LowTexOffset; }
-            set { LowTexOffset = value; }
+            get => GetTextureOffset("_lowTex");
+            set => SetTextureOffset("_lowTex", value);
         }
 
         // Low Bump Map, default = "bump" {}
         [ParserTarget("lowBumpMap")]
-        public Texture2DParser LowBumpMapSetter
+        public MaterialTextureParser LowBumpMapSetter
         {
-            get { return LowBumpMap; }
-            set { LowBumpMap = value; }
+            get => null;
+            set => SetTexture("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapScale")]
         public Vector2Parser LowBumpMapScaleSetter
         {
-            get { return LowBumpMapScale; }
-            set { LowBumpMapScale = value; }
+            get => GetTextureScale("_lowBumpMap");
+            set => SetTextureScale("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapOffset")]
         public Vector2Parser LowBumpMapOffsetSetter
         {
-            get { return LowBumpMapOffset; }
-            set { LowBumpMapOffset = value; }
+            get => GetTextureOffset("_lowBumpMap");
+            set => SetTextureOffset("_lowBumpMap", value);
         }
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<Single> LowNearTilingSetter
+        public NumericParser<float> LowNearTilingSetter
         {
-            get { return LowNearTiling; }
-            set { LowNearTiling = value; }
+            get => GetFloat("_lowNearTiling");
+            set => SetFloat("_lowNearTiling", value);
         }
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<Single> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactorSetter
         {
-            get { return LowMultiFactor; }
-            set { LowMultiFactor = value; }
+            get => GetFloat("_lowMultiFactor");
+            set => SetFloat("_lowMultiFactor", value);
         }
 
         // Low Bump Near Tiling, default = 1
         [ParserTarget("lowBumpNearTiling")]
-        public NumericParser<Single> LowBumpNearTilingSetter
+        public NumericParser<float> LowBumpNearTilingSetter
         {
-            get { return LowBumpNearTiling; }
-            set { LowBumpNearTiling = value; }
+            get => GetFloat("_lowBumpNearTiling");
+            set => SetFloat("_lowBumpNearTiling", value);
         }
 
         // Low Bump Far Tiling, default = 1
         [ParserTarget("lowBumpFarTiling")]
-        public NumericParser<Single> LowBumpFarTilingSetter
+        public NumericParser<float> LowBumpFarTilingSetter
         {
-            get { return LowBumpFarTiling; }
-            set { LowBumpFarTiling = value; }
+            get => GetFloat("_lowBumpFarTiling");
+            set => SetFloat("_lowBumpFarTiling", value);
         }
 
         // Mid Texture, default = "white" {}
         [ParserTarget("midTex")]
-        public Texture2DParser MidTexSetter
+        public MaterialTextureParser MidTexSetter
         {
-            get { return MidTex; }
-            set { MidTex = value; }
+            get => null;
+            set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
         public Vector2Parser MidTexScaleSetter
         {
-            get { return MidTexScale; }
-            set { MidTexScale = value; }
+            get => GetTextureScale("_midTex");
+            set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
         public Vector2Parser MidTexOffsetSetter
         {
-            get { return MidTexOffset; }
-            set { MidTexOffset = value; }
+            get => GetTextureOffset("_midTex");
+            set => SetTextureOffset("_midTex", value);
         }
 
         // Mid Bump Map, default = "bump" {}
         [ParserTarget("midBumpMap")]
-        public Texture2DParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMapSetter
         {
-            get { return MidBumpMap; }
-            set { MidBumpMap = value; }
+            get => null;
+            set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
         public Vector2Parser MidBumpMapScaleSetter
         {
-            get { return MidBumpMapScale; }
-            set { MidBumpMapScale = value; }
+            get => GetTextureScale("_midBumpMap");
+            set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
         public Vector2Parser MidBumpMapOffsetSetter
         {
-            get { return MidBumpMapOffset; }
-            set { MidBumpMapOffset = value; }
+            get => GetTextureOffset("_midBumpMap");
+            set => SetTextureOffset("_midBumpMap", value);
         }
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<Single> MidNearTilingSetter
+        public NumericParser<float> MidNearTilingSetter
         {
-            get { return MidNearTiling; }
-            set { MidNearTiling = value; }
+            get => GetFloat("_midNearTiling");
+            set => SetFloat("_midNearTiling", value);
         }
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<Single> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactorSetter
         {
-            get { return MidMultiFactor; }
-            set { MidMultiFactor = value; }
+            get => GetFloat("_midMultiFactor");
+            set => SetFloat("_midMultiFactor", value);
         }
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<Single> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTilingSetter
         {
-            get { return MidBumpNearTiling; }
-            set { MidBumpNearTiling = value; }
+            get => GetFloat("_midBumpNearTiling");
+            set => SetFloat("_midBumpNearTiling", value);
         }
 
         // Mid Bump Far Tiling, default = 1
         [ParserTarget("midBumpFarTiling")]
-        public NumericParser<Single> MidBumpFarTilingSetter
+        public NumericParser<float> MidBumpFarTilingSetter
         {
-            get { return MidBumpFarTiling; }
-            set { MidBumpFarTiling = value; }
+            get => GetFloat("_midBumpFarTiling");
+            set => SetFloat("_midBumpFarTiling", value);
         }
 
         // High Texture, default = "white" {}
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High Bump Map, default = "bump" {}
         [ParserTarget("highBumpMap")]
-        public Texture2DParser HighBumpMapSetter
+        public MaterialTextureParser HighBumpMapSetter
         {
-            get { return HighBumpMap; }
-            set { HighBumpMap = value; }
+            get => null;
+            set => SetTexture("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapScale")]
         public Vector2Parser HighBumpMapScaleSetter
         {
-            get { return HighBumpMapScale; }
-            set { HighBumpMapScale = value; }
+            get => GetTextureScale("_highBumpMap");
+            set => SetTextureScale("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapOffset")]
         public Vector2Parser HighBumpMapOffsetSetter
         {
-            get { return HighBumpMapOffset; }
-            set { HighBumpMapOffset = value; }
+            get => GetTextureOffset("_highBumpMap");
+            set => SetTextureOffset("_highBumpMap", value);
         }
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<Single> HighNearTilingSetter
+        public NumericParser<float> HighNearTilingSetter
         {
-            get { return HighNearTiling; }
-            set { HighNearTiling = value; }
+            get => GetFloat("_highNearTiling");
+            set => SetFloat("_highNearTiling", value);
         }
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<Single> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactorSetter
         {
-            get { return HighMultiFactor; }
-            set { HighMultiFactor = value; }
+            get => GetFloat("_highMultiFactor");
+            set => SetFloat("_highMultiFactor", value);
         }
 
         // High Bump Near Tiling, default = 1
         [ParserTarget("highBumpNearTiling")]
-        public NumericParser<Single> HighBumpNearTilingSetter
+        public NumericParser<float> HighBumpNearTilingSetter
         {
-            get { return HighBumpNearTiling; }
-            set { HighBumpNearTiling = value; }
+            get => GetFloat("_highBumpNearTiling");
+            set => SetFloat("_highBumpNearTiling", value);
         }
 
         // High Bump Far Tiling, default = 1
         [ParserTarget("highBumpFarTiling")]
-        public NumericParser<Single> HighBumpFarTilingSetter
+        public NumericParser<float> HighBumpFarTilingSetter
         {
-            get { return HighBumpFarTiling; }
-            set { HighBumpFarTiling = value; }
+            get => GetFloat("_highBumpFarTiling");
+            set => SetFloat("_highBumpFarTiling", value);
         }
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<Single> LowStartSetter
+        public NumericParser<float> LowStartSetter
         {
-            get { return LowStart; }
-            set { LowStart = value; }
+            get => GetFloat("_lowStart");
+            set => SetFloat("_lowStart", value);
         }
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<Single> LowEndSetter
+        public NumericParser<float> LowEndSetter
         {
-            get { return LowEnd; }
-            set { LowEnd = value; }
+            get => GetFloat("_lowEnd");
+            set => SetFloat("_lowEnd", value);
         }
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<Single> HighStartSetter
+        public NumericParser<float> HighStartSetter
         {
-            get { return HighStart; }
-            set { HighStart = value; }
+            get => GetFloat("_highStart");
+            set => SetFloat("_highStart", value);
         }
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<Single> HighEndSetter
+        public NumericParser<float> HighEndSetter
         {
-            get { return HighEnd; }
-            set { HighEnd = value; }
+            get => GetFloat("_highEnd");
+            set => SetFloat("_highEnd", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // FogColorRamp, default = "white" {}
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
@@ -462,68 +463,44 @@ namespace Kopernicus.Configuration.MaterialLoader
         [KittopiaHideOption]
         public Gradient FogColorRampGradientSetter
         {
-            set
-            {
-                // Generate the ramp from a gradient
-                Texture2D ramp = new Texture2D(512, 1);
-                Color32[] colors = ramp.GetPixels32(0);
-                for (Int32 i = 0; i < colors.Length; i++)
-                {
-                    // Compute the position in the gradient
-                    Single k = (Single)i / colors.Length;
-                    colors[i] = value.ColorAt(k);
-                }
-
-                ramp.SetPixels32(colors, 0);
-                ramp.Apply(true, false);
-
-                // Set the color ramp
-                FogColorRamp = ramp;
-            }
+            set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<Single> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistanceSetter
         {
-            get { return OceanFogDistance; }
-            set { OceanFogDistance = value; }
+            get => GetFloat("_oceanFogDistance");
+            set => SetFloat("_oceanFogDistance", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSMainExtrasLoader()
-        {
-        }
+        public PQSMainExtrasLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSMainExtrasLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSMainExtrasLoader(Material material) : base(material)
-        {
-        }
+        public PQSMainExtrasLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
@@ -22,472 +22,467 @@
  *
  * https://kerbalspaceprogram.com
  */
+
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSMainFastBlendLoader : PQSMainFastBlend
+    public class PQSMainFastBlendLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Fast Blend";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<Single> PowerNearSetter
+        public NumericParser<float> PowerNearSetter
         {
-            get { return PowerNear; }
-            set { PowerNear = value; }
+            get => GetFloat("_powerNear");
+            set => SetFloat("_powerNear", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<Single> PowerFarSetter
+        public NumericParser<float> PowerFarSetter
         {
-            get { return PowerFar; }
-            set { PowerFar = value; }
+            get => GetFloat("_powerFar");
+            set => SetFloat("_powerFar", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public Texture2DParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMapSetter
         {
-            get { return SteepBumpMap; }
-            set { SteepBumpMap = value; }
+            get => null;
+            set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
         public Vector2Parser SteepBumpMapScaleSetter
         {
-            get { return SteepBumpMapScale; }
-            set { SteepBumpMapScale = value; }
+            get => GetTextureScale("_steepBumpMap");
+            set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
         public Vector2Parser SteepBumpMapOffsetSetter
         {
-            get { return SteepBumpMapOffset; }
-            set { SteepBumpMapOffset = value; }
+            get => GetTextureOffset("_steepBumpMap");
+            set => SetTextureOffset("_steepBumpMap", value);
         }
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<Single> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTilingSetter
         {
-            get { return SteepNearTiling; }
-            set { SteepNearTiling = value; }
+            get => GetFloat("_steepNearTiling");
+            set => SetFloat("_steepNearTiling", value);
         }
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public Texture2DParser LowTexSetter
+        public MaterialTextureParser LowTexSetter
         {
-            get { return LowTex; }
-            set { LowTex = value; }
+            get => null;
+            set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
         public Vector2Parser LowTexScaleSetter
         {
-            get { return LowTexScale; }
-            set { LowTexScale = value; }
+            get => GetTextureScale("_lowTex");
+            set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
         public Vector2Parser LowTexOffsetSetter
         {
-            get { return LowTexOffset; }
-            set { LowTexOffset = value; }
+            get => GetTextureOffset("_lowTex");
+            set => SetTextureOffset("_lowTex", value);
         }
 
         // Low Bump Map, default = "bump" { }
         [ParserTarget("lowBumpMap")]
-        public Texture2DParser LowBumpMapSetter
+        public MaterialTextureParser LowBumpMapSetter
         {
-            get { return LowBumpMap; }
-            set { LowBumpMap = value; }
+            get => null;
+            set => SetTexture("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapScale")]
         public Vector2Parser LowBumpMapScaleSetter
         {
-            get { return LowBumpMapScale; }
-            set { LowBumpMapScale = value; }
+            get => GetTextureScale("_lowBumpMap");
+            set => SetTextureScale("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapOffset")]
         public Vector2Parser LowBumpMapOffsetSetter
         {
-            get { return LowBumpMapOffset; }
-            set { LowBumpMapOffset = value; }
+            get => GetTextureOffset("_lowBumpMap");
+            set => SetTextureOffset("_lowBumpMap", value);
         }
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<Single> LowNearTilingSetter
+        public NumericParser<float> LowNearTilingSetter
         {
-            get { return LowNearTiling; }
-            set { LowNearTiling = value; }
+            get => GetFloat("_lowNearTiling");
+            set => SetFloat("_lowNearTiling", value);
         }
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<Single> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactorSetter
         {
-            get { return LowMultiFactor; }
-            set { LowMultiFactor = value; }
+            get => GetFloat("_lowMultiFactor");
+            set => SetFloat("_lowMultiFactor", value);
         }
 
         // Low Bump Near Tiling, default = 1
         [ParserTarget("lowBumpNearTiling")]
-        public NumericParser<Single> LowBumpNearTilingSetter
+        public NumericParser<float> LowBumpNearTilingSetter
         {
-            get { return LowBumpNearTiling; }
-            set { LowBumpNearTiling = value; }
+            get => GetFloat("_lowBumpNearTiling");
+            set => SetFloat("_lowBumpNearTiling", value);
         }
 
         // Low Bump Far Tiling, default = 1
         [ParserTarget("lowBumpMultiFactor")]
-        public NumericParser<Single> LowBumpMultiFactorSetter
+        public NumericParser<float> LowBumpMultiFactorSetter
         {
-            get { return LowBumpMultiFactor; }
-            set { LowBumpMultiFactor = value; }
+            get => GetFloat("_lowBumpMultiFactor");
+            set => SetFloat("_lowBumpMultiFactor", value);
         }
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public Texture2DParser MidTexSetter
+        public MaterialTextureParser MidTexSetter
         {
-            get { return MidTex; }
-            set { MidTex = value; }
+            get => null;
+            set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
         public Vector2Parser MidTexScaleSetter
         {
-            get { return MidTexScale; }
-            set { MidTexScale = value; }
+            get => GetTextureScale("_midTex");
+            set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
         public Vector2Parser MidTexOffsetSetter
         {
-            get { return MidTexOffset; }
-            set { MidTexOffset = value; }
+            get => GetTextureOffset("_midTex");
+            set => SetTextureOffset("_midTex", value);
         }
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public Texture2DParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMapSetter
         {
-            get { return MidBumpMap; }
-            set { MidBumpMap = value; }
+            get => null;
+            set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
         public Vector2Parser MidBumpMapScaleSetter
         {
-            get { return MidBumpMapScale; }
-            set { MidBumpMapScale = value; }
+            get => GetTextureScale("_midBumpMap");
+            set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
         public Vector2Parser MidBumpMapOffsetSetter
         {
-            get { return MidBumpMapOffset; }
-            set { MidBumpMapOffset = value; }
+            get => GetTextureOffset("_midBumpMap");
+            set => SetTextureOffset("_midBumpMap", value);
         }
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<Single> MidNearTilingSetter
+        public NumericParser<float> MidNearTilingSetter
         {
-            get { return MidNearTiling; }
-            set { MidNearTiling = value; }
+            get => GetFloat("_midNearTiling");
+            set => SetFloat("_midNearTiling", value);
         }
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<Single> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactorSetter
         {
-            get { return MidMultiFactor; }
-            set { MidMultiFactor = value; }
+            get => GetFloat("_midMultiFactor");
+            set => SetFloat("_midMultiFactor", value);
         }
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<Single> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTilingSetter
         {
-            get { return MidBumpNearTiling; }
-            set { MidBumpNearTiling = value; }
+            get => GetFloat("_midBumpNearTiling");
+            set => SetFloat("_midBumpNearTiling", value);
         }
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High Bump Map, default = "bump" { }
         [ParserTarget("highBumpMap")]
-        public Texture2DParser HighBumpMapSetter
+        public MaterialTextureParser HighBumpMapSetter
         {
-            get { return HighBumpMap; }
-            set { HighBumpMap = value; }
+            get => null;
+            set => SetTexture("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapScale")]
         public Vector2Parser HighBumpMapScaleSetter
         {
-            get { return HighBumpMapScale; }
-            set { HighBumpMapScale = value; }
+            get => GetTextureScale("_highBumpMap");
+            set => SetTextureScale("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapOffset")]
         public Vector2Parser HighBumpMapOffsetSetter
         {
-            get { return HighBumpMapOffset; }
-            set { HighBumpMapOffset = value; }
+            get => GetTextureOffset("_highBumpMap");
+            set => SetTextureOffset("_highBumpMap", value);
         }
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<Single> HighNearTilingSetter
+        public NumericParser<float> HighNearTilingSetter
         {
-            get { return HighNearTiling; }
-            set { HighNearTiling = value; }
+            get => GetFloat("_highNearTiling");
+            set => SetFloat("_highNearTiling", value);
         }
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<Single> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactorSetter
         {
-            get { return HighMultiFactor; }
-            set { HighMultiFactor = value; }
+            get => GetFloat("_highMultiFactor");
+            set => SetFloat("_highMultiFactor", value);
         }
 
         // High Bump Near Tiling, default = 1000
         [ParserTarget("highBumpNearTiling")]
-        public NumericParser<Single> HighBumpNearTilingSetter
+        public NumericParser<float> HighBumpNearTilingSetter
         {
-            get { return HighBumpNearTiling; }
-            set { HighBumpNearTiling = value; }
+            get => GetFloat("_highBumpNearTiling");
+            set => SetFloat("_highBumpNearTiling", value);
         }
 
         // High Bump Far Tiling, default = 1
         [ParserTarget("highBumpMultiFactor")]
-        public NumericParser<Single> HighBumpMultiFactorSetter
+        public NumericParser<float> HighBumpMultiFactorSetter
         {
-            get { return HighBumpMultiFactor; }
-            set { HighBumpMultiFactor = value; }
+            get => GetFloat("_highBumpMultiFactor");
+            set => SetFloat("_highBumpMultiFactor", value);
         }
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<Single> LowStartSetter
+        public NumericParser<float> LowStartSetter
         {
-            get { return LowStart; }
-            set { LowStart = value; }
+            get => GetFloat("_lowStart");
+            set => SetFloat("_lowStart", value);
         }
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<Single> LowEndSetter
+        public NumericParser<float> LowEndSetter
         {
-            get { return LowEnd; }
-            set { LowEnd = value; }
+            get => GetFloat("_lowEnd");
+            set => SetFloat("_lowEnd", value);
         }
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<Single> HighStartSetter
+        public NumericParser<float> HighStartSetter
         {
-            get { return HighStart; }
-            set { HighStart = value; }
+            get => GetFloat("_highStart");
+            set => SetFloat("_highStart", value);
         }
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<Single> HighEndSetter
+        public NumericParser<float> HighEndSetter
         {
-            get { return HighEnd; }
-            set { HighEnd = value; }
+            get => GetFloat("_highEnd");
+            set => SetFloat("_highEnd", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<Single> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistanceSetter
         {
-            get { return OceanFogDistance; }
-            set { OceanFogDistance = value; }
+            get => GetFloat("_oceanFogDistance");
+            set => SetFloat("_oceanFogDistance", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSMainFastBlendLoader()
-        {
-        }
+        public PQSMainFastBlendLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSMainFastBlendLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSMainFastBlendLoader(Material material) : base(material)
-        {
-        }
+        public PQSMainFastBlendLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
@@ -24,395 +24,389 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSMainOptimisedFastBlendLoader : PQSMainOptimisedFastBlend
+    public class PQSMainOptimisedFastBlendLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised With Fast Blend";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<Single> PowerNearSetter
+        public NumericParser<float> PowerNearSetter
         {
-            get { return PowerNear; }
-            set { PowerNear = value; }
+            get => GetFloat("_powerNear");
+            set => SetFloat("_powerNear", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<Single> PowerFarSetter
+        public NumericParser<float> PowerFarSetter
         {
-            get { return PowerFar; }
-            set { PowerFar = value; }
+            get => GetFloat("_powerFar");
+            set => SetFloat("_powerFar", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public Texture2DParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMapSetter
         {
-            get { return SteepBumpMap; }
-            set { SteepBumpMap = value; }
+            get => null;
+            set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
         public Vector2Parser SteepBumpMapScaleSetter
         {
-            get { return SteepBumpMapScale; }
-            set { SteepBumpMapScale = value; }
+            get => GetTextureScale("_steepBumpMap");
+            set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
         public Vector2Parser SteepBumpMapOffsetSetter
         {
-            get { return SteepBumpMapOffset; }
-            set { SteepBumpMapOffset = value; }
+            get => GetTextureOffset("_steepBumpMap");
+            set => SetTextureOffset("_steepBumpMap", value);
         }
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<Single> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTilingSetter
         {
-            get { return SteepNearTiling; }
-            set { SteepNearTiling = value; }
+            get => GetFloat("_steepNearTiling");
+            set => SetFloat("_steepNearTiling", value);
         }
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public Texture2DParser LowTexSetter
+        public MaterialTextureParser LowTexSetter
         {
-            get { return LowTex; }
-            set { LowTex = value; }
+            get => null;
+            set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
         public Vector2Parser LowTexScaleSetter
         {
-            get { return LowTexScale; }
-            set { LowTexScale = value; }
+            get => GetTextureScale("_lowTex");
+            set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
         public Vector2Parser LowTexOffsetSetter
         {
-            get { return LowTexOffset; }
-            set { LowTexOffset = value; }
+            get => GetTextureOffset("_lowTex");
+            set => SetTextureOffset("_lowTex", value);
         }
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<Single> LowNearTilingSetter
+        public NumericParser<float> LowNearTilingSetter
         {
-            get { return LowNearTiling; }
-            set { LowNearTiling = value; }
+            get => GetFloat("_lowNearTiling");
+            set => SetFloat("_lowNearTiling", value);
         }
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<Single> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactorSetter
         {
-            get { return LowMultiFactor; }
-            set { LowMultiFactor = value; }
+            get => GetFloat("_lowMultiFactor");
+            set => SetFloat("_lowMultiFactor", value);
         }
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public Texture2DParser MidTexSetter
+        public MaterialTextureParser MidTexSetter
         {
-            get { return MidTex; }
-            set { MidTex = value; }
+            get => null;
+            set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
         public Vector2Parser MidTexScaleSetter
         {
-            get { return MidTexScale; }
-            set { MidTexScale = value; }
+            get => GetTextureScale("_midTex");
+            set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
         public Vector2Parser MidTexOffsetSetter
         {
-            get { return MidTexOffset; }
-            set { MidTexOffset = value; }
+            get => GetTextureOffset("_midTex");
+            set => SetTextureOffset("_midTex", value);
         }
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public Texture2DParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMapSetter
         {
-            get { return MidBumpMap; }
-            set { MidBumpMap = value; }
+            get => null;
+            set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
         public Vector2Parser MidBumpMapScaleSetter
         {
-            get { return MidBumpMapScale; }
-            set { MidBumpMapScale = value; }
+            get => GetTextureScale("_midBumpMap");
+            set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
         public Vector2Parser MidBumpMapOffsetSetter
         {
-            get { return MidBumpMapOffset; }
-            set { MidBumpMapOffset = value; }
+            get => GetTextureOffset("_midBumpMap");
+            set => SetTextureOffset("_midBumpMap", value);
         }
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<Single> MidNearTilingSetter
+        public NumericParser<float> MidNearTilingSetter
         {
-            get { return MidNearTiling; }
-            set { MidNearTiling = value; }
+            get => GetFloat("_midNearTiling");
+            set => SetFloat("_midNearTiling", value);
         }
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<Single> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactorSetter
         {
-            get { return MidMultiFactor; }
-            set { MidMultiFactor = value; }
+            get => GetFloat("_midMultiFactor");
+            set => SetFloat("_midMultiFactor", value);
         }
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<Single> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTilingSetter
         {
-            get { return MidBumpNearTiling; }
-            set { MidBumpNearTiling = value; }
+            get => GetFloat("_midBumpNearTiling");
+            set => SetFloat("_midBumpNearTiling", value);
         }
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<Single> HighNearTilingSetter
+        public NumericParser<float> HighNearTilingSetter
         {
-            get { return HighNearTiling; }
-            set { HighNearTiling = value; }
+            get => GetFloat("_highNearTiling");
+            set => SetFloat("_highNearTiling", value);
         }
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<Single> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactorSetter
         {
-            get { return HighMultiFactor; }
-            set { HighMultiFactor = value; }
+            get => GetFloat("_highMultiFactor");
+            set => SetFloat("_highMultiFactor", value);
         }
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<Single> LowStartSetter
+        public NumericParser<float> LowStartSetter
         {
-            get { return LowStart; }
-            set { LowStart = value; }
+            get => GetFloat("_lowStart");
+            set => SetFloat("_lowStart", value);
         }
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<Single> LowEndSetter
+        public NumericParser<float> LowEndSetter
         {
-            get { return LowEnd; }
-            set { LowEnd = value; }
+            get => GetFloat("_lowEnd");
+            set => SetFloat("_lowEnd", value);
         }
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<Single> HighStartSetter
+        public NumericParser<float> HighStartSetter
         {
-            get { return HighStart; }
-            set { HighStart = value; }
+            get => GetFloat("_highStart");
+            set => SetFloat("_highStart", value);
         }
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<Single> HighEndSetter
+        public NumericParser<float> HighEndSetter
         {
-            get { return HighEnd; }
-            set { HighEnd = value; }
+            get => GetFloat("_highEnd");
+            set => SetFloat("_highEnd", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<Single> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistanceSetter
         {
-            get { return OceanFogDistance; }
-            set { OceanFogDistance = value; }
+            get => GetFloat("_oceanFogDistance");
+            set => SetFloat("_oceanFogDistance", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSMainOptimisedFastBlendLoader()
-        {
-        }
+        public PQSMainOptimisedFastBlendLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSMainOptimisedFastBlendLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSMainOptimisedFastBlendLoader(Material material) : base(material)
-        {
-        }
+        public PQSMainOptimisedFastBlendLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -24,11 +24,10 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
@@ -37,340 +36,342 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSMainOptimisedLoader : PQSMainOptimised
+    public class PQSMainOptimisedLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<Single> PowerNearSetter
+        public NumericParser<float> PowerNearSetter
         {
-            get { return PowerNear; }
-            set { PowerNear = value; }
+            get => GetFloat("_powerNear");
+            set => SetFloat("_powerNear", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<Single> PowerFarSetter
+        public NumericParser<float> PowerFarSetter
         {
-            get { return PowerFar; }
-            set { PowerFar = value; }
+            get => GetFloat("_powerFar");
+            set => SetFloat("_powerFar", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public Texture2DParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMapSetter
         {
-            get { return SteepBumpMap; }
-            set { SteepBumpMap = value; }
+            get => null;
+            set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
         public Vector2Parser SteepBumpMapScaleSetter
         {
-            get { return SteepBumpMapScale; }
-            set { SteepBumpMapScale = value; }
+            get => GetTextureScale("_steepBumpMap");
+            set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
         public Vector2Parser SteepBumpMapOffsetSetter
         {
-            get { return SteepBumpMapOffset; }
-            set { SteepBumpMapOffset = value; }
+            get => GetTextureOffset("_steepBumpMap");
+            set => SetTextureOffset("_steepBumpMap", value);
         }
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<Single> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTilingSetter
         {
-            get { return SteepNearTiling; }
-            set { SteepNearTiling = value; }
+            get => GetFloat("_steepNearTiling");
+            set => SetFloat("_steepNearTiling", value);
         }
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public Texture2DParser LowTexSetter
+        public MaterialTextureParser LowTexSetter
         {
-            get { return LowTex; }
-            set { LowTex = value; }
+            get => null;
+            set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
         public Vector2Parser LowTexScaleSetter
         {
-            get { return LowTexScale; }
-            set { LowTexScale = value; }
+            get => GetTextureScale("_lowTex");
+            set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
         public Vector2Parser LowTexOffsetSetter
         {
-            get { return LowTexOffset; }
-            set { LowTexOffset = value; }
+            get => GetTextureOffset("_lowTex");
+            set => SetTextureOffset("_lowTex", value);
         }
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<Single> LowNearTilingSetter
+        public NumericParser<float> LowNearTilingSetter
         {
-            get { return LowNearTiling; }
-            set { LowNearTiling = value; }
+            get => GetFloat("_lowNearTiling");
+            set => SetFloat("_lowNearTiling", value);
         }
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<Single> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactorSetter
         {
-            get { return LowMultiFactor; }
-            set { LowMultiFactor = value; }
+            get => GetFloat("_lowMultiFactor");
+            set => SetFloat("_lowMultiFactor", value);
         }
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public Texture2DParser MidTexSetter
+        public MaterialTextureParser MidTexSetter
         {
-            get { return MidTex; }
-            set { MidTex = value; }
+            get => null;
+            set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
         public Vector2Parser MidTexScaleSetter
         {
-            get { return MidTexScale; }
-            set { MidTexScale = value; }
+            get => GetTextureScale("_midTex");
+            set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
         public Vector2Parser MidTexOffsetSetter
         {
-            get { return MidTexOffset; }
-            set { MidTexOffset = value; }
+            get => GetTextureOffset("_midTex");
+            set => SetTextureOffset("_midTex", value);
         }
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public Texture2DParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMapSetter
         {
-            get { return MidBumpMap; }
-            set { MidBumpMap = value; }
+            get => null;
+            set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
         public Vector2Parser MidBumpMapScaleSetter
         {
-            get { return MidBumpMapScale; }
-            set { MidBumpMapScale = value; }
+            get => GetTextureScale("_midBumpMap");
+            set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
         public Vector2Parser MidBumpMapOffsetSetter
         {
-            get { return MidBumpMapOffset; }
-            set { MidBumpMapOffset = value; }
+            get => GetTextureOffset("_midBumpMap");
+            set => SetTextureOffset("_midBumpMap", value);
         }
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<Single> MidNearTilingSetter
+        public NumericParser<float> MidNearTilingSetter
         {
-            get { return MidNearTiling; }
-            set { MidNearTiling = value; }
+            get => GetFloat("_midNearTiling");
+            set => SetFloat("_midNearTiling", value);
         }
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<Single> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactorSetter
         {
-            get { return MidMultiFactor; }
-            set { MidMultiFactor = value; }
+            get => GetFloat("_midMultiFactor");
+            set => SetFloat("_midMultiFactor", value);
         }
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<Single> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTilingSetter
         {
-            get { return MidBumpNearTiling; }
-            set { MidBumpNearTiling = value; }
+            get => GetFloat("_midBumpNearTiling");
+            set => SetFloat("_midBumpNearTiling", value);
         }
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<Single> HighNearTilingSetter
+        public NumericParser<float> HighNearTilingSetter
         {
-            get { return HighNearTiling; }
-            set { HighNearTiling = value; }
+            get => GetFloat("_highNearTiling");
+            set => SetFloat("_highNearTiling", value);
         }
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<Single> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactorSetter
         {
-            get { return HighMultiFactor; }
-            set { HighMultiFactor = value; }
+            get => GetFloat("_highMultiFactor");
+            set => SetFloat("_highMultiFactor", value);
         }
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<Single> LowStartSetter
+        public NumericParser<float> LowStartSetter
         {
-            get { return LowStart; }
-            set { LowStart = value; }
+            get => GetFloat("_lowStart");
+            set => SetFloat("_lowStart", value);
         }
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<Single> LowEndSetter
+        public NumericParser<float> LowEndSetter
         {
-            get { return LowEnd; }
-            set { LowEnd = value; }
+            get => GetFloat("_lowEnd");
+            set => SetFloat("_lowEnd", value);
         }
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<Single> HighStartSetter
+        public NumericParser<float> HighStartSetter
         {
-            get { return HighStart; }
-            set { HighStart = value; }
+            get => GetFloat("_highStart");
+            set => SetFloat("_highStart", value);
         }
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<Single> HighEndSetter
+        public NumericParser<float> HighEndSetter
         {
-            get { return HighEnd; }
-            set { HighEnd = value; }
+            get => GetFloat("_highEnd");
+            set => SetFloat("_highEnd", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
@@ -378,68 +379,44 @@ namespace Kopernicus.Configuration.MaterialLoader
         [KittopiaHideOption]
         public Gradient FogColorRampGradientSetter
         {
-            set
-            {
-                // Generate the ramp from a gradient
-                Texture2D ramp = new Texture2D(512, 1);
-                Color32[] colors = ramp.GetPixels32(0);
-                for (Int32 i = 0; i < colors.Length; i++)
-                {
-                    // Compute the position in the gradient
-                    Single k = (Single)i / colors.Length;
-                    colors[i] = value.ColorAt(k);
-                }
-
-                ramp.SetPixels32(colors, 0);
-                ramp.Apply(true, false);
-
-                // Set the color ramp
-                FogColorRamp = ramp;
-            }
+            set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<Single> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistanceSetter
         {
-            get { return OceanFogDistance; }
-            set { OceanFogDistance = value; }
+            get => GetFloat("_oceanFogDistance");
+            set => SetFloat("_oceanFogDistance", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSMainOptimisedLoader()
-        {
-        }
+        public PQSMainOptimisedLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSMainOptimisedLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSMainOptimisedLoader(Material material) : base(material)
-        {
-        }
+        public PQSMainOptimisedLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -24,11 +24,10 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
@@ -37,424 +36,426 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSMainShaderLoader : PQSMainShader
+    public class PQSMainShaderLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/PQS Main Shader";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<Single> PowerNearSetter
+        public NumericParser<float> PowerNearSetter
         {
-            get { return PowerNear; }
-            set { PowerNear = value; }
+            get => GetFloat("_powerNear");
+            set => SetFloat("_powerNear", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<Single> PowerFarSetter
+        public NumericParser<float> PowerFarSetter
         {
-            get { return PowerFar; }
-            set { PowerFar = value; }
+            get => GetFloat("_powerFar");
+            set => SetFloat("_powerFar", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public Texture2DParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMapSetter
         {
-            get { return SteepBumpMap; }
-            set { SteepBumpMap = value; }
+            get => null;
+            set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
         public Vector2Parser SteepBumpMapScaleSetter
         {
-            get { return SteepBumpMapScale; }
-            set { SteepBumpMapScale = value; }
+            get => GetTextureScale("_steepBumpMap");
+            set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
         public Vector2Parser SteepBumpMapOffsetSetter
         {
-            get { return SteepBumpMapOffset; }
-            set { SteepBumpMapOffset = value; }
+            get => GetTextureOffset("_steepBumpMap");
+            set => SetTextureOffset("_steepBumpMap", value);
         }
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<Single> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTilingSetter
         {
-            get { return SteepNearTiling; }
-            set { SteepNearTiling = value; }
+            get => GetFloat("_steepNearTiling");
+            set => SetFloat("_steepNearTiling", value);
         }
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public Texture2DParser LowTexSetter
+        public MaterialTextureParser LowTexSetter
         {
-            get { return LowTex; }
-            set { LowTex = value; }
+            get => null;
+            set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
         public Vector2Parser LowTexScaleSetter
         {
-            get { return LowTexScale; }
-            set { LowTexScale = value; }
+            get => GetTextureScale("_lowTex");
+            set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
         public Vector2Parser LowTexOffsetSetter
         {
-            get { return LowTexOffset; }
-            set { LowTexOffset = value; }
+            get => GetTextureOffset("_lowTex");
+            set => SetTextureOffset("_lowTex", value);
         }
 
         // Low Bump Map, default = "bump" { }
         [ParserTarget("lowBumpMap")]
-        public Texture2DParser LowBumpMapSetter
+        public MaterialTextureParser LowBumpMapSetter
         {
-            get { return LowBumpMap; }
-            set { LowBumpMap = value; }
+            get => null;
+            set => SetTexture("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapScale")]
         public Vector2Parser LowBumpMapScaleSetter
         {
-            get { return LowBumpMapScale; }
-            set { LowBumpMapScale = value; }
+            get => GetTextureScale("_lowBumpMap");
+            set => SetTextureScale("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapOffset")]
         public Vector2Parser LowBumpMapOffsetSetter
         {
-            get { return LowBumpMapOffset; }
-            set { LowBumpMapOffset = value; }
+            get => GetTextureOffset("_lowBumpMap");
+            set => SetTextureOffset("_lowBumpMap", value);
         }
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<Single> LowNearTilingSetter
+        public NumericParser<float> LowNearTilingSetter
         {
-            get { return LowNearTiling; }
-            set { LowNearTiling = value; }
+            get => GetFloat("_lowNearTiling");
+            set => SetFloat("_lowNearTiling", value);
         }
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<Single> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactorSetter
         {
-            get { return LowMultiFactor; }
-            set { LowMultiFactor = value; }
+            get => GetFloat("_lowMultiFactor");
+            set => SetFloat("_lowMultiFactor", value);
         }
 
         // Low Bump Near Tiling, default = 1
         [ParserTarget("lowBumpNearTiling")]
-        public NumericParser<Single> LowBumpNearTilingSetter
+        public NumericParser<float> LowBumpNearTilingSetter
         {
-            get { return LowBumpNearTiling; }
-            set { LowBumpNearTiling = value; }
+            get => GetFloat("_lowBumpNearTiling");
+            set => SetFloat("_lowBumpNearTiling", value);
         }
 
         // Low Bump Far Tiling, default = 1
         [ParserTarget("lowBumpFarTiling")]
-        public NumericParser<Single> LowBumpFarTilingSetter
+        public NumericParser<float> LowBumpFarTilingSetter
         {
-            get { return LowBumpFarTiling; }
-            set { LowBumpFarTiling = value; }
+            get => GetFloat("_lowBumpFarTiling");
+            set => SetFloat("_lowBumpFarTiling", value);
         }
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public Texture2DParser MidTexSetter
+        public MaterialTextureParser MidTexSetter
         {
-            get { return MidTex; }
-            set { MidTex = value; }
+            get => null;
+            set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
         public Vector2Parser MidTexScaleSetter
         {
-            get { return MidTexScale; }
-            set { MidTexScale = value; }
+            get => GetTextureScale("_midTex");
+            set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
         public Vector2Parser MidTexOffsetSetter
         {
-            get { return MidTexOffset; }
-            set { MidTexOffset = value; }
+            get => GetTextureOffset("_midTex");
+            set => SetTextureOffset("_midTex", value);
         }
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public Texture2DParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMapSetter
         {
-            get { return MidBumpMap; }
-            set { MidBumpMap = value; }
+            get => null;
+            set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
         public Vector2Parser MidBumpMapScaleSetter
         {
-            get { return MidBumpMapScale; }
-            set { MidBumpMapScale = value; }
+            get => GetTextureScale("_midBumpMap");
+            set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
         public Vector2Parser MidBumpMapOffsetSetter
         {
-            get { return MidBumpMapOffset; }
-            set { MidBumpMapOffset = value; }
+            get => GetTextureOffset("_midBumpMap");
+            set => SetTextureOffset("_midBumpMap", value);
         }
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<Single> MidNearTilingSetter
+        public NumericParser<float> MidNearTilingSetter
         {
-            get { return MidNearTiling; }
-            set { MidNearTiling = value; }
+            get => GetFloat("_midNearTiling");
+            set => SetFloat("_midNearTiling", value);
         }
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<Single> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactorSetter
         {
-            get { return MidMultiFactor; }
-            set { MidMultiFactor = value; }
+            get => GetFloat("_midMultiFactor");
+            set => SetFloat("_midMultiFactor", value);
         }
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<Single> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTilingSetter
         {
-            get { return MidBumpNearTiling; }
-            set { MidBumpNearTiling = value; }
+            get => GetFloat("_midBumpNearTiling");
+            set => SetFloat("_midBumpNearTiling", value);
         }
 
         // Mid Bump Far Tiling, default = 1
         [ParserTarget("midBumpFarTiling")]
-        public NumericParser<Single> MidBumpFarTilingSetter
+        public NumericParser<float> MidBumpFarTilingSetter
         {
-            get { return MidBumpFarTiling; }
-            set { MidBumpFarTiling = value; }
+            get => GetFloat("_midBumpFarTiling");
+            set => SetFloat("_midBumpFarTiling", value);
         }
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High Bump Map, default = "bump" { }
         [ParserTarget("highBumpMap")]
-        public Texture2DParser HighBumpMapSetter
+        public MaterialTextureParser HighBumpMapSetter
         {
-            get { return HighBumpMap; }
-            set { HighBumpMap = value; }
+            get => null;
+            set => SetTexture("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapScale")]
         public Vector2Parser HighBumpMapScaleSetter
         {
-            get { return HighBumpMapScale; }
-            set { HighBumpMapScale = value; }
+            get => GetTextureScale("_highBumpMap");
+            set => SetTextureScale("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapOffset")]
         public Vector2Parser HighBumpMapOffsetSetter
         {
-            get { return HighBumpMapOffset; }
-            set { HighBumpMapOffset = value; }
+            get => GetTextureOffset("_highBumpMap");
+            set => SetTextureOffset("_highBumpMap", value);
         }
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<Single> HighNearTilingSetter
+        public NumericParser<float> HighNearTilingSetter
         {
-            get { return HighNearTiling; }
-            set { HighNearTiling = value; }
+            get => GetFloat("_highNearTiling");
+            set => SetFloat("_highNearTiling", value);
         }
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<Single> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactorSetter
         {
-            get { return HighMultiFactor; }
-            set { HighMultiFactor = value; }
+            get => GetFloat("_highMultiFactor");
+            set => SetFloat("_highMultiFactor", value);
         }
 
         // High Bump Near Tiling, default = 1
         [ParserTarget("highBumpNearTiling")]
-        public NumericParser<Single> HighBumpNearTilingSetter
+        public NumericParser<float> HighBumpNearTilingSetter
         {
-            get { return HighBumpNearTiling; }
-            set { HighBumpNearTiling = value; }
+            get => GetFloat("_highBumpNearTiling");
+            set => SetFloat("_highBumpNearTiling", value);
         }
 
         // High Bump Far Tiling, default = 1
         [ParserTarget("highBumpFarTiling")]
-        public NumericParser<Single> HighBumpFarTilingSetter
+        public NumericParser<float> HighBumpFarTilingSetter
         {
-            get { return HighBumpFarTiling; }
-            set { HighBumpFarTiling = value; }
+            get => GetFloat("_highBumpFarTiling");
+            set => SetFloat("_highBumpFarTiling", value);
         }
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<Single> LowStartSetter
+        public NumericParser<float> LowStartSetter
         {
-            get { return LowStart; }
-            set { LowStart = value; }
+            get => GetFloat("_lowStart");
+            set => SetFloat("_lowStart", value);
         }
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<Single> LowEndSetter
+        public NumericParser<float> LowEndSetter
         {
-            get { return LowEnd; }
-            set { LowEnd = value; }
+            get => GetFloat("_lowEnd");
+            set => SetFloat("_lowEnd", value);
         }
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<Single> HighStartSetter
+        public NumericParser<float> HighStartSetter
         {
-            get { return HighStart; }
-            set { HighStart = value; }
+            get => GetFloat("_highStart");
+            set => SetFloat("_highStart", value);
         }
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<Single> HighEndSetter
+        public NumericParser<float> HighEndSetter
         {
-            get { return HighEnd; }
-            set { HighEnd = value; }
+            get => GetFloat("_highEnd");
+            set => SetFloat("_highEnd", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
@@ -462,60 +463,36 @@ namespace Kopernicus.Configuration.MaterialLoader
         [KittopiaHideOption]
         public Gradient FogColorRampGradientSetter
         {
-            set
-            {
-                // Generate the ramp from a gradient
-                Texture2D ramp = new Texture2D(512, 1);
-                Color32[] colors = ramp.GetPixels32(0);
-                for (Int32 i = 0; i < colors.Length; i++)
-                {
-                    // Compute the position in the gradient
-                    Single k = (Single)i / colors.Length;
-                    colors[i] = value.ColorAt(k);
-                }
-
-                ramp.SetPixels32(colors, 0);
-                ramp.Apply(true, false);
-
-                // Set the color ramp
-                FogColorRamp = ramp;
-            }
+            set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSMainShaderLoader()
-        {
-        }
+        public PQSMainShaderLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSMainShaderLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSMainShaderLoader(Material material) : base(material)
-        {
-        }
+        public PQSMainShaderLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
@@ -24,149 +24,143 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSOceanSurfaceQuadFallbackLoader : PQSOceanSurfaceQuadFallback
+    public class PQSOceanSurfaceQuadFallbackLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad (Fallback)";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Color From Space, default = (1,1,1,1)
         [ParserTarget("colorFromSpace")]
         public ColorParser ColorFromSpaceSetter
         {
-            get { return ColorFromSpace; }
-            set { ColorFromSpace = value; }
+            get => GetColor("_ColorFromSpace");
+            set => SetColor("_ColorFromSpace", value);
         }
 
         // Specular Color, default = (1,1,1,1)
         [ParserTarget("specColor")]
         public ColorParser SpecColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<Single> ShininessSetter
+        public NumericParser<float> ShininessSetter
         {
-            get { return Shininess; }
-            set { Shininess = value; }
+            get => GetFloat("_Shininess");
+            set => SetFloat("_Shininess", value);
         }
 
         // Gloss, default = 0.078125
         [ParserTarget("gloss")]
-        public NumericParser<Single> GlossSetter
+        public NumericParser<float> GlossSetter
         {
-            get { return Gloss; }
-            set { Gloss = value; }
+            get => GetFloat("_Gloss");
+            set => SetFloat("_Gloss", value);
         }
 
         // Tex Tiling, default = 1
         [ParserTarget("tiling")]
-        public NumericParser<Single> TilingSetter
+        public NumericParser<float> TilingSetter
         {
-            get { return Tiling; }
-            set { Tiling = value; }
+            get => GetFloat("_tiling");
+            set => SetFloat("_tiling", value);
         }
 
         // Tex0, default = "white" { }
         [ParserTarget("waterTex")]
-        public Texture2DParser WaterTexSetter
+        public MaterialTextureParser WaterTexSetter
         {
-            get { return WaterTex; }
-            set { WaterTex = value; }
+            get => null;
+            set => SetTexture("_WaterTex", value);
         }
 
         [ParserTarget("waterTexScale")]
         public Vector2Parser WaterTexScaleSetter
         {
-            get { return WaterTexScale; }
-            set { WaterTexScale = value; }
+            get => GetTextureScale("_WaterTex");
+            set => SetTextureScale("_WaterTex", value);
         }
 
         [ParserTarget("waterTexOffset")]
         public Vector2Parser WaterTexOffsetSetter
         {
-            get { return WaterTexOffset; }
-            set { WaterTexOffset = value; }
+            get => GetTextureOffset("_WaterTex");
+            set => SetTextureOffset("_WaterTex", value);
         }
 
         // Tex1, default = "white" { }
         [ParserTarget("waterTex1")]
-        public Texture2DParser WaterTex1Setter
+        public MaterialTextureParser WaterTex1Setter
         {
-            get { return WaterTex1; }
-            set { WaterTex1 = value; }
+            get => null;
+            set => SetTexture("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Scale")]
         public Vector2Parser WaterTex1ScaleSetter
         {
-            get { return WaterTex1Scale; }
-            set { WaterTex1Scale = value; }
+            get => GetTextureScale("_WaterTex1");
+            set => SetTextureScale("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Offset")]
         public Vector2Parser WaterTex1OffsetSetter
         {
-            get { return WaterTex1Offset; }
-            set { WaterTex1Offset = value; }
+            get => GetTextureOffset("_WaterTex1");
+            set => SetTextureOffset("_WaterTex1", value);
         }
 
         // FadeStart, default = 1
         [ParserTarget("fadeStart")]
-        public NumericParser<Single> FadeStartSetter
+        public NumericParser<float> FadeStartSetter
         {
-            get { return FadeStart; }
-            set { FadeStart = value; }
+            get => GetFloat("_fadeStart");
+            set => SetFloat("_fadeStart", value);
         }
 
         // FadeEnd, default = 1
         [ParserTarget("fadeEnd")]
-        public NumericParser<Single> FadeEndSetter
+        public NumericParser<float> FadeEndSetter
         {
-            get { return FadeEnd; }
-            set { FadeEnd = value; }
+            get => GetFloat("_fadeEnd");
+            set => SetFloat("_fadeEnd", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSOceanSurfaceQuadFallbackLoader()
-        {
-        }
+        public PQSOceanSurfaceQuadFallbackLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSOceanSurfaceQuadFallbackLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSOceanSurfaceQuadFallbackLoader(Material material) : base(material)
-        {
-        }
+        public PQSOceanSurfaceQuadFallbackLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -24,11 +24,10 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
@@ -37,226 +36,228 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSOceanSurfaceQuadLoader : PQSOceanSurfaceQuad
+    public class PQSOceanSurfaceQuadLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Color From Space, default = (1,1,1,1)
         [ParserTarget("colorFromSpace")]
         public ColorParser ColorFromSpaceSetter
         {
-            get { return ColorFromSpace; }
-            set { ColorFromSpace = value; }
+            get => GetColor("_ColorFromSpace");
+            set => SetColor("_ColorFromSpace", value);
         }
 
         // Specular Color, default = (1,1,1,1)
         [ParserTarget("specColor")]
         public ColorParser SpecColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<Single> ShininessSetter
+        public NumericParser<float> ShininessSetter
         {
-            get { return Shininess; }
-            set { Shininess = value; }
+            get => GetFloat("_Shininess");
+            set => SetFloat("_Shininess", value);
         }
 
         // Gloss, default = 0.078125
         [ParserTarget("gloss")]
-        public NumericParser<Single> GlossSetter
+        public NumericParser<float> GlossSetter
         {
-            get { return Gloss; }
-            set { Gloss = value; }
+            get => GetFloat("_Gloss");
+            set => SetFloat("_Gloss", value);
         }
 
         // Tex Tiling, default = 1
         [ParserTarget("tiling")]
-        public NumericParser<Single> TilingSetter
+        public NumericParser<float> TilingSetter
         {
-            get { return Tiling; }
-            set { Tiling = value; }
+            get => GetFloat("_tiling");
+            set => SetFloat("_tiling", value);
         }
 
         // Tex0, default = "white" { }
         [ParserTarget("waterTex")]
-        public Texture2DParser WaterTexSetter
+        public MaterialTextureParser WaterTexSetter
         {
-            get { return WaterTex; }
-            set { WaterTex = value; }
+            get => null;
+            set => SetTexture("_WaterTex", value);
         }
 
         [ParserTarget("waterTexScale")]
         public Vector2Parser WaterTexScaleSetter
         {
-            get { return WaterTexScale; }
-            set { WaterTexScale = value; }
+            get => GetTextureScale("_WaterTex");
+            set => SetTextureScale("_WaterTex", value);
         }
 
         [ParserTarget("waterTexOffset")]
         public Vector2Parser WaterTexOffsetSetter
         {
-            get { return WaterTexOffset; }
-            set { WaterTexOffset = value; }
+            get => GetTextureOffset("_WaterTex");
+            set => SetTextureOffset("_WaterTex", value);
         }
 
         // Tex1, default = "white" { }
         [ParserTarget("waterTex1")]
-        public Texture2DParser WaterTex1Setter
+        public MaterialTextureParser WaterTex1Setter
         {
-            get { return WaterTex1; }
-            set { WaterTex1 = value; }
+            get => null;
+            set => SetTexture("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Scale")]
         public Vector2Parser WaterTex1ScaleSetter
         {
-            get { return WaterTex1Scale; }
-            set { WaterTex1Scale = value; }
+            get => GetTextureScale("_WaterTex1");
+            set => SetTextureScale("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Offset")]
         public Vector2Parser WaterTex1OffsetSetter
         {
-            get { return WaterTex1Offset; }
-            set { WaterTex1Offset = value; }
+            get => GetTextureOffset("_WaterTex1");
+            set => SetTextureOffset("_WaterTex1", value);
         }
 
         // Normal Tiling, default = 1
         [ParserTarget("bTiling")]
-        public NumericParser<Single> BTilingSetter
+        public NumericParser<float> BTilingSetter
         {
-            get { return BTiling; }
-            set { BTiling = value; }
+            get => GetFloat("_bTiling");
+            set => SetFloat("_bTiling", value);
         }
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Water Movement, default = 1
         [ParserTarget("displacement")]
-        public NumericParser<Single> DisplacementSetter
+        public NumericParser<float> DisplacementSetter
         {
-            get { return Displacement; }
-            set { Displacement = value; }
+            get => GetFloat("_displacement");
+            set => SetFloat("_displacement", value);
         }
 
         // Texture Displacement, default = 1
         [ParserTarget("texDisplacement")]
-        public NumericParser<Single> TexDisplacementSetter
+        public NumericParser<float> TexDisplacementSetter
         {
-            get { return TexDisplacement; }
-            set { TexDisplacement = value; }
+            get => GetFloat("_texDisplacement");
+            set => SetFloat("_texDisplacement", value);
         }
 
         // Water Freq, default = 1
         [ParserTarget("dispFreq")]
-        public NumericParser<Single> DispFreqSetter
+        public NumericParser<float> DispFreqSetter
         {
-            get { return DispFreq; }
-            set { DispFreq = value; }
+            get => GetFloat("_dispFreq");
+            set => SetFloat("_dispFreq", value);
         }
 
         // Mix, default = 1
         [ParserTarget("mix")]
-        public NumericParser<Single> MixSetter
+        public NumericParser<float> MixSetter
         {
-            get { return Mix; }
-            set { Mix = value; }
+            get => GetFloat("_Mix");
+            set => SetFloat("_Mix", value);
         }
 
         // Opacity, default = 1
         [ParserTarget("oceanOpacity")]
-        public NumericParser<Single> OceanOpacitySetter
+        public NumericParser<float> OceanOpacitySetter
         {
-            get { return OceanOpacity; }
-            set { OceanOpacity = value; }
+            get => GetFloat("_oceanOpacity");
+            set => SetFloat("_oceanOpacity", value);
         }
 
         // Falloff Power, default = 1
         [ParserTarget("falloffPower")]
-        public NumericParser<Single> FalloffPowerSetter
+        public NumericParser<float> FalloffPowerSetter
         {
-            get { return FalloffPower; }
-            set { FalloffPower = value; }
+            get => GetFloat("_falloffPower");
+            set => SetFloat("_falloffPower", value);
         }
 
         // Falloff Exp, default = 2
         [ParserTarget("falloffExp")]
-        public NumericParser<Single> FalloffExpSetter
+        public NumericParser<float> FalloffExpSetter
         {
-            get { return FalloffExp; }
-            set { FalloffExp = value; }
+            get => GetFloat("_falloffExp");
+            set => SetFloat("_falloffExp", value);
         }
 
         // AP Fog Color, default = (0,0,1,1)
         [ParserTarget("fogColor")]
         public ColorParser FogColorSetter
         {
-            get { return FogColor; }
-            set { FogColor = value; }
+            get => GetColor("_fogColor");
+            set => SetColor("_fogColor", value);
         }
 
         // AP Height Fall Off, default = 1
         [ParserTarget("heightFallOff")]
-        public NumericParser<Single> HeightFallOffSetter
+        public NumericParser<float> HeightFallOffSetter
         {
-            get { return HeightFallOff; }
-            set { HeightFallOff = value; }
+            get => GetFloat("_heightFallOff");
+            set => SetFloat("_heightFallOff", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // AP Atmosphere Depth, default = 1
         [ParserTarget("atmosphereDepth")]
-        public NumericParser<Single> AtmosphereDepthSetter
+        public NumericParser<float> AtmosphereDepthSetter
         {
-            get { return AtmosphereDepth; }
-            set { AtmosphereDepth = value; }
+            get => GetFloat("_atmosphereDepth");
+            set => SetFloat("_atmosphereDepth", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
@@ -264,92 +265,68 @@ namespace Kopernicus.Configuration.MaterialLoader
         [KittopiaHideOption]
         public Gradient FogColorRampGradientSetter
         {
-            set
-            {
-                // Generate the ramp from a gradient
-                Texture2D ramp = new Texture2D(512, 1);
-                Color32[] colors = ramp.GetPixels32(0);
-                for (Int32 i = 0; i < colors.Length; i++)
-                {
-                    // Compute the position in the gradient
-                    Single k = (Single)i / colors.Length;
-                    colors[i] = value.ColorAt(k);
-                }
-
-                ramp.SetPixels32(colors, 0);
-                ramp.Apply(true, false);
-
-                // Set the color ramp
-                FogColorRamp = ramp;
-            }
+            set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // FadeStart, default = 1
         [ParserTarget("fadeStart")]
-        public NumericParser<Single> FadeStartSetter
+        public NumericParser<float> FadeStartSetter
         {
-            get { return FadeStart; }
-            set { FadeStart = value; }
+            get => GetFloat("_fadeStart");
+            set => SetFloat("_fadeStart", value);
         }
 
         // FadeEnd, default = 1
         [ParserTarget("fadeEnd")]
-        public NumericParser<Single> FadeEndSetter
+        public NumericParser<float> FadeEndSetter
         {
-            get { return FadeEnd; }
-            set { FadeEnd = value; }
+            get => GetFloat("_fadeEnd");
+            set => SetFloat("_fadeEnd", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
 
         // NormalXYFudge, default = 0.1
         [ParserTarget("normalXYFudge")]
-        public NumericParser<Single> NormalXyFudgeSetter
+        public NumericParser<float> NormalXyFudgeSetter
         {
-            get { return NormalXyFudge; }
-            set { NormalXyFudge = value; }
+            get => GetFloat("_NormalXYFudge");
+            set => SetFloat("_NormalXYFudge", value);
         }
 
         // NormalZFudge, default = 1.1
         [ParserTarget("normalZFudge")]
-        public NumericParser<Single> NormalZFudgeSetter
+        public NumericParser<float> NormalZFudgeSetter
         {
-            get { return NormalZFudge; }
-            set { NormalZFudge = value; }
+            get => GetFloat("_NormalZFudge");
+            set => SetFloat("_NormalZFudge", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSOceanSurfaceQuadLoader()
-        {
-        }
+        public PQSOceanSurfaceQuadLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSOceanSurfaceQuadLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSOceanSurfaceQuadLoader(Material material) : base(material)
-        {
-        }
+        public PQSOceanSurfaceQuadLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -24,11 +24,10 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
@@ -37,470 +36,472 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSProjectionAerialQuadRelativeLoader : PQSProjectionAerialQuadRelative
+    public class PQSProjectionAerialQuadRelativeLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (AP) ";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Tiling, default = 1000
         [ParserTarget("texTiling")]
-        public NumericParser<Single> TexTilingSetter
+        public NumericParser<float> TexTilingSetter
         {
-            get { return TexTiling; }
-            set { TexTiling = value; }
+            get => GetFloat("_texTiling");
+            set => SetFloat("_texTiling", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("texPower")]
-        public NumericParser<Single> TexPowerSetter
+        public NumericParser<float> TexPowerSetter
         {
-            get { return TexPower; }
-            set { TexPower = value; }
+            get => GetFloat("_texPower");
+            set => SetFloat("_texPower", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("multiPower")]
-        public NumericParser<Single> MultiPowerSetter
+        public NumericParser<float> MultiPowerSetter
         {
-            get { return MultiPower; }
-            set { MultiPower = value; }
+            get => GetFloat("_multiPower");
+            set => SetFloat("_multiPower", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar Start, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Steep Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Deep ground, default = "white" { }
         [ParserTarget("deepTex")]
-        public Texture2DParser DeepTexSetter
+        public MaterialTextureParser DeepTexSetter
         {
-            get { return DeepTex; }
-            set { DeepTex = value; }
+            get => null;
+            set => SetTexture("_deepTex", value);
         }
 
         [ParserTarget("deepTexScale")]
         public Vector2Parser DeepTexScaleSetter
         {
-            get { return DeepTexScale; }
-            set { DeepTexScale = value; }
+            get => GetTextureScale("_deepTex");
+            set => SetTextureScale("_deepTex", value);
         }
 
         [ParserTarget("deepTexOffset")]
         public Vector2Parser DeepTexOffsetSetter
         {
-            get { return DeepTexOffset; }
-            set { DeepTexOffset = value; }
+            get => GetTextureOffset("_deepTex");
+            set => SetTextureOffset("_deepTex", value);
         }
 
         // Deep MT, default = "white" { }
         [ParserTarget("deepMultiTex")]
-        public Texture2DParser DeepMultiTexSetter
+        public MaterialTextureParser DeepMultiTexSetter
         {
-            get { return DeepMultiTex; }
-            set { DeepMultiTex = value; }
+            get => null;
+            set => SetTexture("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexScale")]
         public Vector2Parser DeepMultiTexScaleSetter
         {
-            get { return DeepMultiTexScale; }
-            set { DeepMultiTexScale = value; }
+            get => GetTextureScale("_deepMultiTex");
+            set => SetTextureScale("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexOffset")]
         public Vector2Parser DeepMultiTexOffsetSetter
         {
-            get { return DeepMultiTexOffset; }
-            set { DeepMultiTexOffset = value; }
+            get => GetTextureOffset("_deepMultiTex");
+            set => SetTextureOffset("_deepMultiTex", value);
         }
 
         // Deep MT Tiling, default = 1
         [ParserTarget("deepMultiFactor")]
-        public NumericParser<Single> DeepMultiFactorSetter
+        public NumericParser<float> DeepMultiFactorSetter
         {
-            get { return DeepMultiFactor; }
-            set { DeepMultiFactor = value; }
+            get => GetFloat("_deepMultiFactor");
+            set => SetFloat("_deepMultiFactor", value);
         }
 
         // Main Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_mainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_mainTex");
+            set => SetTextureScale("_mainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_mainTex");
+            set => SetTextureOffset("_mainTex", value);
         }
 
         // Main MT, default = "white" { }
         [ParserTarget("mainMultiTex")]
-        public Texture2DParser MainMultiTexSetter
+        public MaterialTextureParser MainMultiTexSetter
         {
-            get { return MainMultiTex; }
-            set { MainMultiTex = value; }
+            get => null;
+            set => SetTexture("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexScale")]
         public Vector2Parser MainMultiTexScaleSetter
         {
-            get { return MainMultiTexScale; }
-            set { MainMultiTexScale = value; }
+            get => GetTextureScale("_mainMultiTex");
+            set => SetTextureScale("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexOffset")]
         public Vector2Parser MainMultiTexOffsetSetter
         {
-            get { return MainMultiTexOffset; }
-            set { MainMultiTexOffset = value; }
+            get => GetTextureOffset("_mainMultiTex");
+            set => SetTextureOffset("_mainMultiTex", value);
         }
 
         // Main MT Tiling, default = 1
         [ParserTarget("mainMultiFactor")]
-        public NumericParser<Single> MainMultiFactorSetter
+        public NumericParser<float> MainMultiFactorSetter
         {
-            get { return MainMultiFactor; }
-            set { MainMultiFactor = value; }
+            get => GetFloat("_mainMultiFactor");
+            set => SetFloat("_mainMultiFactor", value);
         }
 
         // High Ground, default = "white" { }
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High MT, default = "white" { }
         [ParserTarget("highMultiTex")]
-        public Texture2DParser HighMultiTexSetter
+        public MaterialTextureParser HighMultiTexSetter
         {
-            get { return HighMultiTex; }
-            set { HighMultiTex = value; }
+            get => null;
+            set => SetTexture("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexScale")]
         public Vector2Parser HighMultiTexScaleSetter
         {
-            get { return HighMultiTexScale; }
-            set { HighMultiTexScale = value; }
+            get => GetTextureScale("_highMultiTex");
+            set => SetTextureScale("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexOffset")]
         public Vector2Parser HighMultiTexOffsetSetter
         {
-            get { return HighMultiTexOffset; }
-            set { HighMultiTexOffset = value; }
+            get => GetTextureOffset("_highMultiTex");
+            set => SetTextureOffset("_highMultiTex", value);
         }
 
         // High MT Tiling, default = 1
         [ParserTarget("highMultiFactor")]
-        public NumericParser<Single> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactorSetter
         {
-            get { return HighMultiFactor; }
-            set { HighMultiFactor = value; }
+            get => GetFloat("_highMultiFactor");
+            set => SetFloat("_highMultiFactor", value);
         }
 
         // Snow, default = "white" { }
         [ParserTarget("snowTex")]
-        public Texture2DParser SnowTexSetter
+        public MaterialTextureParser SnowTexSetter
         {
-            get { return SnowTex; }
-            set { SnowTex = value; }
+            get => null;
+            set => SetTexture("_snowTex", value);
         }
 
         [ParserTarget("snowTexScale")]
         public Vector2Parser SnowTexScaleSetter
         {
-            get { return SnowTexScale; }
-            set { SnowTexScale = value; }
+            get => GetTextureScale("_snowTex");
+            set => SetTextureScale("_snowTex", value);
         }
 
         [ParserTarget("snowTexOffset")]
         public Vector2Parser SnowTexOffsetSetter
         {
-            get { return SnowTexOffset; }
-            set { SnowTexOffset = value; }
+            get => GetTextureOffset("_snowTex");
+            set => SetTextureOffset("_snowTex", value);
         }
 
         // Snow MT, default = "white" { }
         [ParserTarget("snowMultiTex")]
-        public Texture2DParser SnowMultiTexSetter
+        public MaterialTextureParser SnowMultiTexSetter
         {
-            get { return SnowMultiTex; }
-            set { SnowMultiTex = value; }
+            get => null;
+            set => SetTexture("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexScale")]
         public Vector2Parser SnowMultiTexScaleSetter
         {
-            get { return SnowMultiTexScale; }
-            set { SnowMultiTexScale = value; }
+            get => GetTextureScale("_snowMultiTex");
+            set => SetTextureScale("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexOffset")]
         public Vector2Parser SnowMultiTexOffsetSetter
         {
-            get { return SnowMultiTexOffset; }
-            set { SnowMultiTexOffset = value; }
+            get => GetTextureOffset("_snowMultiTex");
+            set => SetTextureOffset("_snowMultiTex", value);
         }
 
         // Snow MT Tiling, default = 1
         [ParserTarget("snowMultiFactor")]
-        public NumericParser<Single> SnowMultiFactorSetter
+        public NumericParser<float> SnowMultiFactorSetter
         {
-            get { return SnowMultiFactor; }
-            set { SnowMultiFactor = value; }
+            get => GetFloat("_snowMultiFactor");
+            set => SetFloat("_snowMultiFactor", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Deep Start, default = 0
         [ParserTarget("deepStart")]
-        public NumericParser<Single> DeepStartSetter
+        public NumericParser<float> DeepStartSetter
         {
-            get { return DeepStart; }
-            set { DeepStart = value; }
+            get => GetFloat("_deepStart");
+            set => SetFloat("_deepStart", value);
         }
 
         // Deep End, default = 0.3
         [ParserTarget("deepEnd")]
-        public NumericParser<Single> DeepEndSetter
+        public NumericParser<float> DeepEndSetter
         {
-            get { return DeepEnd; }
-            set { DeepEnd = value; }
+            get => GetFloat("_deepEnd");
+            set => SetFloat("_deepEnd", value);
         }
 
         // Main lower boundary start, default = 0
         [ParserTarget("mainLoStart")]
-        public NumericParser<Single> MainLoStartSetter
+        public NumericParser<float> MainLoStartSetter
         {
-            get { return MainLoStart; }
-            set { MainLoStart = value; }
+            get => GetFloat("_mainLoStart");
+            set => SetFloat("_mainLoStart", value);
         }
 
         // Main lower boundary end, default = 0.5
         [ParserTarget("mainLoEnd")]
-        public NumericParser<Single> MainLoEndSetter
+        public NumericParser<float> MainLoEndSetter
         {
-            get { return MainLoEnd; }
-            set { MainLoEnd = value; }
+            get => GetFloat("_mainLoEnd");
+            set => SetFloat("_mainLoEnd", value);
         }
 
         // Main upper boundary start, default = 0.3
         [ParserTarget("mainHiStart")]
-        public NumericParser<Single> MainHiStartSetter
+        public NumericParser<float> MainHiStartSetter
         {
-            get { return MainHiStart; }
-            set { MainHiStart = value; }
+            get => GetFloat("_mainHiStart");
+            set => SetFloat("_mainHiStart", value);
         }
 
         // Main upper boundary end, default = 0.5
         [ParserTarget("mainHiEnd")]
-        public NumericParser<Single> MainHiEndSetter
+        public NumericParser<float> MainHiEndSetter
         {
-            get { return MainHiEnd; }
-            set { MainHiEnd = value; }
+            get => GetFloat("_mainHiEnd");
+            set => SetFloat("_mainHiEnd", value);
         }
 
         // High lower boundary start, default = 0.6
         [ParserTarget("hiLoStart")]
-        public NumericParser<Single> HiLoStartSetter
+        public NumericParser<float> HiLoStartSetter
         {
-            get { return HiLoStart; }
-            set { HiLoStart = value; }
+            get => GetFloat("_hiLoStart");
+            set => SetFloat("_hiLoStart", value);
         }
 
         // High lower boundary end, default = 0.6
         [ParserTarget("hiLoEnd")]
-        public NumericParser<Single> HiLoEndSetter
+        public NumericParser<float> HiLoEndSetter
         {
-            get { return HiLoEnd; }
-            set { HiLoEnd = value; }
+            get => GetFloat("_hiLoEnd");
+            set => SetFloat("_hiLoEnd", value);
         }
 
         // High upper boundary start, default = 0.6
         [ParserTarget("hiHiStart")]
-        public NumericParser<Single> HiHiStartSetter
+        public NumericParser<float> HiHiStartSetter
         {
-            get { return HiHiStart; }
-            set { HiHiStart = value; }
+            get => GetFloat("_hiHiStart");
+            set => SetFloat("_hiHiStart", value);
         }
 
         // High upper boundary end, default = 0.9
         [ParserTarget("hiHiEnd")]
-        public NumericParser<Single> HiHiEndSetter
+        public NumericParser<float> HiHiEndSetter
         {
-            get { return HiHiEnd; }
-            set { HiHiEnd = value; }
+            get => GetFloat("_hiHiEnd");
+            set => SetFloat("_hiHiEnd", value);
         }
 
         // Snow Start, default = 0.9
         [ParserTarget("snowStart")]
-        public NumericParser<Single> SnowStartSetter
+        public NumericParser<float> SnowStartSetter
         {
-            get { return SnowStart; }
-            set { SnowStart = value; }
+            get => GetFloat("_snowStart");
+            set => SetFloat("_snowStart", value);
         }
 
         // Snow End, default = 1
         [ParserTarget("snowEnd")]
-        public NumericParser<Single> SnowEndSetter
+        public NumericParser<float> SnowEndSetter
         {
-            get { return SnowEnd; }
-            set { SnowEnd = value; }
+            get => GetFloat("_snowEnd");
+            set => SetFloat("_snowEnd", value);
         }
 
         // AP Fog Color, default = (0,0,1,1)
         [ParserTarget("fogColor")]
         public ColorParser FogColorSetter
         {
-            get { return FogColor; }
-            set { FogColor = value; }
+            get => GetColor("_fogColor");
+            set => SetColor("_fogColor", value);
         }
 
         // AP Height Fall Off, default = 1
         [ParserTarget("heightFallOff")]
-        public NumericParser<Single> HeightFallOffSetter
+        public NumericParser<float> HeightFallOffSetter
         {
-            get { return HeightFallOff; }
-            set { HeightFallOff = value; }
+            get => GetFloat("_heightFallOff");
+            set => SetFloat("_heightFallOff", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // AP Atmosphere Depth, default = 1
         [ParserTarget("atmosphereDepth")]
-        public NumericParser<Single> AtmosphereDepthSetter
+        public NumericParser<float> AtmosphereDepthSetter
         {
-            get { return AtmosphereDepth; }
-            set { AtmosphereDepth = value; }
+            get => GetFloat("_atmosphereDepth");
+            set => SetFloat("_atmosphereDepth", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
@@ -508,60 +509,36 @@ namespace Kopernicus.Configuration.MaterialLoader
         [KittopiaHideOption]
         public Gradient FogColorRampGradientSetter
         {
-            set
-            {
-                // Generate the ramp from a gradient
-                Texture2D ramp = new Texture2D(512, 1);
-                Color32[] colors = ramp.GetPixels32(0);
-                for (Int32 i = 0; i < colors.Length; i++)
-                {
-                    // Compute the position in the gradient
-                    Single k = (Single)i / colors.Length;
-                    colors[i] = value.ColorAt(k);
-                }
-
-                ramp.SetPixels32(colors, 0);
-                ramp.Apply(true, false);
-
-                // Set the color ramp
-                FogColorRamp = ramp;
-            }
+            set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSProjectionAerialQuadRelativeLoader()
-        {
-        }
+        public PQSProjectionAerialQuadRelativeLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSProjectionAerialQuadRelativeLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSProjectionAerialQuadRelativeLoader(Material material) : base(material)
-        {
-        }
+        public PQSProjectionAerialQuadRelativeLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
@@ -24,135 +24,130 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSProjectionFallbackLoader : PQSProjectionFallback
+    public class PQSProjectionFallbackLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (Fallback) ";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Tiling, default = 1000
         [ParserTarget("texTiling")]
-        public NumericParser<Single> TexTilingSetter
+        public NumericParser<float> TexTilingSetter
         {
-            get { return TexTiling; }
-            set { TexTiling = value; }
+            get => GetFloat("_texTiling");
+            set => SetFloat("_texTiling", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("texPower")]
-        public NumericParser<Single> TexPowerSetter
+        public NumericParser<float> TexPowerSetter
         {
-            get { return TexPower; }
-            set { TexPower = value; }
+            get => GetFloat("_texPower");
+            set => SetFloat("_texPower", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("multiPower")]
-        public NumericParser<Single> MultiPowerSetter
+        public NumericParser<float> MultiPowerSetter
         {
-            get { return MultiPower; }
-            set { MultiPower = value; }
+            get => GetFloat("_multiPower");
+            set => SetFloat("_multiPower", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar Start, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Multifactor, default = 0.5
         [ParserTarget("multiFactor")]
-        public NumericParser<Single> MultiFactorSetter
+        public NumericParser<float> MultiFactorSetter
         {
-            get { return MultiFactor; }
-            set { MultiFactor = value; }
+            get => GetFloat("_multiFactor");
+            set => SetFloat("_multiFactor", value);
         }
 
         // Main Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_mainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_mainTex");
+            set => SetTextureScale("_mainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_mainTex");
+            set => SetTextureOffset("_mainTex", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
+        public override NumericParser<bool> OnDemand { get; set; } = false;
 
         // Constructors
-        public PQSProjectionFallbackLoader()
-        {
-        }
+        public PQSProjectionFallbackLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSProjectionFallbackLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSProjectionFallbackLoader(Material material) : base(material)
-        {
-        }
+        public PQSProjectionFallbackLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
@@ -24,463 +24,457 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSProjectionSurfaceQuadLoader : PQSProjectionSurfaceQuad
+    public class PQSProjectionSurfaceQuadLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Near Tiling, default = 1000
         [ParserTarget("texTiling")]
-        public NumericParser<Single> TexTilingSetter
+        public NumericParser<float> TexTilingSetter
         {
-            get { return TexTiling; }
-            set { TexTiling = value; }
+            get => GetFloat("_texTiling");
+            set => SetFloat("_texTiling", value);
         }
 
         // Near Blend, default = 0.5
         [ParserTarget("texPower")]
-        public NumericParser<Single> TexPowerSetter
+        public NumericParser<float> TexPowerSetter
         {
-            get { return TexPower; }
-            set { TexPower = value; }
+            get => GetFloat("_texPower");
+            set => SetFloat("_texPower", value);
         }
 
         // Far Blend, default = 0.5
         [ParserTarget("multiPower")]
-        public NumericParser<Single> MultiPowerSetter
+        public NumericParser<float> MultiPowerSetter
         {
-            get { return MultiPower; }
-            set { MultiPower = value; }
+            get => GetFloat("_multiPower");
+            set => SetFloat("_multiPower", value);
         }
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<Single> GroundTexStartSetter
+        public NumericParser<float> GroundTexStartSetter
         {
-            get { return GroundTexStart; }
-            set { GroundTexStart = value; }
+            get => GetFloat("_groundTexStart");
+            set => SetFloat("_groundTexStart", value);
         }
 
         // NearFar Start, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<Single> GroundTexEndSetter
+        public NumericParser<float> GroundTexEndSetter
         {
-            get { return GroundTexEnd; }
-            set { GroundTexEnd = value; }
+            get => GetFloat("_groundTexEnd");
+            set => SetFloat("_groundTexEnd", value);
         }
 
         // Steep Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Deep ground, default = "white" { }
         [ParserTarget("deepTex")]
-        public Texture2DParser DeepTexSetter
+        public MaterialTextureParser DeepTexSetter
         {
-            get { return DeepTex; }
-            set { DeepTex = value; }
+            get => null;
+            set => SetTexture("_deepTex", value);
         }
 
         [ParserTarget("deepTexScale")]
         public Vector2Parser DeepTexScaleSetter
         {
-            get { return DeepTexScale; }
-            set { DeepTexScale = value; }
+            get => GetTextureScale("_deepTex");
+            set => SetTextureScale("_deepTex", value);
         }
 
         [ParserTarget("deepTexOffset")]
         public Vector2Parser DeepTexOffsetSetter
         {
-            get { return DeepTexOffset; }
-            set { DeepTexOffset = value; }
+            get => GetTextureOffset("_deepTex");
+            set => SetTextureOffset("_deepTex", value);
         }
 
         // Deep MT, default = "white" { }
         [ParserTarget("deepMultiTex")]
-        public Texture2DParser DeepMultiTexSetter
+        public MaterialTextureParser DeepMultiTexSetter
         {
-            get { return DeepMultiTex; }
-            set { DeepMultiTex = value; }
+            get => null;
+            set => SetTexture("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexScale")]
         public Vector2Parser DeepMultiTexScaleSetter
         {
-            get { return DeepMultiTexScale; }
-            set { DeepMultiTexScale = value; }
+            get => GetTextureScale("_deepMultiTex");
+            set => SetTextureScale("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexOffset")]
         public Vector2Parser DeepMultiTexOffsetSetter
         {
-            get { return DeepMultiTexOffset; }
-            set { DeepMultiTexOffset = value; }
+            get => GetTextureOffset("_deepMultiTex");
+            set => SetTextureOffset("_deepMultiTex", value);
         }
 
         // Deep MT Tiling, default = 1
         [ParserTarget("deepMultiFactor")]
-        public NumericParser<Single> DeepMultiFactorSetter
+        public NumericParser<float> DeepMultiFactorSetter
         {
-            get { return DeepMultiFactor; }
-            set { DeepMultiFactor = value; }
+            get => GetFloat("_deepMultiFactor");
+            set => SetFloat("_deepMultiFactor", value);
         }
 
         // Main Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_mainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_mainTex");
+            set => SetTextureScale("_mainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_mainTex");
+            set => SetTextureOffset("_mainTex", value);
         }
 
         // Main MT, default = "white" { }
         [ParserTarget("mainMultiTex")]
-        public Texture2DParser MainMultiTexSetter
+        public MaterialTextureParser MainMultiTexSetter
         {
-            get { return MainMultiTex; }
-            set { MainMultiTex = value; }
+            get => null;
+            set => SetTexture("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexScale")]
         public Vector2Parser MainMultiTexScaleSetter
         {
-            get { return MainMultiTexScale; }
-            set { MainMultiTexScale = value; }
+            get => GetTextureScale("_mainMultiTex");
+            set => SetTextureScale("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexOffset")]
         public Vector2Parser MainMultiTexOffsetSetter
         {
-            get { return MainMultiTexOffset; }
-            set { MainMultiTexOffset = value; }
+            get => GetTextureOffset("_mainMultiTex");
+            set => SetTextureOffset("_mainMultiTex", value);
         }
 
         // Main MT Tiling, default = 1
         [ParserTarget("mainMultiFactor")]
-        public NumericParser<Single> MainMultiFactorSetter
+        public NumericParser<float> MainMultiFactorSetter
         {
-            get { return MainMultiFactor; }
-            set { MainMultiFactor = value; }
+            get => GetFloat("_mainMultiFactor");
+            set => SetFloat("_mainMultiFactor", value);
         }
 
         // High Ground, default = "white" { }
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High MT, default = "white" { }
         [ParserTarget("highMultiTex")]
-        public Texture2DParser HighMultiTexSetter
+        public MaterialTextureParser HighMultiTexSetter
         {
-            get { return HighMultiTex; }
-            set { HighMultiTex = value; }
+            get => null;
+            set => SetTexture("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexScale")]
         public Vector2Parser HighMultiTexScaleSetter
         {
-            get { return HighMultiTexScale; }
-            set { HighMultiTexScale = value; }
+            get => GetTextureScale("_highMultiTex");
+            set => SetTextureScale("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexOffset")]
         public Vector2Parser HighMultiTexOffsetSetter
         {
-            get { return HighMultiTexOffset; }
-            set { HighMultiTexOffset = value; }
+            get => GetTextureOffset("_highMultiTex");
+            set => SetTextureOffset("_highMultiTex", value);
         }
 
         // High MT Tiling, default = 1
         [ParserTarget("highMultiFactor")]
-        public NumericParser<Single> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactorSetter
         {
-            get { return HighMultiFactor; }
-            set { HighMultiFactor = value; }
+            get => GetFloat("_highMultiFactor");
+            set => SetFloat("_highMultiFactor", value);
         }
 
         // Snow, default = "white" { }
         [ParserTarget("snowTex")]
-        public Texture2DParser SnowTexSetter
+        public MaterialTextureParser SnowTexSetter
         {
-            get { return SnowTex; }
-            set { SnowTex = value; }
+            get => null;
+            set => SetTexture("_snowTex", value);
         }
 
         [ParserTarget("snowTexScale")]
         public Vector2Parser SnowTexScaleSetter
         {
-            get { return SnowTexScale; }
-            set { SnowTexScale = value; }
+            get => GetTextureScale("_snowTex");
+            set => SetTextureScale("_snowTex", value);
         }
 
         [ParserTarget("snowTexOffset")]
         public Vector2Parser SnowTexOffsetSetter
         {
-            get { return SnowTexOffset; }
-            set { SnowTexOffset = value; }
+            get => GetTextureOffset("_snowTex");
+            set => SetTextureOffset("_snowTex", value);
         }
 
         // Snow MT, default = "white" { }
         [ParserTarget("snowMultiTex")]
-        public Texture2DParser SnowMultiTexSetter
+        public MaterialTextureParser SnowMultiTexSetter
         {
-            get { return SnowMultiTex; }
-            set { SnowMultiTex = value; }
+            get => null;
+            set => SetTexture("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexScale")]
         public Vector2Parser SnowMultiTexScaleSetter
         {
-            get { return SnowMultiTexScale; }
-            set { SnowMultiTexScale = value; }
+            get => GetTextureScale("_snowMultiTex");
+            set => SetTextureScale("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexOffset")]
         public Vector2Parser SnowMultiTexOffsetSetter
         {
-            get { return SnowMultiTexOffset; }
-            set { SnowMultiTexOffset = value; }
+            get => GetTextureOffset("_snowMultiTex");
+            set => SetTextureOffset("_snowMultiTex", value);
         }
 
         // Snow MT Tiling, default = 1
         [ParserTarget("snowMultiFactor")]
-        public NumericParser<Single> SnowMultiFactorSetter
+        public NumericParser<float> SnowMultiFactorSetter
         {
-            get { return SnowMultiFactor; }
-            set { SnowMultiFactor = value; }
+            get => GetFloat("_snowMultiFactor");
+            set => SetFloat("_snowMultiFactor", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Deep Start, default = 0
         [ParserTarget("deepStart")]
-        public NumericParser<Single> DeepStartSetter
+        public NumericParser<float> DeepStartSetter
         {
-            get { return DeepStart; }
-            set { DeepStart = value; }
+            get => GetFloat("_deepStart");
+            set => SetFloat("_deepStart", value);
         }
 
         // Deep End, default = 0.3
         [ParserTarget("deepEnd")]
-        public NumericParser<Single> DeepEndSetter
+        public NumericParser<float> DeepEndSetter
         {
-            get { return DeepEnd; }
-            set { DeepEnd = value; }
+            get => GetFloat("_deepEnd");
+            set => SetFloat("_deepEnd", value);
         }
 
         // Main lower boundary start, default = 0
         [ParserTarget("mainLoStart")]
-        public NumericParser<Single> MainLoStartSetter
+        public NumericParser<float> MainLoStartSetter
         {
-            get { return MainLoStart; }
-            set { MainLoStart = value; }
+            get => GetFloat("_mainLoStart");
+            set => SetFloat("_mainLoStart", value);
         }
 
         // Main lower boundary end, default = 0.5
         [ParserTarget("mainLoEnd")]
-        public NumericParser<Single> MainLoEndSetter
+        public NumericParser<float> MainLoEndSetter
         {
-            get { return MainLoEnd; }
-            set { MainLoEnd = value; }
+            get => GetFloat("_mainLoEnd");
+            set => SetFloat("_mainLoEnd", value);
         }
 
         // Main upper boundary start, default = 0.3
         [ParserTarget("mainHiStart")]
-        public NumericParser<Single> MainHiStartSetter
+        public NumericParser<float> MainHiStartSetter
         {
-            get { return MainHiStart; }
-            set { MainHiStart = value; }
+            get => GetFloat("_mainHiStart");
+            set => SetFloat("_mainHiStart", value);
         }
 
         // Main upper boundary end, default = 0.5
         [ParserTarget("mainHiEnd")]
-        public NumericParser<Single> MainHiEndSetter
+        public NumericParser<float> MainHiEndSetter
         {
-            get { return MainHiEnd; }
-            set { MainHiEnd = value; }
+            get => GetFloat("_mainHiEnd");
+            set => SetFloat("_mainHiEnd", value);
         }
 
         // High lower boundary start, default = 0.6
         [ParserTarget("hiLoStart")]
-        public NumericParser<Single> HiLoStartSetter
+        public NumericParser<float> HiLoStartSetter
         {
-            get { return HiLoStart; }
-            set { HiLoStart = value; }
+            get => GetFloat("_hiLoStart");
+            set => SetFloat("_hiLoStart", value);
         }
 
         // High lower boundary end, default = 0.6
         [ParserTarget("hiLoEnd")]
-        public NumericParser<Single> HiLoEndSetter
+        public NumericParser<float> HiLoEndSetter
         {
-            get { return HiLoEnd; }
-            set { HiLoEnd = value; }
+            get => GetFloat("_hiLoEnd");
+            set => SetFloat("_hiLoEnd", value);
         }
 
         // High upper boundary start, default = 0.6
         [ParserTarget("hiHiStart")]
-        public NumericParser<Single> HiHiStartSetter
+        public NumericParser<float> HiHiStartSetter
         {
-            get { return HiHiStart; }
-            set { HiHiStart = value; }
+            get => GetFloat("_hiHiStart");
+            set => SetFloat("_hiHiStart", value);
         }
 
         // High upper boundary end, default = 0.9
         [ParserTarget("hiHiEnd")]
-        public NumericParser<Single> HiHiEndSetter
+        public NumericParser<float> HiHiEndSetter
         {
-            get { return HiHiEnd; }
-            set { HiHiEnd = value; }
+            get => GetFloat("_hiHiEnd");
+            set => SetFloat("_hiHiEnd", value);
         }
 
         // Snow Start, default = 0.9
         [ParserTarget("snowStart")]
-        public NumericParser<Single> SnowStartSetter
+        public NumericParser<float> SnowStartSetter
         {
-            get { return SnowStart; }
-            set { SnowStart = value; }
+            get => GetFloat("_snowStart");
+            set => SetFloat("_snowStart", value);
         }
 
         // Snow End, default = 1
         [ParserTarget("snowEnd")]
-        public NumericParser<Single> SnowEndSetter
+        public NumericParser<float> SnowEndSetter
         {
-            get { return SnowEnd; }
-            set { SnowEnd = value; }
+            get => GetFloat("_snowEnd");
+            set => SetFloat("_snowEnd", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSProjectionSurfaceQuadLoader()
-        {
-        }
+        public PQSProjectionSurfaceQuadLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSProjectionSurfaceQuadLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSProjectionSurfaceQuadLoader(Material material) : base(material)
-        {
-        }
+        public PQSProjectionSurfaceQuadLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
@@ -24,379 +24,373 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSTriplanarZoomRotationLoader : PQSTriplanarZoomRotation
+    public class PQSTriplanarZoomRotationLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Factor, default = 10
         [ParserTarget("factor")]
-        public NumericParser<Single> FactorSetter
+        public NumericParser<float> FactorSetter
         {
-            get { return Factor; }
-            set { Factor = value; }
+            get => GetFloat("_factor");
+            set => SetFloat("_factor", value);
         }
 
         // Factor Blend Width, default = 0.1
         [ParserTarget("factorBlendWidth")]
-        public NumericParser<Single> FactorBlendWidthSetter
+        public NumericParser<float> FactorBlendWidthSetter
         {
-            get { return FactorBlendWidth; }
-            set { FactorBlendWidth = value; }
+            get => GetFloat("_factorBlendWidth");
+            set => SetFloat("_factorBlendWidth", value);
         }
 
         // Factor Rotation, default = 30
         [ParserTarget("factorRotation")]
-        public NumericParser<Single> FactorRotationSetter
+        public NumericParser<float> FactorRotationSetter
         {
-            get { return FactorRotation; }
-            set { FactorRotation = value; }
+            get => GetFloat("_factorRotation");
+            set => SetFloat("_factorRotation", value);
         }
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Specular Color, default = (0.2,0.2,0.2,0.2)
         [ParserTarget("specularColor")]
         public ColorParser SpecularColorSetter
         {
-            get { return SpecularColor; }
-            set { SpecularColor = value; }
+            get => GetColor("_specularColor");
+            set => SetColor("_specularColor", value);
         }
 
         // Brightness, default = 2
         [ParserTarget("albedoBrightness")]
-        public NumericParser<Single> AlbedoBrightnessSetter
+        public NumericParser<float> AlbedoBrightnessSetter
         {
-            get { return AlbedoBrightness; }
-            set { AlbedoBrightness = value; }
+            get => GetFloat("_albedoBrightness");
+            set => SetFloat("_albedoBrightness", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public Texture2DParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMapSetter
         {
-            get { return SteepBumpMap; }
-            set { SteepBumpMap = value; }
+            get => null;
+            set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
         public Vector2Parser SteepBumpMapScaleSetter
         {
-            get { return SteepBumpMapScale; }
-            set { SteepBumpMapScale = value; }
+            get => GetTextureScale("_steepBumpMap");
+            set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
         public Vector2Parser SteepBumpMapOffsetSetter
         {
-            get { return SteepBumpMapOffset; }
-            set { SteepBumpMapOffset = value; }
+            get => GetTextureOffset("_steepBumpMap");
+            set => SetTextureOffset("_steepBumpMap", value);
         }
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<Single> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTilingSetter
         {
-            get { return SteepNearTiling; }
-            set { SteepNearTiling = value; }
+            get => GetFloat("_steepNearTiling");
+            set => SetFloat("_steepNearTiling", value);
         }
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public Texture2DParser LowTexSetter
+        public MaterialTextureParser LowTexSetter
         {
-            get { return LowTex; }
-            set { LowTex = value; }
+            get => null;
+            set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
         public Vector2Parser LowTexScaleSetter
         {
-            get { return LowTexScale; }
-            set { LowTexScale = value; }
+            get => GetTextureScale("_lowTex");
+            set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
         public Vector2Parser LowTexOffsetSetter
         {
-            get { return LowTexOffset; }
-            set { LowTexOffset = value; }
+            get => GetTextureOffset("_lowTex");
+            set => SetTextureOffset("_lowTex", value);
         }
 
         // Low Tiling, default = 100000
         [ParserTarget("lowTiling")]
-        public NumericParser<Single> LowTilingSetter
+        public NumericParser<float> LowTilingSetter
         {
-            get { return LowTiling; }
-            set { LowTiling = value; }
+            get => GetFloat("_lowTiling");
+            set => SetFloat("_lowTiling", value);
         }
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public Texture2DParser MidTexSetter
+        public MaterialTextureParser MidTexSetter
         {
-            get { return MidTex; }
-            set { MidTex = value; }
+            get => null;
+            set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
         public Vector2Parser MidTexScaleSetter
         {
-            get { return MidTexScale; }
-            set { MidTexScale = value; }
+            get => GetTextureScale("_midTex");
+            set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
         public Vector2Parser MidTexOffsetSetter
         {
-            get { return MidTexOffset; }
-            set { MidTexOffset = value; }
+            get => GetTextureOffset("_midTex");
+            set => SetTextureOffset("_midTex", value);
         }
 
         // Mid Tiling, default = 100000
         [ParserTarget("midTiling")]
-        public NumericParser<Single> MidTilingSetter
+        public NumericParser<float> MidTilingSetter
         {
-            get { return MidTiling; }
-            set { MidTiling = value; }
+            get => GetFloat("_midTiling");
+            set => SetFloat("_midTiling", value);
         }
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public Texture2DParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMapSetter
         {
-            get { return MidBumpMap; }
-            set { MidBumpMap = value; }
+            get => null;
+            set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
         public Vector2Parser MidBumpMapScaleSetter
         {
-            get { return MidBumpMapScale; }
-            set { MidBumpMapScale = value; }
+            get => GetTextureScale("_midBumpMap");
+            set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
         public Vector2Parser MidBumpMapOffsetSetter
         {
-            get { return MidBumpMapOffset; }
-            set { MidBumpMapOffset = value; }
+            get => GetTextureOffset("_midBumpMap");
+            set => SetTextureOffset("_midBumpMap", value);
         }
 
         // Mid Bump Tiling, default = 100000
         [ParserTarget("midBumpTiling")]
-        public NumericParser<Single> MidBumpTilingSetter
+        public NumericParser<float> MidBumpTilingSetter
         {
-            get { return MidBumpTiling; }
-            set { MidBumpTiling = value; }
+            get => GetFloat("_midBumpTiling");
+            set => SetFloat("_midBumpTiling", value);
         }
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public Texture2DParser HighTexSetter
+        public MaterialTextureParser HighTexSetter
         {
-            get { return HighTex; }
-            set { HighTex = value; }
+            get => null;
+            set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
         public Vector2Parser HighTexScaleSetter
         {
-            get { return HighTexScale; }
-            set { HighTexScale = value; }
+            get => GetTextureScale("_highTex");
+            set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
         public Vector2Parser HighTexOffsetSetter
         {
-            get { return HighTexOffset; }
-            set { HighTexOffset = value; }
+            get => GetTextureOffset("_highTex");
+            set => SetTextureOffset("_highTex", value);
         }
 
         // High Tiling, default = 100000
         [ParserTarget("highTiling")]
-        public NumericParser<Single> HighTilingSetter
+        public NumericParser<float> HighTilingSetter
         {
-            get { return HighTiling; }
-            set { HighTiling = value; }
+            get => GetFloat("_highTiling");
+            set => SetFloat("_highTiling", value);
         }
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<Single> LowStartSetter
+        public NumericParser<float> LowStartSetter
         {
-            get { return LowStart; }
-            set { LowStart = value; }
+            get => GetFloat("_lowStart");
+            set => SetFloat("_lowStart", value);
         }
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<Single> LowEndSetter
+        public NumericParser<float> LowEndSetter
         {
-            get { return LowEnd; }
-            set { LowEnd = value; }
+            get => GetFloat("_lowEnd");
+            set => SetFloat("_lowEnd", value);
         }
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<Single> HighStartSetter
+        public NumericParser<float> HighStartSetter
         {
-            get { return HighStart; }
-            set { HighStart = value; }
+            get => GetFloat("_highStart");
+            set => SetFloat("_highStart", value);
         }
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<Single> HighEndSetter
+        public NumericParser<float> HighEndSetter
         {
-            get { return HighEnd; }
-            set { HighEnd = value; }
+            get => GetFloat("_highEnd");
+            set => SetFloat("_highEnd", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<Single> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistanceSetter
         {
-            get { return OceanFogDistance; }
-            set { OceanFogDistance = value; }
+            get => GetFloat("_oceanFogDistance");
+            set => SetFloat("_oceanFogDistance", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSTriplanarZoomRotationLoader()
-        {
-        }
+        public PQSTriplanarZoomRotationLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSTriplanarZoomRotationLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSTriplanarZoomRotationLoader(Material material) : base(material)
-        {
-        }
+        public PQSTriplanarZoomRotationLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
@@ -22,37 +22,54 @@
  *
  * https://kerbalspaceprogram.com
  */
+
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
+
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSTriplanarZoomRotationTextureArrayLoader : PQSTriplanarZoomRotationTextureArray
+    public class PQSTriplanarZoomRotationTextureArrayLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation Texture Array";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+
+        // The texture-atlas mod (see ModLoader/TextureAtlas.cs) hot-swaps the shader to one of
+        // the "- N Blend" permutations at runtime. They share the same property layout as the
+        // base shader, so they all map to this loader/wrapper.
+        public static bool UsesSameShader(Material m)
+        {
+            if (m == null) return false;
+            String n = m.shader.name;
+            return n == SHADER_NAME
+                || n == SHADER_NAME + " - 1 Blend"
+                || n == SHADER_NAME + " - 2 Blend"
+                || n == SHADER_NAME + " - 3 Blend"
+                || n == SHADER_NAME + " - 4 Blend";
+        }
+
         // Color Lerp Modifier, default = 1
         [ParserTarget("colorLerpModifier")]
-        public NumericParser<Single> ColorLerpModifierSetter
+        public NumericParser<float> ColorLerpModifierSetter
         {
-            get { return ColorLerpModifier; }
-            set { ColorLerpModifier = value; }
+            get => GetFloat("_ColorLerpModifier");
+            set => SetFloat("_ColorLerpModifier", value);
         }
+
         // Atlas Texture, default = 100000
         [ParserTarget("atlasTiling")]
-        public NumericParser<Single> AtlasTilingSetter
+        public NumericParser<float> AtlasTilingSetter
         {
-            get { return AtlasTiling; }
-            set { AtlasTiling = value; }
+            get => GetFloat("_AtlasTiling");
+            set => SetFloat("_AtlasTiling", value);
         }
 
         // Atlas Texture, default = "white" { }
@@ -70,7 +87,7 @@ namespace Kopernicus.Configuration.MaterialLoader
                 }
 
                 List<Texture2D> textures = value.Select(t => Utility.CreateReadable(t.Value)).ToList();
-                AtlasTex = KSPUtil.GenerateTexture2DArray(textures, TextureFormat.RGBA32, true);
+                Value.SetTexture("_AtlasTex", KSPUtil.GenerateTexture2DArray(textures, TextureFormat.RGBA32, true));
             }
         }
 
@@ -89,215 +106,209 @@ namespace Kopernicus.Configuration.MaterialLoader
                 }
 
                 List<Texture2D> textures = value.Select(t => Utility.CreateReadable(t.Value)).ToList();
-                NormalTex = KSPUtil.GenerateTexture2DArray(textures, TextureFormat.RGBA32, true);
+                Value.SetTexture("_NormalTex", KSPUtil.GenerateTexture2DArray(textures, TextureFormat.RGBA32, true));
             }
         }
+
         // Factor, default = 10
         [ParserTarget("factor")]
-        public NumericParser<Single> FactorSetter
+        public NumericParser<float> FactorSetter
         {
-            get { return Factor; }
-            set { Factor = value; }
+            get => GetFloat("_factor");
+            set => SetFloat("_factor", value);
         }
 
         // Factor Blend Width, default = 0.1
         [ParserTarget("factorBlendWidth")]
-        public NumericParser<Single> FactorBlendWidthSetter
+        public NumericParser<float> FactorBlendWidthSetter
         {
-            get { return FactorBlendWidth; }
-            set { FactorBlendWidth = value; }
+            get => GetFloat("_factorBlendWidth");
+            set => SetFloat("_factorBlendWidth", value);
         }
 
         // Factor Rotation, default = 30
         [ParserTarget("factorRotation")]
-        public NumericParser<Single> FactorRotationSetter
+        public NumericParser<float> FactorRotationSetter
         {
-            get { return FactorRotation; }
-            set { FactorRotation = value; }
+            get => GetFloat("_factorRotation");
+            set => SetFloat("_factorRotation", value);
         }
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<Single> SaturationSetter
+        public NumericParser<float> SaturationSetter
         {
-            get { return Saturation; }
-            set { Saturation = value; }
+            get => GetFloat("_saturation");
+            set => SetFloat("_saturation", value);
         }
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<Single> ContrastSetter
+        public NumericParser<float> ContrastSetter
         {
-            get { return Contrast; }
-            set { Contrast = value; }
+            get => GetFloat("_contrast");
+            set => SetFloat("_contrast", value);
         }
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
         public ColorParser TintColorSetter
         {
-            get { return TintColor; }
-            set { TintColor = value; }
+            get => GetColor("_tintColor");
+            set => SetColor("_tintColor", value);
         }
 
         // Specular Color, default = (0.2,0.2,0.2,0.2)
         [ParserTarget("specularColor")]
         public ColorParser SpecularColorSetter
         {
-            get { return SpecularColor; }
-            set { SpecularColor = value; }
+            get => GetColor("_specularColor");
+            set => SetColor("_specularColor", value);
         }
 
         // Brightness, default = 2
         [ParserTarget("albedoBrightness")]
-        public NumericParser<Single> AlbedoBrightnessSetter
+        public NumericParser<float> AlbedoBrightnessSetter
         {
-            get { return AlbedoBrightness; }
-            set { AlbedoBrightness = value; }
+            get => GetFloat("_albedoBrightness");
+            set => SetFloat("_albedoBrightness", value);
         }
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<Single> SteepPowerSetter
+        public NumericParser<float> SteepPowerSetter
         {
-            get { return SteepPower; }
-            set { SteepPower = value; }
+            get => GetFloat("_steepPower");
+            set => SetFloat("_steepPower", value);
         }
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<Single> SteepTexStartSetter
+        public NumericParser<float> SteepTexStartSetter
         {
-            get { return SteepTexStart; }
-            set { SteepTexStart = value; }
+            get => GetFloat("_steepTexStart");
+            set => SetFloat("_steepTexStart", value);
         }
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<Single> SteepTexEndSetter
+        public NumericParser<float> SteepTexEndSetter
         {
-            get { return SteepTexEnd; }
-            set { SteepTexEnd = value; }
+            get => GetFloat("_steepTexEnd");
+            set => SetFloat("_steepTexEnd", value);
         }
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public Texture2DParser SteepTexSetter
+        public MaterialTextureParser SteepTexSetter
         {
-            get { return SteepTex; }
-            set { SteepTex = value; }
+            get => null;
+            set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
         public Vector2Parser SteepTexScaleSetter
         {
-            get { return SteepTexScale; }
-            set { SteepTexScale = value; }
+            get => GetTextureScale("_steepTex");
+            set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
         public Vector2Parser SteepTexOffsetSetter
         {
-            get { return SteepTexOffset; }
-            set { SteepTexOffset = value; }
+            get => GetTextureOffset("_steepTex");
+            set => SetTextureOffset("_steepTex", value);
         }
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public Texture2DParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMapSetter
         {
-            get { return SteepBumpMap; }
-            set { SteepBumpMap = value; }
+            get => null;
+            set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
         public Vector2Parser SteepBumpMapScaleSetter
         {
-            get { return SteepBumpMapScale; }
-            set { SteepBumpMapScale = value; }
+            get => GetTextureScale("_steepBumpMap");
+            set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
         public Vector2Parser SteepBumpMapOffsetSetter
         {
-            get { return SteepBumpMapOffset; }
-            set { SteepBumpMapOffset = value; }
+            get => GetTextureOffset("_steepBumpMap");
+            set => SetTextureOffset("_steepBumpMap", value);
         }
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<Single> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTilingSetter
         {
-            get { return SteepNearTiling; }
-            set { SteepNearTiling = value; }
+            get => GetFloat("_steepNearTiling");
+            set => SetFloat("_steepNearTiling", value);
         }
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<Single> SteepTilingSetter
+        public NumericParser<float> SteepTilingSetter
         {
-            get { return SteepTiling; }
-            set { SteepTiling = value; }
+            get => GetFloat("_steepTiling");
+            set => SetFloat("_steepTiling", value);
         }
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<Single> GlobalDensitySetter
+        public NumericParser<float> GlobalDensitySetter
         {
-            get { return GlobalDensity; }
-            set { GlobalDensity = value; }
+            get => GetFloat("_globalDensity");
+            set => SetFloat("_globalDensity", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public Texture2DParser FogColorRampSetter
+        public MaterialTextureParser FogColorRampSetter
         {
-            get { return FogColorRamp; }
-            set { FogColorRamp = value; }
+            get => null;
+            set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
         public Vector2Parser FogColorRampScaleSetter
         {
-            get { return FogColorRampScale; }
-            set { FogColorRampScale = value; }
+            get => GetTextureScale("_fogColorRamp");
+            set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
         public Vector2Parser FogColorRampOffsetSetter
         {
-            get { return FogColorRampOffset; }
-            set { FogColorRampOffset = value; }
+            get => GetTextureOffset("_fogColorRamp");
+            set => SetTextureOffset("_fogColorRamp", value);
         }
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<Single> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacitySetter
         {
-            get { return PlanetOpacity; }
-            set { PlanetOpacity = value; }
+            get => GetFloat("_PlanetOpacity");
+            set => SetFloat("_PlanetOpacity", value);
         }
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<Single> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistanceSetter
         {
-            get { return OceanFogDistance; }
-            set { OceanFogDistance = value; }
+            get => GetFloat("_oceanFogDistance");
+            set => SetFloat("_oceanFogDistance", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public PQSTriplanarZoomRotationTextureArrayLoader()
-        {
-        }
+        public PQSTriplanarZoomRotationTextureArrayLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public PQSTriplanarZoomRotationTextureArrayLoader(String contents) : base(contents)
-        {
-        }
-
-        public PQSTriplanarZoomRotationTextureArrayLoader(Material material) : base(material)
-        {
-        }
+        public PQSTriplanarZoomRotationTextureArrayLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
@@ -24,62 +24,57 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    public class ParticleAddSmoothLoader : ParticleAddSmooth
+    public class ParticleAddSmoothLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Legacy Shaders/Particles/Additive (Soft)";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Particle Texture, default = "white" { }
         [ParserTarget("texture")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Soft Particles Factor, default = 1
         [ParserTarget("invFade")]
-        public NumericParser<Single> InvFadeSetter
+        public NumericParser<float> InvFadeSetter
         {
-            get { return InvFade; }
-            set { InvFade = value; }
+            get => GetFloat("_InvFade");
+            set => SetFloat("_InvFade", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public ParticleAddSmoothLoader()
-        {
-        }
+        public ParticleAddSmoothLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public ParticleAddSmoothLoader(String contents) : base(contents)
-        {
-        }
-
-        public ParticleAddSmoothLoader(Material material) : base(material)
-        {
-        }
+        public ParticleAddSmoothLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -24,11 +24,10 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
@@ -37,192 +36,170 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class ScaledPlanetRimAerialLoader : ScaledPlanetRimAerial
+    public class ScaledPlanetRimAerialLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial)";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
         public ColorParser SpecColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<Single> ShininessSetter
+        public NumericParser<float> ShininessSetter
         {
-            get { return Shininess; }
-            set { Shininess = value; }
+            get => GetFloat("_Shininess");
+            set => SetFloat("_Shininess", value);
         }
 
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("texture")]
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Normal map, default = "bump" { }
         [ParserTarget("normals")]
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<Single> OpacitySetter
+        public NumericParser<float> OpacitySetter
         {
-            get { return Opacity; }
-            set { Opacity = value; }
+            get => GetFloat("_Opacity");
+            set => SetFloat("_Opacity", value);
         }
 
         // Rim Power, default = 3
         [ParserTarget("rimPower")]
-        public NumericParser<Single> RimPowerSetter
+        public NumericParser<float> RimPowerSetter
         {
-            get { return RimPower; }
-            set { RimPower = value; }
+            get => GetFloat("_rimPower");
+            set => SetFloat("_rimPower", value);
         }
 
         // Rim Blend, default = 1
         [ParserTarget("rimBlend")]
-        public NumericParser<Single> RimBlendSetter
+        public NumericParser<float> RimBlendSetter
         {
-            get { return RimBlend; }
-            set { RimBlend = value; }
+            get => GetFloat("_rimBlend");
+            set => SetFloat("_rimBlend", value);
         }
 
         // RimColorRamp, default = "white" { }
         [ParserTarget("rimColorRamp")]
-        public Texture2DParser RimColorRampSetter
+        public MaterialTextureParser RimColorRampSetter
         {
-            get { return RimColorRamp; }
-            set { RimColorRamp = value; }
+            get => null;
+            set => SetTexture("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampScale")]
         public Vector2Parser RimColorRampScaleSetter
         {
-            get { return RimColorRampScale; }
-            set { RimColorRampScale = value; }
+            get => GetTextureScale("_rimColorRamp");
+            set => SetTextureScale("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampOffset")]
         public Vector2Parser RimColorRampOffsetSetter
         {
-            get { return RimColorRampOffset; }
-            set { RimColorRampOffset = value; }
+            get => GetTextureOffset("_rimColorRamp");
+            set => SetTextureOffset("_rimColorRamp", value);
         }
 
         [ParserTarget("Gradient")]
         [KittopiaHideOption]
         public Gradient RimColorRampGradientSetter
         {
-            set
-            {
-                // Generate the ramp from a gradient 
-                Texture2D ramp = new Texture2D(512, 1);
-                Color32[] colors = ramp.GetPixels32(0);
-                for (Int32 i = 0; i < colors.Length; i++)
-                {
-                    // Compute the position in the gradient 
-                    Single k = (Single)i / colors.Length;
-                    colors[i] = value.ColorAt(k);
-                }
-
-                ramp.SetPixels32(colors, 0);
-                ramp.Apply(true, false);
-
-                // Set the color ramp 
-                RimColorRamp = ramp;
-            }
+            set => SetGradient("_rimColorRamp", value);
         }
 
         // LightDirection, default = (1,0,0,0)
         [ParserTarget("localLightDirection")]
         public Vector4Parser LocalLightDirectionSetter
         {
-            get { return LocalLightDirection; }
-            set { LocalLightDirection = value; }
+            get => GetVector("_localLightDirection");
+            set => SetVector("_localLightDirection", value);
         }
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public Texture2DParser ResourceMapSetter
+        public MaterialTextureParser ResourceMapSetter
         {
-            get { return ResourceMap; }
-            set { ResourceMap = value; }
+            get => null;
+            set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
         public Vector2Parser ResourceMapScaleSetter
         {
-            get { return ResourceMapScale; }
-            set { ResourceMapScale = value; }
+            get => GetTextureScale("_ResourceMap");
+            set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
         public Vector2Parser ResourceMapOffsetSetter
         {
-            get { return ResourceMapOffset; }
-            set { ResourceMapOffset = value; }
+            get => GetTextureOffset("_ResourceMap");
+            set => SetTextureOffset("_ResourceMap", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public ScaledPlanetRimAerialLoader()
-        {
-        }
+        public ScaledPlanetRimAerialLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public ScaledPlanetRimAerialLoader(String contents) : base(contents)
-        {
-        }
-
-        public ScaledPlanetRimAerialLoader(Material material) : base(material)
-        {
-        }
+        public ScaledPlanetRimAerialLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Kopernicus Planetary System Modifier
  * -------------------------------------------------------------
  * This library is free software; you can redistribute it and/or
@@ -22,12 +22,12 @@
  *
  * https://kerbalspaceprogram.com
  */
+
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
 using UnityEngine;
@@ -36,192 +36,170 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class ScaledPlanetRimAerialStandardLoader : ScaledPlanetRimAerialStandard
+    public class ScaledPlanetRimAerialStandardLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial) Standard";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
         public ColorParser SpecColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<Single> ShininessSetter
+        public NumericParser<float> ShininessSetter
         {
-            get { return Shininess; }
-            set { Shininess = value; }
+            get => GetFloat("_Shininess");
+            set => SetFloat("_Shininess", value);
         }
 
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("texture")]
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Normal map, default = "bump" { }
         [ParserTarget("normals")]
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<Single> OpacitySetter
+        public NumericParser<float> OpacitySetter
         {
-            get { return Opacity; }
-            set { Opacity = value; }
+            get => GetFloat("_Opacity");
+            set => SetFloat("_Opacity", value);
         }
 
         // Rim Power, default = 3
         [ParserTarget("rimPower")]
-        public NumericParser<Single> RimPowerSetter
+        public NumericParser<float> RimPowerSetter
         {
-            get { return RimPower; }
-            set { RimPower = value; }
+            get => GetFloat("_rimPower");
+            set => SetFloat("_rimPower", value);
         }
 
         // Rim Blend, default = 1
         [ParserTarget("rimBlend")]
-        public NumericParser<Single> RimBlendSetter
+        public NumericParser<float> RimBlendSetter
         {
-            get { return RimBlend; }
-            set { RimBlend = value; }
+            get => GetFloat("_rimBlend");
+            set => SetFloat("_rimBlend", value);
         }
 
         // RimColorRamp, default = "white" { }
         [ParserTarget("rimColorRamp")]
-        public Texture2DParser RimColorRampSetter
+        public MaterialTextureParser RimColorRampSetter
         {
-            get { return RimColorRamp; }
-            set { RimColorRamp = value; }
+            get => null;
+            set => SetTexture("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampScale")]
         public Vector2Parser RimColorRampScaleSetter
         {
-            get { return RimColorRampScale; }
-            set { RimColorRampScale = value; }
+            get => GetTextureScale("_rimColorRamp");
+            set => SetTextureScale("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampOffset")]
         public Vector2Parser RimColorRampOffsetSetter
         {
-            get { return RimColorRampOffset; }
-            set { RimColorRampOffset = value; }
+            get => GetTextureOffset("_rimColorRamp");
+            set => SetTextureOffset("_rimColorRamp", value);
         }
 
         [ParserTarget("Gradient")]
         [KittopiaHideOption]
         public Gradient RimColorRampGradientSetter
         {
-            set
-            {
-                // Generate the ramp from a gradient 
-                Texture2D ramp = new Texture2D(512, 1);
-                Color32[] colors = ramp.GetPixels32(0);
-                for (Int32 i = 0; i < colors.Length; i++)
-                {
-                    // Compute the position in the gradient 
-                    Single k = (Single)i / colors.Length;
-                    colors[i] = value.ColorAt(k);
-                }
-
-                ramp.SetPixels32(colors, 0);
-                ramp.Apply(true, false);
-
-                // Set the color ramp 
-                RimColorRamp = ramp;
-            }
+            set => SetGradient("_rimColorRamp", value);
         }
 
         // LightDirection, default = (1,0,0,0)
         [ParserTarget("localLightDirection")]
         public Vector4Parser LocalLightDirectionSetter
         {
-            get { return LocalLightDirection; }
-            set { LocalLightDirection = value; }
+            get => GetVector("_localLightDirection");
+            set => SetVector("_localLightDirection", value);
         }
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public Texture2DParser ResourceMapSetter
+        public MaterialTextureParser ResourceMapSetter
         {
-            get { return ResourceMap; }
-            set { ResourceMap = value; }
+            get => null;
+            set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
         public Vector2Parser ResourceMapScaleSetter
         {
-            get { return ResourceMapScale; }
-            set { ResourceMapScale = value; }
+            get => GetTextureScale("_ResourceMap");
+            set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
         public Vector2Parser ResourceMapOffsetSetter
         {
-            get { return ResourceMapOffset; }
-            set { ResourceMapOffset = value; }
+            get => GetTextureOffset("_ResourceMap");
+            set => SetTextureOffset("_ResourceMap", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public ScaledPlanetRimAerialStandardLoader()
-        {
-        }
+        public ScaledPlanetRimAerialStandardLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public ScaledPlanetRimAerialStandardLoader(String contents) : base(contents)
-        {
-        }
-
-        public ScaledPlanetRimAerialStandardLoader(Material material) : base(material)
-        {
-        }
+        public ScaledPlanetRimAerialStandardLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
@@ -24,147 +24,141 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class ScaledPlanetRimLightLoader : ScaledPlanetRimLight
+    public class ScaledPlanetRimLightLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/Scaled Planet (RimLight)";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
         public ColorParser SpecColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<Single> ShininessSetter
+        public NumericParser<float> ShininessSetter
         {
-            get { return Shininess; }
-            set { Shininess = value; }
+            get => GetFloat("_Shininess");
+            set => SetFloat("_Shininess", value);
         }
 
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Normalmap, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<Single> OpacitySetter
+        public NumericParser<float> OpacitySetter
         {
-            get { return Opacity; }
-            set { Opacity = value; }
+            get => GetFloat("_Opacity");
+            set => SetFloat("_Opacity", value);
         }
 
         // Rim Color, default = (0.26,0.19,0.16,0)
         [ParserTarget("rimColor")]
         public ColorParser RimColorSetter
         {
-            get { return RimColor; }
-            set { RimColor = value; }
+            get => GetColor("_RimColor");
+            set => SetColor("_RimColor", value);
         }
 
         // Rim Power, default = 3
         [ParserTarget("rimPower")]
-        public NumericParser<Single> RimPowerSetter
+        public NumericParser<float> RimPowerSetter
         {
-            get { return RimPower; }
-            set { RimPower = value; }
+            get => GetFloat("_RimPower");
+            set => SetFloat("_RimPower", value);
         }
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public Texture2DParser ResourceMapSetter
+        public MaterialTextureParser ResourceMapSetter
         {
-            get { return ResourceMap; }
-            set { ResourceMap = value; }
+            get => null;
+            set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
         public Vector2Parser ResourceMapScaleSetter
         {
-            get { return ResourceMapScale; }
-            set { ResourceMapScale = value; }
+            get => GetTextureScale("_ResourceMap");
+            set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
         public Vector2Parser ResourceMapOffsetSetter
         {
-            get { return ResourceMapOffset; }
-            set { ResourceMapOffset = value; }
+            get => GetTextureOffset("_ResourceMap");
+            set => SetTextureOffset("_ResourceMap", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public ScaledPlanetRimLightLoader()
-        {
-        }
+        public ScaledPlanetRimLightLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public ScaledPlanetRimLightLoader(String contents) : base(contents)
-        {
-        }
-
-        public ScaledPlanetRimLightLoader(Material material) : base(material)
-        {
-        }
+        public ScaledPlanetRimLightLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
@@ -24,133 +24,127 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class ScaledPlanetSimpleLoader : ScaledPlanetSimple
+    public class ScaledPlanetSimpleLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Terrain/Scaled Planet (Simple)";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
         public ColorParser ColorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
         public ColorParser SpecColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<Single> ShininessSetter
+        public NumericParser<float> ShininessSetter
         {
-            get { return Shininess; }
-            set { Shininess = value; }
+            get => GetFloat("_Shininess");
+            set => SetFloat("_Shininess", value);
         }
 
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("texture")]
         [ParserTarget("mainTex")]
-        public Texture2DParser MainTexSetter
+        public MaterialTextureParser MainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser MainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser MainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Normal map, default = "bump" { }
         [ParserTarget("normals")]
         [ParserTarget("bumpMap")]
-        public Texture2DParser BumpMapSetter
+        public MaterialTextureParser BumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser BumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser BumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<Single> OpacitySetter
+        public NumericParser<float> OpacitySetter
         {
-            get { return Opacity; }
-            set { Opacity = value; }
+            get => GetFloat("_Opacity");
+            set => SetFloat("_Opacity", value);
         }
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public Texture2DParser ResourceMapSetter
+        public MaterialTextureParser ResourceMapSetter
         {
-            get { return ResourceMap; }
-            set { ResourceMap = value; }
+            get => null;
+            set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
         public Vector2Parser ResourceMapScaleSetter
         {
-            get { return ResourceMapScale; }
-            set { ResourceMapScale = value; }
+            get => GetTextureScale("_ResourceMap");
+            set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
         public Vector2Parser ResourceMapOffsetSetter
         {
-            get { return ResourceMapOffset; }
-            set { ResourceMapOffset = value; }
+            get => GetTextureOffset("_ResourceMap");
+            set => SetTextureOffset("_ResourceMap", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public ScaledPlanetSimpleLoader()
-        {
-        }
+        public ScaledPlanetSimpleLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public ScaledPlanetSimpleLoader(String contents) : base(contents)
-        {
-        }
-
-        public ScaledPlanetSimpleLoader(Material material) : base(material)
-        {
-        }
+        public ScaledPlanetSimpleLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
@@ -24,368 +24,362 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [RequireConfigType(ConfigType.Node)]
-    public class StandardLoader : Standard
+    public class StandardLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Standard";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Color, default = (1.000000,1.000000,1.000000,1.000000)
         [ParserTarget("color", Optional = true)]
         public ColorParser colorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Albedo, default = "white" { }
         [ParserTarget("mainTex", Optional = true)]
-        public Texture2DParser mainTexSetter
+        public MaterialTextureParser mainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale", Optional = true)]
         public Vector2Parser mainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset", Optional = true)]
         public Vector2Parser mainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Alpha Cutoff, default = 0.500000
         [ParserTarget("cutoff", Optional = true)]
-        public NumericParser<Single> cutoffSetter
+        public NumericParser<float> cutoffSetter
         {
-            get { return Cutoff; }
-            set { Cutoff = value; }
+            get => GetFloat("_Cutoff");
+            set => SetFloat("_Cutoff", value);
         }
 
         // Smoothness, default = 0.500000
         [ParserTarget("glossiness", Optional = true)]
-        public NumericParser<Single> glossinessSetter
+        public NumericParser<float> glossinessSetter
         {
-            get { return Glossiness; }
-            set { Glossiness = value; }
+            get => GetFloat("_Glossiness");
+            set => SetFloat("_Glossiness", value);
         }
 
         // Smoothness Scale, default = 1.000000
         [ParserTarget("glossMapScale", Optional = true)]
-        public NumericParser<Single> glossMapScaleSetter
+        public NumericParser<float> glossMapScaleSetter
         {
-            get { return GlossMapScale; }
-            set { GlossMapScale = value; }
+            get => GetFloat("_GlossMapScale");
+            set => SetFloat("_GlossMapScale", value);
         }
 
         // Smoothness texture channel, default = 0.000000
         [ParserTarget("smoothnessTextureChannel", Optional = true)]
-        public EnumParser<TextureChannel> smoothnessTextureChannelSetter
+        public NumericParser<float> smoothnessTextureChannelSetter
         {
-            get { return SmoothnessTextureChannel; }
-            set { SmoothnessTextureChannel = value; }
+            get => GetFloat("_SmoothnessTextureChannel");
+            set => SetFloat("_SmoothnessTextureChannel", value);
         }
 
         // Metallic, default = 0.000000
         [ParserTarget("metallic", Optional = true)]
-        public NumericParser<Single> metallicSetter
+        public NumericParser<float> metallicSetter
         {
-            get { return Metallic; }
-            set { Metallic = value; }
+            get => GetFloat("_Metallic");
+            set => SetFloat("_Metallic", value);
         }
 
         // Metallic, default = "white" { }
         [ParserTarget("metallicGlossMap", Optional = true)]
-        public Texture2DParser metallicGlossMapSetter
+        public MaterialTextureParser metallicGlossMapSetter
         {
-            get { return MetallicGlossMap; }
-            set { MetallicGlossMap = value; }
+            get => null;
+            set => SetTexture("_MetallicGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapScale", Optional = true)]
         public Vector2Parser metallicGlossMapScaleSetter
         {
-            get { return MetallicGlossMapScale; }
-            set { MetallicGlossMapScale = value; }
+            get => GetTextureScale("_MetallicGlossMap");
+            set => SetTextureScale("_MetallicGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapOffset", Optional = true)]
         public Vector2Parser metallicGlossMapOffsetSetter
         {
-            get { return MetallicGlossMapOffset; }
-            set { MetallicGlossMapOffset = value; }
+            get => GetTextureOffset("_MetallicGlossMap");
+            set => SetTextureOffset("_MetallicGlossMap", value);
         }
 
         // Specular Highlights, default = 1.000000
         [ParserTarget("specularHighlights", Optional = true)]
-        public NumericParser<Boolean> specularHighlightsSetter
+        public NumericParser<float> specularHighlightsSetter
         {
-            get { return SpecularHighlights; }
-            set { SpecularHighlights = value; }
+            get => GetFloat("_SpecularHighlights");
+            set => SetFloat("_SpecularHighlights", value);
         }
 
         // Glossy Reflections, default = 1.000000
         [ParserTarget("glossyReflections", Optional = true)]
-        public NumericParser<Boolean> glossyReflectionsSetter
+        public NumericParser<float> glossyReflectionsSetter
         {
-            get { return GlossyReflections; }
-            set { GlossyReflections = value; }
+            get => GetFloat("_GlossyReflections");
+            set => SetFloat("_GlossyReflections", value);
         }
 
         // Scale, default = 1.000000
         [ParserTarget("bumpScale", Optional = true)]
-        public NumericParser<Single> bumpScaleSetter
+        public NumericParser<float> bumpScaleSetter
         {
-            get { return BumpScale; }
-            set { BumpScale = value; }
+            get => GetFloat("_BumpScale");
+            set => SetFloat("_BumpScale", value);
         }
 
         // Normal Map, default = "bump" { }
         [ParserTarget("bumpMap", Optional = true)]
-        public Texture2DParser bumpMapSetter
+        public MaterialTextureParser bumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale", Optional = true)]
         public Vector2Parser bumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset", Optional = true)]
         public Vector2Parser bumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Height Scale, default = 0.020000
         [ParserTarget("parallax", Optional = true)]
-        public NumericParser<Single> parallaxSetter
+        public NumericParser<float> parallaxSetter
         {
-            get { return Parallax; }
-            set { Parallax = value; }
+            get => GetFloat("_Parallax");
+            set => SetFloat("_Parallax", value);
         }
 
         // Height Map, default = "black" { }
         [ParserTarget("parallaxMap", Optional = true)]
-        public Texture2DParser parallaxMapSetter
+        public MaterialTextureParser parallaxMapSetter
         {
-            get { return ParallaxMap; }
-            set { ParallaxMap = value; }
+            get => null;
+            set => SetTexture("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapScale", Optional = true)]
         public Vector2Parser parallaxMapScaleSetter
         {
-            get { return ParallaxMapScale; }
-            set { ParallaxMapScale = value; }
+            get => GetTextureScale("_ParallaxMap");
+            set => SetTextureScale("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapOffset", Optional = true)]
         public Vector2Parser parallaxMapOffsetSetter
         {
-            get { return ParallaxMapOffset; }
-            set { ParallaxMapOffset = value; }
+            get => GetTextureOffset("_ParallaxMap");
+            set => SetTextureOffset("_ParallaxMap", value);
         }
 
         // Strength, default = 1.000000
         [ParserTarget("occlusionStrength", Optional = true)]
-        public NumericParser<Single> occlusionStrengthSetter
+        public NumericParser<float> occlusionStrengthSetter
         {
-            get { return OcclusionStrength; }
-            set { OcclusionStrength = value; }
+            get => GetFloat("_OcclusionStrength");
+            set => SetFloat("_OcclusionStrength", value);
         }
 
         // Occlusion, default = "white" { }
         [ParserTarget("occlusionMap", Optional = true)]
-        public Texture2DParser occlusionMapSetter
+        public MaterialTextureParser occlusionMapSetter
         {
-            get { return OcclusionMap; }
-            set { OcclusionMap = value; }
+            get => null;
+            set => SetTexture("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapScale", Optional = true)]
         public Vector2Parser occlusionMapScaleSetter
         {
-            get { return OcclusionMapScale; }
-            set { OcclusionMapScale = value; }
+            get => GetTextureScale("_OcclusionMap");
+            set => SetTextureScale("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapOffset", Optional = true)]
         public Vector2Parser occlusionMapOffsetSetter
         {
-            get { return OcclusionMapOffset; }
-            set { OcclusionMapOffset = value; }
+            get => GetTextureOffset("_OcclusionMap");
+            set => SetTextureOffset("_OcclusionMap", value);
         }
 
         // Color, default = (0.000000,0.000000,0.000000,1.000000)
         [ParserTarget("emissionColor", Optional = true)]
         public ColorParser emissionColorSetter
         {
-            get { return EmissionColor; }
-            set { EmissionColor = value; }
+            get => GetColor("_EmissionColor");
+            set => SetColor("_EmissionColor", value);
         }
 
         // Emission, default = "white" { }
         [ParserTarget("emissionMap", Optional = true)]
-        public Texture2DParser emissionMapSetter
+        public MaterialTextureParser emissionMapSetter
         {
-            get { return EmissionMap; }
-            set { EmissionMap = value; }
+            get => null;
+            set => SetTexture("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapScale", Optional = true)]
         public Vector2Parser emissionMapScaleSetter
         {
-            get { return EmissionMapScale; }
-            set { EmissionMapScale = value; }
+            get => GetTextureScale("_EmissionMap");
+            set => SetTextureScale("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapOffset", Optional = true)]
         public Vector2Parser emissionMapOffsetSetter
         {
-            get { return EmissionMapOffset; }
-            set { EmissionMapOffset = value; }
+            get => GetTextureOffset("_EmissionMap");
+            set => SetTextureOffset("_EmissionMap", value);
         }
 
         // Detail Mask, default = "white" { }
         [ParserTarget("detailMask", Optional = true)]
-        public Texture2DParser detailMaskSetter
+        public MaterialTextureParser detailMaskSetter
         {
-            get { return DetailMask; }
-            set { DetailMask = value; }
+            get => null;
+            set => SetTexture("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskScale", Optional = true)]
         public Vector2Parser detailMaskScaleSetter
         {
-            get { return DetailMaskScale; }
-            set { DetailMaskScale = value; }
+            get => GetTextureScale("_DetailMask");
+            set => SetTextureScale("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskOffset", Optional = true)]
         public Vector2Parser detailMaskOffsetSetter
         {
-            get { return DetailMaskOffset; }
-            set { DetailMaskOffset = value; }
+            get => GetTextureOffset("_DetailMask");
+            set => SetTextureOffset("_DetailMask", value);
         }
 
         // Detail Albedo x2, default = "grey" { }
         [ParserTarget("detailAlbedoMap", Optional = true)]
-        public Texture2DParser detailAlbedoMapSetter
+        public MaterialTextureParser detailAlbedoMapSetter
         {
-            get { return DetailAlbedoMap; }
-            set { DetailAlbedoMap = value; }
+            get => null;
+            set => SetTexture("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapScale", Optional = true)]
         public Vector2Parser detailAlbedoMapScaleSetter
         {
-            get { return DetailAlbedoMapScale; }
-            set { DetailAlbedoMapScale = value; }
+            get => GetTextureScale("_DetailAlbedoMap");
+            set => SetTextureScale("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapOffset", Optional = true)]
         public Vector2Parser detailAlbedoMapOffsetSetter
         {
-            get { return DetailAlbedoMapOffset; }
-            set { DetailAlbedoMapOffset = value; }
+            get => GetTextureOffset("_DetailAlbedoMap");
+            set => SetTextureOffset("_DetailAlbedoMap", value);
         }
 
         // Normal Map, default = "bump" { }
         [ParserTarget("detailNormalMap", Optional = true)]
-        public Texture2DParser detailNormalMapSetter
+        public MaterialTextureParser detailNormalMapSetter
         {
-            get { return DetailNormalMap; }
-            set { DetailNormalMap = value; }
+            get => null;
+            set => SetTexture("_DetailNormalMap", value);
         }
 
         // Scale, default = 1.000000
         [ParserTarget("detailNormalMapScale", Optional = true)]
         public Vector2Parser detailNormalMapScaleSetter
         {
-            get { return DetailNormalMapScale; }
-            set { DetailNormalMapScale = value; }
+            get => GetTextureScale("_DetailNormalMap");
+            set => SetTextureScale("_DetailNormalMap", value);
         }
 
         [ParserTarget("detailNormalMapOffset", Optional = true)]
         public Vector2Parser detailNormalMapOffsetSetter
         {
-            get { return DetailNormalMapOffset; }
-            set { DetailNormalMapOffset = value; }
+            get => GetTextureOffset("_DetailNormalMap");
+            set => SetTextureOffset("_DetailNormalMap", value);
         }
 
         // UV Set for secondary textures, default = 0.000000
         [ParserTarget("UVSec", Optional = true)]
-        public EnumParser<UvSet> UVSecSetter
+        public NumericParser<float> UVSecSetter
         {
-            get { return UvSec; }
-            set { UvSec = value; }
+            get => GetFloat("_UVSec");
+            set => SetFloat("_UVSec", value);
         }
 
         // __mode, default = 0.000000
         [ParserTarget("mode", Optional = true)]
-        public EnumParser<BlendMode> modeSetter
+        public NumericParser<float> modeSetter
         {
-            get { return Mode; }
-            set { Mode = value; }
+            get => GetFloat("_Mode");
+            set => SetFloat("_Mode", value);
         }
 
         // __src, default = 1.000000
         [ParserTarget("srcBlend", Optional = true)]
-        public NumericParser<Single> srcBlendSetter
+        public NumericParser<float> srcBlendSetter
         {
-            get { return SrcBlend; }
-            set { SrcBlend = value; }
+            get => GetFloat("_SrcBlend");
+            set => SetFloat("_SrcBlend", value);
         }
 
         // __dst, default = 0.000000
         [ParserTarget("dstBlend", Optional = true)]
-        public NumericParser<Single> dstBlendSetter
+        public NumericParser<float> dstBlendSetter
         {
-            get { return DstBlend; }
-            set { DstBlend = value; }
+            get => GetFloat("_DstBlend");
+            set => SetFloat("_DstBlend", value);
         }
 
         // __zw, default = 1.000000
         [ParserTarget("ZWrite", Optional = true)]
-        public NumericParser<Single> ZWriteSetter
+        public NumericParser<float> ZWriteSetter
         {
-            get { return ZWrite; }
-            set { ZWrite = value; }
+            get => GetFloat("_ZWrite");
+            set => SetFloat("_ZWrite", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public StandardLoader()
-        {
-        }
+        public StandardLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public StandardLoader(String contents) : base(contents)
-        {
-        }
-
-        public StandardLoader(Material material) : base(material)
-        {
-        }
+        public StandardLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
@@ -24,368 +24,362 @@
  */
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
 
 namespace Kopernicus.Configuration.MaterialLoader
 {
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [RequireConfigType(ConfigType.Node)]
-    public class StandardSpecularLoader : StandardSpecular
+    public class StandardSpecularLoader : BaseMaterialLoader
     {
+        private const String SHADER_NAME = "Standard (Specular setup)";
+        private static readonly Shader Shader = Shader.Find(SHADER_NAME);
+        public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
+
         // Color, default = (1.000000,1.000000,1.000000,1.000000)
         [ParserTarget("color")]
         public ColorParser colorSetter
         {
-            get { return Color; }
-            set { Color = value; }
+            get => GetColor("_Color");
+            set => SetColor("_Color", value);
         }
 
         // Albedo, default = "white" { }
         [ParserTarget("mainTex")]
-        public Texture2DParser mainTexSetter
+        public MaterialTextureParser mainTexSetter
         {
-            get { return MainTex; }
-            set { MainTex = value; }
+            get => null;
+            set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
         public Vector2Parser mainTexScaleSetter
         {
-            get { return MainTexScale; }
-            set { MainTexScale = value; }
+            get => GetTextureScale("_MainTex");
+            set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
         public Vector2Parser mainTexOffsetSetter
         {
-            get { return MainTexOffset; }
-            set { MainTexOffset = value; }
+            get => GetTextureOffset("_MainTex");
+            set => SetTextureOffset("_MainTex", value);
         }
 
         // Alpha Cutoff, default = 0.500000
         [ParserTarget("cutoff")]
-        public NumericParser<Single> cutoffSetter
+        public NumericParser<float> cutoffSetter
         {
-            get { return Cutoff; }
-            set { Cutoff = value; }
+            get => GetFloat("_Cutoff");
+            set => SetFloat("_Cutoff", value);
         }
 
         // Smoothness, default = 0.500000
         [ParserTarget("glossiness")]
-        public NumericParser<Single> glossinessSetter
+        public NumericParser<float> glossinessSetter
         {
-            get { return Glossiness; }
-            set { Glossiness = value; }
+            get => GetFloat("_Glossiness");
+            set => SetFloat("_Glossiness", value);
         }
 
         // Smoothness Scale, default = 1.000000
         [ParserTarget("glossMapScale")]
-        public NumericParser<Single> glossMapScaleSetter
+        public NumericParser<float> glossMapScaleSetter
         {
-            get { return GlossMapScale; }
-            set { GlossMapScale = value; }
+            get => GetFloat("_GlossMapScale");
+            set => SetFloat("_GlossMapScale", value);
         }
 
         // Smoothness texture channel, default = 0.000000
         [ParserTarget("smoothnessTextureChannel")]
-        public EnumParser<TextureChannel> smoothnessTextureChannelSetter
+        public NumericParser<float> smoothnessTextureChannelSetter
         {
-            get { return SmoothnessTextureChannel; }
-            set { SmoothnessTextureChannel = value; }
+            get => GetFloat("_SmoothnessTextureChannel");
+            set => SetFloat("_SmoothnessTextureChannel", value);
         }
 
         // Specular, default = (0.2,0.2,0.2,1)
         [ParserTarget("specColor")]
         public ColorParser specColorSetter
         {
-            get { return SpecColor; }
-            set { SpecColor = value; }
+            get => GetColor("_SpecColor");
+            set => SetColor("_SpecColor", value);
         }
 
         // Specular, default = "white" { }
         [ParserTarget("specGlossMap")]
-        public Texture2DParser specGlossMapSetter
+        public MaterialTextureParser specGlossMapSetter
         {
-            get { return SpecGlossMap; }
-            set { SpecGlossMap = value; }
+            get => null;
+            set => SetTexture("_SpecGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapScale")]
         public Vector2Parser metallicGlossMapScaleSetter
         {
-            get { return MetallicGlossMapScale; }
-            set { MetallicGlossMapScale = value; }
+            get => GetTextureScale("_SpecGlossMap");
+            set => SetTextureScale("_SpecGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapOffset")]
         public Vector2Parser metallicGlossMapOffsetSetter
         {
-            get { return MetallicGlossMapOffset; }
-            set { MetallicGlossMapOffset = value; }
+            get => GetTextureOffset("_SpecGlossMap");
+            set => SetTextureOffset("_SpecGlossMap", value);
         }
 
         // Specular Highlights, default = 1.000000
         [ParserTarget("specularHighlights")]
-        public NumericParser<Boolean> specularHighlightsSetter
+        public NumericParser<float> specularHighlightsSetter
         {
-            get { return SpecularHighlights; }
-            set { SpecularHighlights = value; }
+            get => GetFloat("_SpecularHighlights");
+            set => SetFloat("_SpecularHighlights", value);
         }
 
         // Glossy Reflections, default = 1.000000
         [ParserTarget("glossyReflections")]
-        public NumericParser<Boolean> glossyReflectionsSetter
+        public NumericParser<float> glossyReflectionsSetter
         {
-            get { return GlossyReflections; }
-            set { GlossyReflections = value; }
+            get => GetFloat("_GlossyReflections");
+            set => SetFloat("_GlossyReflections", value);
         }
 
         // Scale, default = 1.000000
         [ParserTarget("bumpScale")]
-        public NumericParser<Single> bumpScaleSetter
+        public NumericParser<float> bumpScaleSetter
         {
-            get { return BumpScale; }
-            set { BumpScale = value; }
+            get => GetFloat("_BumpScale");
+            set => SetFloat("_BumpScale", value);
         }
 
         // Normal Map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public Texture2DParser bumpMapSetter
+        public MaterialTextureParser bumpMapSetter
         {
-            get { return BumpMap; }
-            set { BumpMap = value; }
+            get => null;
+            set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
         public Vector2Parser bumpMapScaleSetter
         {
-            get { return BumpMapScale; }
-            set { BumpMapScale = value; }
+            get => GetTextureScale("_BumpMap");
+            set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
         public Vector2Parser bumpMapOffsetSetter
         {
-            get { return BumpMapOffset; }
-            set { BumpMapOffset = value; }
+            get => GetTextureOffset("_BumpMap");
+            set => SetTextureOffset("_BumpMap", value);
         }
 
         // Height Scale, default = 0.020000
         [ParserTarget("parallax")]
-        public NumericParser<Single> parallaxSetter
+        public NumericParser<float> parallaxSetter
         {
-            get { return Parallax; }
-            set { Parallax = value; }
+            get => GetFloat("_Parallax");
+            set => SetFloat("_Parallax", value);
         }
 
         // Height Map, default = "black" { }
         [ParserTarget("parallaxMap")]
-        public Texture2DParser parallaxMapSetter
+        public MaterialTextureParser parallaxMapSetter
         {
-            get { return ParallaxMap; }
-            set { ParallaxMap = value; }
+            get => null;
+            set => SetTexture("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapScale")]
         public Vector2Parser parallaxMapScaleSetter
         {
-            get { return ParallaxMapScale; }
-            set { ParallaxMapScale = value; }
+            get => GetTextureScale("_ParallaxMap");
+            set => SetTextureScale("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapOffset")]
         public Vector2Parser parallaxMapOffsetSetter
         {
-            get { return ParallaxMapOffset; }
-            set { ParallaxMapOffset = value; }
+            get => GetTextureOffset("_ParallaxMap");
+            set => SetTextureOffset("_ParallaxMap", value);
         }
 
         // Strength, default = 1.000000
         [ParserTarget("occlusionStrength")]
-        public NumericParser<Single> occlusionStrengthSetter
+        public NumericParser<float> occlusionStrengthSetter
         {
-            get { return OcclusionStrength; }
-            set { OcclusionStrength = value; }
+            get => GetFloat("_OcclusionStrength");
+            set => SetFloat("_OcclusionStrength", value);
         }
 
         // Occlusion, default = "white" { }
         [ParserTarget("occlusionMap")]
-        public Texture2DParser occlusionMapSetter
+        public MaterialTextureParser occlusionMapSetter
         {
-            get { return OcclusionMap; }
-            set { OcclusionMap = value; }
+            get => null;
+            set => SetTexture("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapScale")]
         public Vector2Parser occlusionMapScaleSetter
         {
-            get { return OcclusionMapScale; }
-            set { OcclusionMapScale = value; }
+            get => GetTextureScale("_OcclusionMap");
+            set => SetTextureScale("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapOffset")]
         public Vector2Parser occlusionMapOffsetSetter
         {
-            get { return OcclusionMapOffset; }
-            set { OcclusionMapOffset = value; }
+            get => GetTextureOffset("_OcclusionMap");
+            set => SetTextureOffset("_OcclusionMap", value);
         }
 
         // Color, default = (0.000000,0.000000,0.000000,1.000000)
         [ParserTarget("emissionColor")]
         public ColorParser emissionColorSetter
         {
-            get { return EmissionColor; }
-            set { EmissionColor = value; }
+            get => GetColor("_EmissionColor");
+            set => SetColor("_EmissionColor", value);
         }
 
         // Emission, default = "white" { }
         [ParserTarget("emissionMap")]
-        public Texture2DParser emissionMapSetter
+        public MaterialTextureParser emissionMapSetter
         {
-            get { return EmissionMap; }
-            set { EmissionMap = value; }
+            get => null;
+            set => SetTexture("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapScale")]
         public Vector2Parser emissionMapScaleSetter
         {
-            get { return EmissionMapScale; }
-            set { EmissionMapScale = value; }
+            get => GetTextureScale("_EmissionMap");
+            set => SetTextureScale("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapOffset")]
         public Vector2Parser emissionMapOffsetSetter
         {
-            get { return EmissionMapOffset; }
-            set { EmissionMapOffset = value; }
+            get => GetTextureOffset("_EmissionMap");
+            set => SetTextureOffset("_EmissionMap", value);
         }
 
         // Detail Mask, default = "white" { }
         [ParserTarget("detailMask")]
-        public Texture2DParser detailMaskSetter
+        public MaterialTextureParser detailMaskSetter
         {
-            get { return DetailMask; }
-            set { DetailMask = value; }
+            get => null;
+            set => SetTexture("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskScale")]
         public Vector2Parser detailMaskScaleSetter
         {
-            get { return DetailMaskScale; }
-            set { DetailMaskScale = value; }
+            get => GetTextureScale("_DetailMask");
+            set => SetTextureScale("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskOffset")]
         public Vector2Parser detailMaskOffsetSetter
         {
-            get { return DetailMaskOffset; }
-            set { DetailMaskOffset = value; }
+            get => GetTextureOffset("_DetailMask");
+            set => SetTextureOffset("_DetailMask", value);
         }
 
         // Detail Albedo x2, default = "grey" { }
         [ParserTarget("detailAlbedoMap")]
-        public Texture2DParser detailAlbedoMapSetter
+        public MaterialTextureParser detailAlbedoMapSetter
         {
-            get { return DetailAlbedoMap; }
-            set { DetailAlbedoMap = value; }
+            get => null;
+            set => SetTexture("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapScale")]
         public Vector2Parser detailAlbedoMapScaleSetter
         {
-            get { return DetailAlbedoMapScale; }
-            set { DetailAlbedoMapScale = value; }
+            get => GetTextureScale("_DetailAlbedoMap");
+            set => SetTextureScale("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapOffset")]
         public Vector2Parser detailAlbedoMapOffsetSetter
         {
-            get { return DetailAlbedoMapOffset; }
-            set { DetailAlbedoMapOffset = value; }
+            get => GetTextureOffset("_DetailAlbedoMap");
+            set => SetTextureOffset("_DetailAlbedoMap", value);
         }
 
         // Normal Map, default = "bump" { }
         [ParserTarget("detailNormalMap")]
-        public Texture2DParser detailNormalMapSetter
+        public MaterialTextureParser detailNormalMapSetter
         {
-            get { return DetailNormalMap; }
-            set { DetailNormalMap = value; }
+            get => null;
+            set => SetTexture("_DetailNormalMap", value);
         }
 
         // Scale, default = 1.000000
         [ParserTarget("detailNormalMapScale")]
         public Vector2Parser detailNormalMapScaleSetter
         {
-            get { return DetailNormalMapScale; }
-            set { DetailNormalMapScale = value; }
+            get => GetTextureScale("_DetailNormalMap");
+            set => SetTextureScale("_DetailNormalMap", value);
         }
 
         [ParserTarget("detailNormalMapOffset")]
         public Vector2Parser detailNormalMapOffsetSetter
         {
-            get { return DetailNormalMapOffset; }
-            set { DetailNormalMapOffset = value; }
+            get => GetTextureOffset("_DetailNormalMap");
+            set => SetTextureOffset("_DetailNormalMap", value);
         }
 
         // UV Set for secondary textures, default = 0.000000
         [ParserTarget("UVSec")]
-        public EnumParser<UvSet> UVSecSetter
+        public NumericParser<float> UVSecSetter
         {
-            get { return UvSec; }
-            set { UvSec = value; }
+            get => GetFloat("_UVSec");
+            set => SetFloat("_UVSec", value);
         }
 
         // __mode, default = 0.000000
         [ParserTarget("mode")]
-        public EnumParser<BlendMode> modeSetter
+        public NumericParser<float> modeSetter
         {
-            get { return Mode; }
-            set { Mode = value; }
+            get => GetFloat("_Mode");
+            set => SetFloat("_Mode", value);
         }
 
         // __src, default = 1.000000
         [ParserTarget("srcBlend")]
-        public NumericParser<Single> srcBlendSetter
+        public NumericParser<float> srcBlendSetter
         {
-            get { return SrcBlend; }
-            set { SrcBlend = value; }
+            get => GetFloat("_SrcBlend");
+            set => SetFloat("_SrcBlend", value);
         }
 
         // __dst, default = 0.000000
         [ParserTarget("dstBlend")]
-        public NumericParser<Single> dstBlendSetter
+        public NumericParser<float> dstBlendSetter
         {
-            get { return DstBlend; }
-            set { DstBlend = value; }
+            get => GetFloat("_DstBlend");
+            set => SetFloat("_DstBlend", value);
         }
 
         // __zw, default = 1.000000
         [ParserTarget("ZWrite")]
-        public NumericParser<Single> ZWriteSetter
+        public NumericParser<float> ZWriteSetter
         {
-            get { return ZWrite; }
-            set { ZWrite = value; }
+            get => GetFloat("_ZWrite");
+            set => SetFloat("_ZWrite", value);
         }
+
+        public override ShaderParser ShaderParser { get; set; } = Shader;
 
         // Constructors
-        public StandardSpecularLoader()
-        {
-        }
+        public StandardSpecularLoader() { }
 
-        [Obsolete("Creating materials from shader source String is no longer supported. Use Shader assets instead.")]
-        public StandardSpecularLoader(String contents) : base(contents)
-        {
-        }
-
-        public StandardSpecularLoader(Material material) : base(material)
-        {
-        }
+        public StandardSpecularLoader(Material material) => Value = new(material);
     }
 }

--- a/src/Kopernicus/Configuration/ModLoader/LandControl.cs
+++ b/src/Kopernicus/Configuration/ModLoader/LandControl.cs
@@ -53,11 +53,17 @@ namespace Kopernicus.Configuration.ModLoader
         // Loader for a Ground Scatter
         [RequireConfigType(ConfigType.Node)]
         [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
-        public class LandClassScatterLoader : IPatchable, ITypeParser<PQSLandControl.LandClassScatter>
+        public class LandClassScatterLoader : IPatchable, ITypeParser<PQSLandControl.LandClassScatter>, IParserPostApplyEventSubscriber
         {
             // The value we are editing
             public PQSLandControl.LandClassScatter Value { get; set; }
             public ModularScatter Scatter { get; set; }
+
+            // Backing storage for the parsed material loader. Committed to
+            // Value.material in PostApply.
+            private BaseMaterialLoader _material;
+
+            private Material CurrentMaterial => _material?.Value ?? Value.material;
 
             /// <summary>
             /// Returns the currently edited PQS
@@ -98,211 +104,110 @@ namespace Kopernicus.Configuration.ModLoader
             {
                 get
                 {
-                    if (NormalDiffuse.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.Diffuse;
-                    }
-                    if (NormalBumped.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.BumpedDiffuse;
-                    }
-                    if (NormalDiffuseDetail.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.DiffuseDetail;
-                    }
-                    if (DiffuseWrap.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.DiffuseWrapped;
-                    }
-                    if (AlphaTestDiffuse.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.CutoutDiffuse;
-                    }
-                    if (AerialTransCutout.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.AerialCutout;
-                    }
-                    if (Standard.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.Standard;
-                    }
-                    if (StandardSpecular.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.StandardSpecular;
-                    }
-                    if (KSPBumped.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.KSPBumped;
-                    }
-                    if (KSPBumpedSpecular.UsesSameShader(Value.material))
-                    {
-                        return ScatterMaterialType.KSPBumpedSpecular;
-                    }
+                    Material material = CurrentMaterial;
 
-                    throw new Exception("The shader '" + Value.material.shader.name + "' is not supported.");
+                    if (NormalDiffuse.UsesSameShader(material))
+                        return ScatterMaterialType.Diffuse;
+                    if (NormalBumped.UsesSameShader(material))
+                        return ScatterMaterialType.BumpedDiffuse;
+                    if (NormalDiffuseDetail.UsesSameShader(material))
+                        return ScatterMaterialType.DiffuseDetail;
+                    if (DiffuseWrap.UsesSameShader(material))
+                        return ScatterMaterialType.DiffuseWrapped;
+                    if (AlphaTestDiffuse.UsesSameShader(material))
+                        return ScatterMaterialType.CutoutDiffuse;
+                    if (AerialTransCutout.UsesSameShader(material))
+                        return ScatterMaterialType.AerialCutout;
+                    if (Standard.UsesSameShader(material))
+                        return ScatterMaterialType.Standard;
+                    if (StandardSpecular.UsesSameShader(material))
+                        return ScatterMaterialType.StandardSpecular;
+                    if (KSPBumped.UsesSameShader(material))
+                        return ScatterMaterialType.KSPBumped;
+                    if (KSPBumpedSpecular.UsesSameShader(material))
+                        return ScatterMaterialType.KSPBumpedSpecular;
+
+                    throw new Exception("The shader '" + material.shader.name + "' is not supported.");
                 }
                 set
                 {
-                    Boolean isDiffuse = NormalDiffuse.UsesSameShader(Value.material);
-                    Boolean isBumped = NormalBumped.UsesSameShader(Value.material);
-                    Boolean isDetail = NormalDiffuseDetail.UsesSameShader(Value.material);
-                    Boolean isWrapped = DiffuseWrap.UsesSameShader(Value.material);
-                    Boolean isCutout = AlphaTestDiffuse.UsesSameShader(Value.material);
-                    Boolean isAerial = AerialTransCutout.UsesSameShader(Value.material);
-                    Boolean isStandard = Standard.UsesSameShader(Value.material);
-                    Boolean isStandardSpecular = StandardSpecular.UsesSameShader(Value.material);
-                    Boolean isKspBumped = KSPBumped.UsesSameShader(Value.material);
-                    Boolean isKspBumpedSpecular = KSPBumpedSpecular.UsesSameShader(Value.material);
+                    if (UsesScatterShader(value.Value, CurrentMaterial))
+                        return;
 
-                    switch (value.Value)
+                    _material = value.Value switch
                     {
-                        case ScatterMaterialType.Diffuse when !isDiffuse:
-                            Value.material = new NormalDiffuseLoader();
-                            break;
-                        case ScatterMaterialType.BumpedDiffuse when !isBumped:
-                            Value.material = new NormalBumpedLoader();
-                            break;
-                        case ScatterMaterialType.DiffuseDetail when !isDetail:
-                            Value.material = new NormalDiffuseDetailLoader();
-                            break;
-                        case ScatterMaterialType.DiffuseWrapped when !isWrapped:
-                            Value.material = new DiffuseWrapLoader();
-                            break;
-                        case ScatterMaterialType.CutoutDiffuse when !isCutout:
-                            Value.material = new AlphaTestDiffuseLoader();
-                            break;
-                        case ScatterMaterialType.AerialCutout when !isAerial:
-                            Value.material = new AerialTransCutoutLoader();
-                            break;
-                        case ScatterMaterialType.Standard when !isStandard:
-                            Value.material = new StandardLoader();
-                            break;
-                        case ScatterMaterialType.StandardSpecular when !isStandardSpecular:
-                            Value.material = new StandardSpecularLoader();
-                            break;
-                        case ScatterMaterialType.KSPBumped when !isKspBumped:
-                            Value.material = new KSPBumpedLoader();
-                            break;
-                        case ScatterMaterialType.KSPBumpedSpecular when !isKspBumpedSpecular:
-                            Value.material = new KSPBumpedSpecularLoader();
-                            break;
-                        default:
-                            return;
-                    }
+                        ScatterMaterialType.Diffuse => new NormalDiffuseLoader(),
+                        ScatterMaterialType.BumpedDiffuse => new NormalBumpedLoader(),
+                        ScatterMaterialType.DiffuseDetail => new NormalDiffuseDetailLoader(),
+                        ScatterMaterialType.DiffuseWrapped => new DiffuseWrapLoader(),
+                        ScatterMaterialType.CutoutDiffuse => new AlphaTestDiffuseLoader(),
+                        ScatterMaterialType.AerialCutout => new AerialTransCutoutLoader(),
+                        ScatterMaterialType.Standard => new StandardLoader(),
+                        ScatterMaterialType.StandardSpecular => new StandardSpecularLoader(),
+                        ScatterMaterialType.KSPBumped => new KSPBumpedLoader(),
+                        ScatterMaterialType.KSPBumpedSpecular => new KSPBumpedSpecularLoader(),
+                        _ => _material,
+                    };
                 }
             }
 
+            private static Boolean UsesScatterShader(ScatterMaterialType type, Material material) => type switch
+            {
+                ScatterMaterialType.Diffuse => NormalDiffuse.UsesSameShader(material),
+                ScatterMaterialType.BumpedDiffuse => NormalBumped.UsesSameShader(material),
+                ScatterMaterialType.DiffuseDetail => NormalDiffuseDetail.UsesSameShader(material),
+                ScatterMaterialType.DiffuseWrapped => DiffuseWrap.UsesSameShader(material),
+                ScatterMaterialType.CutoutDiffuse => AlphaTestDiffuse.UsesSameShader(material),
+                ScatterMaterialType.AerialCutout => AerialTransCutout.UsesSameShader(material),
+                ScatterMaterialType.Standard => Standard.UsesSameShader(material),
+                ScatterMaterialType.StandardSpecular => StandardSpecular.UsesSameShader(material),
+                ScatterMaterialType.KSPBumped => KSPBumped.UsesSameShader(material),
+                ScatterMaterialType.KSPBumpedSpecular => KSPBumpedSpecular.UsesSameShader(material),
+                _ => false,
+            };
+
             // Custom scatter material
             [ParserTarget("Material", AllowMerge = true)]
-            public Material Material
+            public BaseMaterialLoader Material
             {
                 get
                 {
-                    Boolean isDiffuse = Value.material is NormalDiffuseLoader;
-                    Boolean isBumped = Value.material is NormalBumpedLoader;
-                    Boolean isDetail = Value.material is NormalDiffuseDetailLoader;
-                    Boolean isWrapped = Value.material is DiffuseWrapLoader;
-                    Boolean isCutout = Value.material is AlphaTestDiffuseLoader;
-                    Boolean isAerial = Value.material is AerialTransCutoutLoader;
-                    Boolean isStandard = Value.material is StandardLoader;
-                    Boolean isStandardSpecular = Value.material is StandardSpecularLoader;
-                    Boolean isKspBumped = Value.material is KSPBumpedLoader;
-                    Boolean isKspBumpedSpecular = Value.material is KSPBumpedSpecularLoader;
+                    if (_material != null)
+                        return _material;
 
-                    switch (Type.Value)
+                    Material existing = Value.material;
+                    _material = Type.Value switch
                     {
-                        case ScatterMaterialType.Diffuse when !isDiffuse:
-                            Value.material = new NormalDiffuseLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.BumpedDiffuse when !isBumped:
-                            Value.material = new NormalBumpedLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.DiffuseDetail when !isDetail:
-                            Value.material = new NormalDiffuseDetailLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.DiffuseWrapped when !isWrapped:
-                            Value.material = new DiffuseWrapLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.CutoutDiffuse when !isCutout:
-                            Value.material = new AlphaTestDiffuseLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.AerialCutout when !isAerial:
-                            Value.material = new AerialTransCutoutLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.Standard when !isStandard:
-                            Value.material = new StandardLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.StandardSpecular when !isStandardSpecular:
-                            Value.material = new StandardSpecularLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.KSPBumped when !isKspBumped:
-                            Value.material = new KSPBumpedLoader(Value.material);
-                            goto default;
-                        case ScatterMaterialType.KSPBumpedSpecular when !isKspBumpedSpecular:
-                            Value.material = new KSPBumpedSpecularLoader(Value.material);
-                            goto default;
-                        default:
-                            return Value.material;
-                    }
+                        ScatterMaterialType.Diffuse => new NormalDiffuseLoader(existing),
+                        ScatterMaterialType.BumpedDiffuse => new NormalBumpedLoader(existing),
+                        ScatterMaterialType.DiffuseDetail => new NormalDiffuseDetailLoader(existing),
+                        ScatterMaterialType.DiffuseWrapped => new DiffuseWrapLoader(existing),
+                        ScatterMaterialType.CutoutDiffuse => new AlphaTestDiffuseLoader(existing),
+                        ScatterMaterialType.AerialCutout => new AerialTransCutoutLoader(existing),
+                        ScatterMaterialType.Standard => new StandardLoader(existing),
+                        ScatterMaterialType.StandardSpecular => new StandardSpecularLoader(existing),
+                        ScatterMaterialType.KSPBumped => new KSPBumpedLoader(existing),
+                        ScatterMaterialType.KSPBumpedSpecular => new KSPBumpedSpecularLoader(existing),
+                        _ => throw new Exception("Unsupported scatter material type: " + Type.Value),
+                    };
+                    return _material;
                 }
-                set
-                {
-                    Boolean isDiffuse = value is NormalDiffuseLoader;
-                    Boolean isBumped = value is NormalBumpedLoader;
-                    Boolean isDetail = value is NormalDiffuseDetailLoader;
-                    Boolean isWrapped = value is DiffuseWrapLoader;
-                    Boolean isCutout = value is AlphaTestDiffuseLoader;
-                    Boolean isAerial = value is AerialTransCutoutLoader;
-                    Boolean isStandard = value is StandardLoader;
-                    Boolean isStandardSpecular = value is StandardSpecularLoader;
-                    Boolean isKspBumped = Value.material is KSPBumpedLoader;
-                    Boolean isKspBumpedSpecular = Value.material is KSPBumpedSpecularLoader;
-
-                    switch (Type.Value)
-                    {
-                        case ScatterMaterialType.Diffuse when !isDiffuse:
-                            Value.material = new NormalDiffuseLoader(value);
-                            break;
-                        case ScatterMaterialType.BumpedDiffuse when !isBumped:
-                            Value.material = new NormalBumpedLoader(value);
-                            break;
-                        case ScatterMaterialType.DiffuseDetail when !isDetail:
-                            Value.material = new NormalDiffuseDetailLoader(value);
-                            break;
-                        case ScatterMaterialType.DiffuseWrapped when !isWrapped:
-                            Value.material = new DiffuseWrapLoader(value);
-                            break;
-                        case ScatterMaterialType.CutoutDiffuse when !isCutout:
-                            Value.material = new AlphaTestDiffuseLoader(value);
-                            break;
-                        case ScatterMaterialType.AerialCutout when !isAerial:
-                            Value.material = new AerialTransCutoutLoader(value);
-                            break;
-                        case ScatterMaterialType.Standard when !isStandard:
-                            Value.material = new StandardLoader(value);
-                            break;
-                        case ScatterMaterialType.StandardSpecular when !isStandardSpecular:
-                            Value.material = new StandardSpecularLoader(value);
-                            break;
-                        case ScatterMaterialType.KSPBumped when !isKspBumped:
-                            Value.material = new KSPBumpedLoader(value);
-                            break;
-                        case ScatterMaterialType.KSPBumpedSpecular when !isKspBumpedSpecular:
-                            Value.material = new KSPBumpedSpecularLoader(value);
-                            break;
-                        default:
-                            Value.material = value;
-                            break;
-                    }
-                }
+                set { _material = value; }
             }
 
             // Stock material
             [ParserTarget("material", AllowMerge = true)]
             public StockMaterialParser StockMaterial
             {
-                get { return Material; }
-                set { Material = value; }
+                get { return Material?.Value; }
+                set
+                {
+                    Material stock = value;
+                    if (stock == null)
+                        return;
+                    Value.material = stock;
+                    _material = null;
+                }
             }
 
             // The biome list of the landclass
@@ -591,6 +496,12 @@ namespace Kopernicus.Configuration.ModLoader
             public static implicit operator LandClassScatterLoader(PQSLandControl.LandClassScatter value)
             {
                 return new LandClassScatterLoader(value);
+            }
+
+            void IParserPostApplyEventSubscriber.PostApply(ConfigNode node)
+            {
+                if (_material != null)
+                    Value.material = _material.Value;
             }
         }
 

--- a/src/Kopernicus/Configuration/OceanLoader.cs
+++ b/src/Kopernicus/Configuration/OceanLoader.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Kopernicus.Components;
+using Kopernicus.Components.MaterialWrapper;
 using Kopernicus.ConfigParser;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
@@ -168,60 +169,25 @@ namespace Kopernicus.Configuration
             }
         }
 
+        private PQSOceanSurfaceQuadLoader _surfaceMaterial;
+        private PQSOceanSurfaceQuadFallbackLoader _fallbackMaterial;
+
         // Surface Material of the PQS
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
-        [SuppressMessage("ReSharper", "ConvertIfStatementToReturnStatement")]
         [KittopiaUntouchable]
-        public Material SurfaceMaterial
+        public PQSOceanSurfaceQuadLoader SurfaceMaterial
         {
-            get
-            {
-                if (!(BasicSurfaceMaterial is PQSProjectionFallbackLoader))
-                {
-                    BasicSurfaceMaterial = new PQSOceanSurfaceQuadLoader(BasicSurfaceMaterial);
-                }
-
-                return BasicSurfaceMaterial;
-            }
-            set
-            {
-                if (value is PQSOceanSurfaceQuadLoader)
-                {
-                    BasicSurfaceMaterial = value;
-                }
-                else
-                {
-                    BasicSurfaceMaterial = new PQSOceanSurfaceQuadLoader(value);
-                }
-            }
+            get { return _surfaceMaterial ??= new PQSOceanSurfaceQuadLoader(BasicSurfaceMaterial); }
+            set { _surfaceMaterial = value; }
         }
 
         // Fallback Material of the PQS (its always the same material)
         [ParserTarget("FallbackMaterial", AllowMerge = true, GetChild = false)]
-        [SuppressMessage("ReSharper", "ConvertIfStatementToReturnStatement")]
         [KittopiaUntouchable]
-        public Material FallbackMaterial
+        public PQSOceanSurfaceQuadFallbackLoader FallbackMaterial
         {
-            get
-            {
-                if (!(Value.fallbackMaterial is PQSOceanSurfaceQuadFallbackLoader))
-                {
-                    Value.fallbackMaterial = new PQSOceanSurfaceQuadFallbackLoader(Value.fallbackMaterial);
-                }
-
-                return Value.fallbackMaterial;
-            }
-            set
-            {
-                if (value is PQSOceanSurfaceQuadFallbackLoader)
-                {
-                    Value.fallbackMaterial = value;
-                }
-                else
-                {
-                    Value.fallbackMaterial = new PQSOceanSurfaceQuadFallbackLoader(value);
-                }
-            }
+            get { return _fallbackMaterial ??= new PQSOceanSurfaceQuadFallbackLoader(Value.fallbackMaterial); }
+            set { _fallbackMaterial = value; }
         }
 
         // PQSMod loader
@@ -270,8 +236,8 @@ namespace Kopernicus.Configuration
                     Utility.CopyObjectFields(oceans[i], Value);
 
                     // Create the material (always the same shader)
-                    SurfaceMaterial = new PQSOceanSurfaceQuadLoader(oceans[i].surfaceMaterial);
-                    FallbackMaterial = new PQSOceanSurfaceQuadFallbackLoader(oceans[i].fallbackMaterial);
+                    BasicSurfaceMaterial = new PQSOceanSurfaceQuad(oceans[i].surfaceMaterial);
+                    Value.fallbackMaterial = new PQSOceanSurfaceQuadFallback(oceans[i].fallbackMaterial);
 
                     break;
                 }
@@ -355,8 +321,8 @@ namespace Kopernicus.Configuration
                     Utility.CopyObjectFields(oceans[i], Value);
 
                     // Create the material (always the same shader)
-                    SurfaceMaterial = new PQSOceanSurfaceQuadLoader(oceans[i].surfaceMaterial);
-                    FallbackMaterial = new PQSOceanSurfaceQuadFallbackLoader(oceans[i].fallbackMaterial);
+                    BasicSurfaceMaterial = new PQSOceanSurfaceQuad(oceans[i].surfaceMaterial);
+                    Value.fallbackMaterial = new PQSOceanSurfaceQuadFallback(oceans[i].fallbackMaterial);
 
                     break;
                 }
@@ -426,6 +392,12 @@ namespace Kopernicus.Configuration
         // Post Apply
         void IParserEventSubscriber.PostApply(ConfigNode node)
         {
+            // Commit parsed materials to the underlying PQS
+            if (_surfaceMaterial != null)
+                BasicSurfaceMaterial = _surfaceMaterial.Value;
+            if (_fallbackMaterial != null)
+                Value.fallbackMaterial = _fallbackMaterial.Value;
+
             // Reset the PQS state
             Parser.ClearState("Kopernicus:pqsVersion");
 

--- a/src/Kopernicus/Configuration/PQSLoader.cs
+++ b/src/Kopernicus/Configuration/PQSLoader.cs
@@ -175,6 +175,13 @@ namespace Kopernicus.Configuration
                 Value.surfaceMaterial = value;
             }
         }
+
+        // Backing storage for the parsed material loaders. Committed to the
+        // underlying PQS in PostApply.
+        private BaseMaterialLoader _surfaceMaterial;
+        private PQSProjectionFallbackLoader _fallbackMaterial;
+
+        private Material CurrentSurfaceMaterial => _surfaceMaterial?.Value ?? BasicSurfaceMaterial;
         [PreApply]
         [ParserTarget("materialType")]
         [SuppressMessage("ReSharper", "ConvertIfStatementToReturnStatement")]
@@ -182,219 +189,109 @@ namespace Kopernicus.Configuration
         {
             get
             {
-                if (PQSProjectionSurfaceQuad.UsesSameShader(BasicSurfaceMaterial))
-                {
+                Material material = CurrentSurfaceMaterial;
+
+                if (PQSProjectionSurfaceQuad.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.Vacuum;
-                }
-                if (PQSProjectionAerialQuadRelative.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSProjectionAerialQuadRelative.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.Basic;
-                }
-                if (PQSMainShader.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSMainShader.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.Main;
-                }
-                if (PQSMainOptimised.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSMainOptimised.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.Optimized;
-                }
-                if (PQSMainExtras.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSMainExtras.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.Extra;
-                }
-                if (PQSMainOptimisedFastBlend.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSMainOptimisedFastBlend.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.OptimizedFastBlend;
-                }
-                if (PQSTriplanarZoomRotation.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSTriplanarZoomRotation.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.Triplanar;
-                }
-                if (PQSMainFastBlend.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSMainFastBlend.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.MainFastBlend;
-                }
-                if (PQSTriplanarZoomRotationTextureArray.UsesSameShader(BasicSurfaceMaterial))
-                {
+                if (PQSTriplanarZoomRotationTextureArray.UsesSameShader(material))
                     return NewShaderSurfaceMaterialType.TriplanarAtlas;
-                }
-                throw new Exception("The shader '" + BasicSurfaceMaterial.shader.name + "' is not supported.");
+
+                throw new Exception("The shader '" + material.shader.name + "' is not supported.");
             }
             set
             {
-                Boolean isVaccum = PQSProjectionSurfaceQuad.UsesSameShader(BasicSurfaceMaterial);
-                Boolean isBasic = PQSProjectionAerialQuadRelative.UsesSameShader(BasicSurfaceMaterial);
-                Boolean isMain = PQSMainShader.UsesSameShader(BasicSurfaceMaterial);
-                Boolean isOptimised = PQSMainOptimised.UsesSameShader(BasicSurfaceMaterial);
-                Boolean isExtra = PQSMainExtras.UsesSameShader(BasicSurfaceMaterial);
-                isMainFastBlend = PQSMainFastBlend.UsesSameShader(BasicSurfaceMaterial);
-                Boolean isOptimisedFastBlend = PQSMainOptimisedFastBlend.UsesSameShader(BasicSurfaceMaterial);
-                Boolean isTriplanar = PQSTriplanarZoomRotation.UsesSameShader(BasicSurfaceMaterial);
-                isTriplanarAtlas = PQSTriplanarZoomRotationTextureArray.UsesSameShader(BasicSurfaceMaterial);
-                switch (value.Value)
+                if (UsesSurfaceShader(value.Value, CurrentSurfaceMaterial))
                 {
-                    case NewShaderSurfaceMaterialType.Vacuum when !isVaccum:
-                        BasicSurfaceMaterial = new PQSProjectionSurfaceQuadLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.Basic when !isBasic:
-                        BasicSurfaceMaterial = new PQSProjectionAerialQuadRelativeLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.Main when !isMain:
-                        BasicSurfaceMaterial = new PQSMainShaderLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.Optimized when !isOptimised:
-                        BasicSurfaceMaterial = new PQSMainOptimisedLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.Extra when !isExtra:
-                        BasicSurfaceMaterial = new PQSMainExtrasLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.MainFastBlend when !isMainFastBlend:
-                        BasicSurfaceMaterial = new PQSMainFastBlendLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.OptimizedFastBlend when !isOptimisedFastBlend:
-                        BasicSurfaceMaterial = new PQSMainOptimisedFastBlendLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.Triplanar when !isTriplanar:
-                        BasicSurfaceMaterial = new PQSTriplanarZoomRotationLoader();
-                        break;
-                    case NewShaderSurfaceMaterialType.TriplanarAtlas when !isTriplanarAtlas:
-                        BasicSurfaceMaterial = new PQSTriplanarZoomRotationTextureArrayLoader();
-                        break;
-                    default:
-                        return;
+                    if (value.Value == NewShaderSurfaceMaterialType.MainFastBlend)
+                        isMainFastBlend = true;
+                    if (value.Value == NewShaderSurfaceMaterialType.TriplanarAtlas)
+                        isTriplanarAtlas = true;
+                    return;
                 }
+
+                _surfaceMaterial = value.Value switch
+                {
+                    NewShaderSurfaceMaterialType.Vacuum => new PQSProjectionSurfaceQuadLoader(),
+                    NewShaderSurfaceMaterialType.Basic => new PQSProjectionAerialQuadRelativeLoader(),
+                    NewShaderSurfaceMaterialType.Main => new PQSMainShaderLoader(),
+                    NewShaderSurfaceMaterialType.Optimized => new PQSMainOptimisedLoader(),
+                    NewShaderSurfaceMaterialType.Extra => new PQSMainExtrasLoader(),
+                    NewShaderSurfaceMaterialType.MainFastBlend => new PQSMainFastBlendLoader(),
+                    NewShaderSurfaceMaterialType.OptimizedFastBlend => new PQSMainOptimisedFastBlendLoader(),
+                    NewShaderSurfaceMaterialType.Triplanar => new PQSTriplanarZoomRotationLoader(),
+                    NewShaderSurfaceMaterialType.TriplanarAtlas => new PQSTriplanarZoomRotationTextureArrayLoader(),
+                    _ => _surfaceMaterial,
+                };
+
+                isMainFastBlend = value.Value == NewShaderSurfaceMaterialType.MainFastBlend;
+                isTriplanarAtlas = value.Value == NewShaderSurfaceMaterialType.TriplanarAtlas;
             }
         }
+
+        private static Boolean UsesSurfaceShader(NewShaderSurfaceMaterialType type, Material material) => type switch
+        {
+            NewShaderSurfaceMaterialType.Vacuum => PQSProjectionSurfaceQuad.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.Basic => PQSProjectionAerialQuadRelative.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.Main => PQSMainShader.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.Optimized => PQSMainOptimised.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.Extra => PQSMainExtras.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.MainFastBlend => PQSMainFastBlend.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.OptimizedFastBlend => PQSMainOptimisedFastBlend.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.Triplanar => PQSTriplanarZoomRotation.UsesSameShader(material),
+            NewShaderSurfaceMaterialType.TriplanarAtlas => PQSTriplanarZoomRotationTextureArray.UsesSameShader(material),
+            _ => false,
+        };
+
         // Surface Material of the PQS
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public Material SurfaceMaterial
+        public BaseMaterialLoader SurfaceMaterial
         {
             get
             {
-                Boolean isVaccum = BasicSurfaceMaterial is PQSProjectionSurfaceQuadLoader;
-                Boolean isBasic = BasicSurfaceMaterial is PQSProjectionAerialQuadRelativeLoader;
-                Boolean isMain = BasicSurfaceMaterial is PQSMainShaderLoader;
-                Boolean isOptimised = BasicSurfaceMaterial is PQSMainOptimisedLoader;
-                Boolean isExtra = BasicSurfaceMaterial is PQSMainExtrasLoader;
-                isMainFastBlend = BasicSurfaceMaterial is PQSMainFastBlendLoader;
-                Boolean isOptimisedFastBlend = BasicSurfaceMaterial is PQSMainOptimisedFastBlendLoader;
-                Boolean isTriplanar = BasicSurfaceMaterial is PQSTriplanarZoomRotationLoader;
-                isTriplanarAtlas = BasicSurfaceMaterial is PQSTriplanarZoomRotationTextureArrayLoader;
-                switch (NewMaterialType.Value)
+                if (_surfaceMaterial != null)
+                    return _surfaceMaterial;
+
+                Material existing = BasicSurfaceMaterial;
+                _surfaceMaterial = NewMaterialType.Value switch
                 {
-                    case NewShaderSurfaceMaterialType.Vacuum when !isVaccum:
-                        BasicSurfaceMaterial = new PQSProjectionSurfaceQuadLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.Basic when !isBasic:
-                        BasicSurfaceMaterial = new PQSProjectionAerialQuadRelativeLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.Main when !isMain:
-                        BasicSurfaceMaterial = new PQSMainShaderLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.Optimized when !isOptimised:
-                        BasicSurfaceMaterial = new PQSMainOptimisedLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.Extra when !isExtra:
-                        BasicSurfaceMaterial = new PQSMainExtrasLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.MainFastBlend when !isMainFastBlend:
-                        BasicSurfaceMaterial = new PQSMainFastBlendLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.OptimizedFastBlend when !isOptimisedFastBlend:
-                        BasicSurfaceMaterial = new PQSMainOptimisedFastBlendLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.Triplanar when !isTriplanar:
-                        BasicSurfaceMaterial = new PQSTriplanarZoomRotationLoader(BasicSurfaceMaterial);
-                        goto default;
-                    case NewShaderSurfaceMaterialType.TriplanarAtlas when !isTriplanarAtlas:
-                        BasicSurfaceMaterial = new PQSTriplanarZoomRotationTextureArrayLoader(BasicSurfaceMaterial);
-                        goto default;
-                    default:
-                        return BasicSurfaceMaterial;
-                }
+                    NewShaderSurfaceMaterialType.Vacuum => new PQSProjectionSurfaceQuadLoader(existing),
+                    NewShaderSurfaceMaterialType.Basic => new PQSProjectionAerialQuadRelativeLoader(existing),
+                    NewShaderSurfaceMaterialType.Main => new PQSMainShaderLoader(existing),
+                    NewShaderSurfaceMaterialType.Optimized => new PQSMainOptimisedLoader(existing),
+                    NewShaderSurfaceMaterialType.Extra => new PQSMainExtrasLoader(existing),
+                    NewShaderSurfaceMaterialType.MainFastBlend => new PQSMainFastBlendLoader(existing),
+                    NewShaderSurfaceMaterialType.OptimizedFastBlend => new PQSMainOptimisedFastBlendLoader(existing),
+                    NewShaderSurfaceMaterialType.Triplanar => new PQSTriplanarZoomRotationLoader(existing),
+                    NewShaderSurfaceMaterialType.TriplanarAtlas => new PQSTriplanarZoomRotationTextureArrayLoader(existing),
+                    _ => throw new Exception("Unsupported surface material type: " + NewMaterialType.Value),
+                };
+                return _surfaceMaterial;
             }
-            set
-            {
-                Boolean isVaccum = value is PQSProjectionSurfaceQuadLoader;
-                Boolean isBasic = value is PQSProjectionAerialQuadRelativeLoader;
-                Boolean isMain = value is PQSMainShaderLoader;
-                Boolean isOptimised = value is PQSMainOptimisedLoader;
-                Boolean isExtra = value is PQSMainExtrasLoader;
-                if (!(Versioning.version_minor < 9))
-                {
-                    isMainFastBlend = value is PQSMainFastBlendLoader;
-                }
-                Boolean isOptimisedFastBlend = value is PQSMainOptimisedFastBlendLoader;
-                Boolean isTriplanar = value is PQSTriplanarZoomRotationLoader;
-                if (!(Versioning.version_minor < 9))
-                {
-                    isTriplanarAtlas = value is PQSTriplanarZoomRotationTextureArrayLoader;
-                }
-                // We need to set the material before we check it, so we can reuse the code in MaterialType
-                BasicSurfaceMaterial = value;
-                switch (NewMaterialType.Value)
-                {
-                    case NewShaderSurfaceMaterialType.Vacuum when !isVaccum:
-                        BasicSurfaceMaterial = new PQSProjectionSurfaceQuadLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.Basic when !isBasic:
-                        BasicSurfaceMaterial = new PQSProjectionAerialQuadRelativeLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.Main when !isMain:
-                        BasicSurfaceMaterial = new PQSMainShaderLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.Optimized when !isOptimised:
-                        BasicSurfaceMaterial = new PQSMainOptimisedLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.Extra when !isExtra:
-                        BasicSurfaceMaterial = new PQSMainExtrasLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.MainFastBlend when !isMainFastBlend:
-                        BasicSurfaceMaterial = new PQSMainFastBlendLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.OptimizedFastBlend when !isOptimisedFastBlend:
-                        BasicSurfaceMaterial = new PQSMainOptimisedFastBlendLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.Triplanar when !isTriplanar:
-                        BasicSurfaceMaterial = new PQSTriplanarZoomRotationLoader(value);
-                        break;
-                    case NewShaderSurfaceMaterialType.TriplanarAtlas when !isTriplanarAtlas:
-                        BasicSurfaceMaterial = new PQSTriplanarZoomRotationTextureArrayLoader(value);
-                        break;
-                    default:
-                        BasicSurfaceMaterial = value;
-                        break;
-                }
-            }
+            set { _surfaceMaterial = value; }
         }
 
-        // Fallback Material of the PQS (its always the same material)
+        // Fallback Material of the PQS (its always the same shader)
         [ParserTarget("FallbackMaterial", AllowMerge = true, GetChild = false)]
-        [SuppressMessage("ReSharper", "ConvertIfStatementToReturnStatement")]
         [KittopiaUntouchable]
-        public Material FallbackMaterial
+        public PQSProjectionFallbackLoader FallbackMaterial
         {
-            get
-            {
-                if (!(Value.fallbackMaterial is PQSProjectionFallbackLoader))
-                {
-                    Value.fallbackMaterial = new PQSProjectionFallbackLoader(Value.fallbackMaterial);
-                }
-
-                return Value.fallbackMaterial;
-            }
-            set
-            {
-                if (value is PQSProjectionFallbackLoader)
-                {
-                    Value.fallbackMaterial = value;
-                }
-                else
-                {
-                    Value.fallbackMaterial = new PQSProjectionFallbackLoader(value);
-                }
-            }
+            get { return _fallbackMaterial ??= new PQSProjectionFallbackLoader(Value.fallbackMaterial); }
+            set { _fallbackMaterial = value; }
         }
 
         // PQSMod loader
@@ -443,7 +340,7 @@ namespace Kopernicus.Configuration
                 Utility.CopyObjectFields(laythe.pqsVersion, Value);
 
                 // Create the fallback material (always the same shader)
-                FallbackMaterial = new PQSProjectionFallbackLoader();
+                Value.fallbackMaterial = new PQSProjectionFallback();
 
                 // Create the celestial body transform
                 _transform = Utility.AddMod<PQSMod_CelestialBodyTransform>(Value, 10);
@@ -587,7 +484,7 @@ namespace Kopernicus.Configuration
                 Utility.CopyObjectFields(laythe.pqsVersion, Value);
 
                 // Create the fallback material (always the same shader)
-                FallbackMaterial = new PQSProjectionFallbackLoader();
+                Value.fallbackMaterial = new PQSProjectionFallback();
 
                 // Create the celestial body transform
                 _transform = Utility.AddMod<PQSMod_CelestialBodyTransform>(Value, 10);
@@ -695,6 +592,12 @@ namespace Kopernicus.Configuration
         // PostApply Event
         void IParserEventSubscriber.PostApply(ConfigNode node)
         {
+            // Commit the parsed materials onto the underlying PQS
+            if (_surfaceMaterial != null)
+                BasicSurfaceMaterial = _surfaceMaterial.Value;
+            if (_fallbackMaterial != null)
+                Value.fallbackMaterial = _fallbackMaterial.Value;
+
             // Reset the PQS state
             Parser.ClearState("Kopernicus:pqsVersion");
 

--- a/src/Kopernicus/Configuration/ScaledVersionLoader.cs
+++ b/src/Kopernicus/Configuration/ScaledVersionLoader.cs
@@ -72,6 +72,14 @@ namespace Kopernicus.Configuration
             public String Normals { get; set; }
         }
 
+        // Backing storage for the scaled-body material loader. Populated lazily
+        // by the Material getter or directly by the Type setter; committed to
+        // the renderer in PostApply.
+        private BaseMaterialLoader _material;
+
+        private Material CurrentMaterial =>
+            _material?.Value ?? Value.scaledBody.GetComponent<Renderer>().sharedMaterial;
+
         // Type of object this body's scaled version is
         [PreApply]
         [ParserTarget("type")]
@@ -80,7 +88,7 @@ namespace Kopernicus.Configuration
         {
             get
             {
-                Material material = Value.scaledBody.GetComponent<Renderer>().sharedMaterial;
+                Material material = CurrentMaterial;
 
                 if (ScaledPlanetSimple.UsesSameShader(material))
                 {
@@ -109,31 +117,29 @@ namespace Kopernicus.Configuration
             }
             set
             {
-                Renderer renderer = Value.scaledBody.GetComponent<Renderer>();
-
-                Boolean isVaccum = ScaledPlanetSimple.UsesSameShader(renderer.sharedMaterial);
-                Boolean isAtmospheric = ScaledPlanetRimAerial.UsesSameShader(renderer.sharedMaterial);
+                Boolean isVaccum = ScaledPlanetSimple.UsesSameShader(CurrentMaterial);
+                Boolean isAtmospheric = ScaledPlanetRimAerial.UsesSameShader(CurrentMaterial);
                 Boolean isAtmosphericStandard = false;
                 if (!(Versioning.version_minor < 9))
                 {
-                    isAtmosphericStandard = ScaledPlanetRimAerialStandard.UsesSameShader(renderer.sharedMaterial);
+                    isAtmosphericStandard = ScaledPlanetRimAerialStandard.UsesSameShader(CurrentMaterial);
                 }
-                Boolean isStar = EmissiveMultiRampSunspots.UsesSameShader(renderer.sharedMaterial);
+                Boolean isStar = EmissiveMultiRampSunspots.UsesSameShader(CurrentMaterial);
                 if (!(Versioning.version_minor < 9))
                 {
                     switch (value.Value)
                     {
                         case ScaledMaterialType.Vacuum when !isVaccum:
-                            renderer.sharedMaterial = new ScaledPlanetSimpleLoader();
+                            _material = new ScaledPlanetSimpleLoader();
                             break;
                         case ScaledMaterialType.Atmospheric when !isAtmospheric:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialLoader();
+                            _material = new ScaledPlanetRimAerialLoader();
                             break;
                         case ScaledMaterialType.AtmosphericStandard when !isAtmosphericStandard:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialStandardLoader();
+                            _material = new ScaledPlanetRimAerialStandardLoader();
                             break;
                         case ScaledMaterialType.Star when !isStar:
-                            renderer.sharedMaterial = new EmissiveMultiRampSunspotsLoader();
+                            _material = new EmissiveMultiRampSunspotsLoader();
                             break;
                         default:
                             return;
@@ -144,13 +150,13 @@ namespace Kopernicus.Configuration
                     switch (value.Value)
                     {
                         case ScaledMaterialType.Vacuum when !isVaccum:
-                            renderer.sharedMaterial = new ScaledPlanetSimpleLoader();
+                            _material = new ScaledPlanetSimpleLoader();
                             break;
                         case ScaledMaterialType.Atmospheric when !isAtmospheric:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialLoader();
+                            _material = new ScaledPlanetRimAerialLoader();
                             break;
                         case ScaledMaterialType.Star when !isStar:
-                            renderer.sharedMaterial = new EmissiveMultiRampSunspotsLoader();
+                            _material = new EmissiveMultiRampSunspotsLoader();
                             break;
                         default:
                             return;
@@ -269,110 +275,26 @@ namespace Kopernicus.Configuration
 
         [ParserTarget("Material", AllowMerge = true)]
         [KittopiaUntouchable]
-        public Material Material
+        public BaseMaterialLoader Material
         {
             get
             {
-                Renderer renderer = Value.scaledBody.GetComponent<Renderer>();
+                if (_material != null)
+                    return _material;
 
-                Boolean isVaccum = renderer.sharedMaterial is ScaledPlanetSimpleLoader;
-                Boolean isAtmospheric = renderer.sharedMaterial is ScaledPlanetRimAerialLoader;
-                Boolean isAtmosphericStandard = false;
-                if (!(Versioning.version_minor < 9))
+                Material existing = Value.scaledBody.GetComponent<Renderer>().sharedMaterial;
+                _material = Type.Value switch
                 {
-                    isAtmosphericStandard = renderer.sharedMaterial is ScaledPlanetRimAerialStandardLoader;
-                }
-                Boolean isStar = renderer.sharedMaterial is EmissiveMultiRampSunspotsLoader;
-                if (!(Versioning.version_minor < 9))
-                {
-                    switch (Type.Value)
-                    {
-                        case ScaledMaterialType.Vacuum when !isVaccum:
-                            renderer.sharedMaterial = new ScaledPlanetSimpleLoader(renderer.sharedMaterial);
-                            goto default;
-                        case ScaledMaterialType.Atmospheric when !isAtmospheric:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialLoader(renderer.sharedMaterial);
-                            goto default;
-                        case ScaledMaterialType.AtmosphericStandard when !isAtmosphericStandard:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialStandardLoader(renderer.sharedMaterial);
-                            goto default;
-                        case ScaledMaterialType.Star when !isStar:
-                            renderer.sharedMaterial = new EmissiveMultiRampSunspotsLoader(renderer.sharedMaterial);
-                            goto default;
-                        default:
-                            return renderer.sharedMaterial;
-                    }
-                }
-                else
-                {
-                    switch (Type.Value)
-                    {
-                        case ScaledMaterialType.Vacuum when !isVaccum:
-                            renderer.sharedMaterial = new ScaledPlanetSimpleLoader(renderer.sharedMaterial);
-                            goto default;
-                        case ScaledMaterialType.Atmospheric when !isAtmospheric:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialLoader(renderer.sharedMaterial);
-                            goto default;
-                        case ScaledMaterialType.Star when !isStar:
-                            renderer.sharedMaterial = new EmissiveMultiRampSunspotsLoader(renderer.sharedMaterial);
-                            goto default;
-                        default:
-                            return renderer.sharedMaterial;
-                    }
-                }
+                    ScaledMaterialType.Vacuum => new ScaledPlanetSimpleLoader(existing),
+                    ScaledMaterialType.Atmospheric => new ScaledPlanetRimAerialLoader(existing),
+                    ScaledMaterialType.AtmosphericStandard when !(Versioning.version_minor < 9) =>
+                        new ScaledPlanetRimAerialStandardLoader(existing),
+                    ScaledMaterialType.Star => new EmissiveMultiRampSunspotsLoader(existing),
+                    _ => throw new Exception("Unsupported scaled material type: " + Type.Value),
+                };
+                return _material;
             }
-            set
-            {
-                Renderer renderer = Value.scaledBody.GetComponent<Renderer>();
-
-                Boolean isVaccum = value is ScaledPlanetSimpleLoader;
-                Boolean isAtmospheric = value is ScaledPlanetRimAerialLoader;
-                Boolean isAtmosphericStandard = false;
-                if (!(Versioning.version_minor < 9))
-                {
-                    isAtmosphericStandard = value is ScaledPlanetRimAerialStandardLoader;
-                }
-                Boolean isStar = value is EmissiveMultiRampSunspotsLoader;
-                if (!(Versioning.version_minor < 9))
-                {
-                    switch (Type.Value)
-                    {
-                        case ScaledMaterialType.Vacuum when !isVaccum:
-                            renderer.sharedMaterial = new ScaledPlanetSimpleLoader(value);
-                            break;
-                        case ScaledMaterialType.Atmospheric when !isAtmospheric:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialLoader(value);
-                            break;
-                        case ScaledMaterialType.AtmosphericStandard when !isAtmosphericStandard:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialStandardLoader(value);
-                            break;
-                        case ScaledMaterialType.Star when !isStar:
-                            renderer.sharedMaterial = new EmissiveMultiRampSunspotsLoader(value);
-                            break;
-                        default:
-                            renderer.sharedMaterial = value;
-                            break;
-                    }
-                }
-                else
-                {
-                    switch (Type.Value)
-                    {
-                        case ScaledMaterialType.Vacuum when !isVaccum:
-                            renderer.sharedMaterial = new ScaledPlanetSimpleLoader(value);
-                            break;
-                        case ScaledMaterialType.Atmospheric when !isAtmospheric:
-                            renderer.sharedMaterial = new ScaledPlanetRimAerialLoader(value);
-                            break;
-                        case ScaledMaterialType.Star when !isStar:
-                            renderer.sharedMaterial = new EmissiveMultiRampSunspotsLoader(value);
-                            break;
-                        default:
-                            renderer.sharedMaterial = value;
-                            break;
-                    }
-                }
-            }
+            set { _material = value; }
         }
 
         [ParserTarget("OnDemand")]
@@ -466,11 +388,15 @@ namespace Kopernicus.Configuration
         // Post apply event
         void IParserEventSubscriber.PostApply(ConfigNode node)
         {
+            // Commit the parsed material to the renderer
+            if (_material != null)
+                Value.scaledBody.GetComponent<Renderer>().sharedMaterial = _material.Value;
+
             Logger.Active.Log("============= Scaled Version Dump ===================");
             Utility.GameObjectWalk(Value.scaledBody);
             Logger.Active.Log("===========================================");
 
-            // If we are a star, we need to generate the coronas 
+            // If we are a star, we need to generate the coronas
             if (Type == ScaledMaterialType.Star)
             {
                 // Restore backed up coronas if no custom ones were specified
@@ -507,14 +433,14 @@ namespace Kopernicus.Configuration
                     {
                         Texture2D texture = new Texture2D(1, 1);
                         texture.Apply();
-                        Material.SetTexture(MainTex, texture);
+                        Material.Value.SetTexture(MainTex, texture);
                     }
 
                     if (OnDemandTextures.Normals != null)
                     {
                         Texture2D texture = new Texture2D(1, 1);
                         texture.Apply();
-                        Material.SetTexture(BumpMap, texture);
+                        Material.Value.SetTexture(BumpMap, texture);
                     }
                 }
                 else
@@ -525,13 +451,13 @@ namespace Kopernicus.Configuration
                     if (OnDemandTextures.Texture != null)
                     {
                         parser.SetFromString(OnDemandTextures.Texture);
-                        Material.SetTexture(MainTex, parser);
+                        Material.Value.SetTexture(MainTex, parser);
                     }
 
                     if (OnDemandTextures.Normals != null)
                     {
                         parser.SetFromString(OnDemandTextures.Normals);
-                        Material.SetTexture(BumpMap, parser);
+                        Material.Value.SetTexture(BumpMap, parser);
                     }
                 }
             }


### PR DESCRIPTION
This builds on top of #839. It is rather chonky.

It converts every existing per-shader loader from the old loader style to instead inherit from `BaseLoader` and to use the helper functions defined within. All existing configs should continue to work, but now everyone can directly set shader properties by doing `_PropName` and it will automatically pick the right loader by introspecting the shader.