### PR TITLE
Add `OnPQSSphereStartedPreInit` event

### DIFF
--- a/src/Kopernicus/Events.cs
+++ b/src/Kopernicus/Events.cs
@@ -268,6 +268,15 @@ namespace Kopernicus
         [Description("RuntimeUtility.SwitchStar")]
         public static EventData<KopernicusStar> OnRuntimeUtilitySwitchStar { get; private set; }
 
+        /// <summary>
+        /// Called when a PQS sphere is just started, just before the call to
+        /// <see cref="PQS.UpdateQuadsInit" />. Other than a prefix patch, this
+        /// is the only reliable way to run code before PQS construction starts,
+        /// since stock doesn't provide an event for this by default.
+        /// </summary>
+        [Description("RuntimeUtility.PQSSphereStartedPreInit")]
+        public static EventData<PQS> OnPQSSphereStartedPreInit { get; private set; }
+
         [Description("RuntimeUtility.SpawnAsteroid.NR")]
         private static EventData<ProtoVessel> OnRuntimeUtilitySpawnAsteroidNR { get; set; }
         [Description("RuntimeUtility.SwitchStar.NR")]

--- a/src/Kopernicus/Patches/PQS_UpdateQuadsInit.cs
+++ b/src/Kopernicus/Patches/PQS_UpdateQuadsInit.cs
@@ -1,0 +1,20 @@
+using HarmonyLib;
+
+namespace Kopernicus.Patches;
+
+// PQS.UpdateQuadsInit is the point where each quad gets its surfaceMaterial
+// assigned. When PQS.useSharedMaterial is false (e.g. when PQSMod_MaterialQuadRelative
+// is in use) Unity clones surfaceMaterial into a per-quad instance via
+// MeshRenderer::set_material, so any texture writes that happen after this point
+// only reach future quads, never the ones that were just assigned.
+//
+// PQSMod.OnSphereStart fires before UpdateQuadsInit on the first start, but the
+// ActivateSphere path that runs when isStarted=true && isAlive=false skips
+// OnSphereStart entirely and goes straight to UpdateQuadsInit. There is no stock
+// callback that fires reliably in every path, so we synthesize one here.
+[HarmonyPatch(typeof(PQS), "UpdateQuadsInit")]
+internal static class PQS_UpdateQuadsInit
+{
+    static void Prefix(PQS __instance) =>
+        Events.OnPQSSphereStartedPreInit.Fire(__instance);
+}


### PR DESCRIPTION
So I was looking to do some more on-demand work and realized I wanted an event that fires when PQS activates but before `UpdateQuadsInit`. None of the stock `PQSMod` callbacks provide this, so I decided it would be better to just provide an event others can use.

This will be used in future PRs in the sequence here.