### PR TITLE
Rework how PQSMod_OnDemandHandler submits texture events

### DIFF
--- a/src/Kopernicus/OnDemand/IOnDemandTextureListener.cs
+++ b/src/Kopernicus/OnDemand/IOnDemandTextureListener.cs
@@ -1,0 +1,51 @@
+/**
+ * Kopernicus Planetary System Modifier
+ * -------------------------------------------------------------
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ *
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright of TakeTwo Interactive. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ *
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using UnityEngine;
+
+namespace Kopernicus.OnDemand;
+
+public interface IOnDemandTextureListener
+{
+    /// <summary>
+    /// The shader that this texture will be loaded for, if any. This will be
+    /// used to choose the type of texture loaded. If null then the texture
+    /// loader will load it as a generic <see cref="Texture" /> which may not
+    /// necessarily match up with what the shader expects.
+    /// </summary>
+    Shader Shader { get; }
+
+    /// <summary>
+    /// Whether the texture associated with this listener needs to be loaded
+    /// immediately.
+    /// </summary>
+    bool Immediate { get; }
+
+    /// <summary>
+    /// This gets called once the texture is loaded with the new texture.
+    /// </summary>
+    void OnTextureLoaded(string property, Texture texture);
+}

--- a/src/Kopernicus/OnDemand/Listeners.cs
+++ b/src/Kopernicus/OnDemand/Listeners.cs
@@ -1,0 +1,83 @@
+/**
+ * Kopernicus Planetary System Modifier
+ * -------------------------------------------------------------
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ *
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright of TakeTwo Interactive. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ *
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using UnityEngine;
+
+namespace Kopernicus.OnDemand;
+
+// These classes are responsible for routing material loads from PQSMod_OnDemandHandler
+// to the actual material they are supposed to apply to.
+//
+// They don't have any behaviour (beyond the callback) but make sure that the correct
+// material or object is being modified once the planetary system is instantiated.
+
+internal class PQSSurfaceMaterialTextureListener : MonoBehaviour, IOnDemandTextureListener
+{
+    [SerializeField]
+    private PQS pqs;
+
+    public Shader Shader => pqs?.surfaceMaterial?.shader;
+    public bool Immediate => false;
+
+    void Start()
+    {
+        pqs ??= GetComponent<PQS>();
+    }
+
+    public void OnTextureLoaded(string property, Texture texture) =>
+        pqs?.surfaceMaterial?.SetTexture(property, texture);
+}
+
+internal class PQSFallbackMaterialTextureListener : MonoBehaviour, IOnDemandTextureListener
+{
+    [SerializeField]
+    private PQS pqs;
+
+    public Shader Shader => pqs?.fallbackMaterial?.shader;
+    public bool Immediate => false;
+
+    void Start()
+    {
+        pqs ??= GetComponent<PQS>();
+    }
+
+    public void OnTextureLoaded(string property, Texture texture) =>
+        pqs?.fallbackMaterial?.SetTexture(property, texture);
+}
+
+internal class MaterialTextureListener : MonoBehaviour, IOnDemandTextureListener
+{
+    [SerializeField]
+    private Material material;
+
+    public Shader Shader => material?.shader;
+    public bool Immediate => false;
+
+    public void Setup(Material material) => this.material = material;
+
+    public void OnTextureLoaded(string property, Texture texture) =>
+        material?.SetTexture(property, texture);
+}

--- a/src/Kopernicus/OnDemand/OnDemandStorage.cs
+++ b/src/Kopernicus/OnDemand/OnDemandStorage.cs
@@ -30,7 +30,9 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using DDSHeaders;
+using KSPTextureLoader;
 using UnityEngine;
+using UnityEngine.Rendering;
 using Object = UnityEngine.Object;
 
 namespace Kopernicus.OnDemand
@@ -61,6 +63,19 @@ namespace Kopernicus.OnDemand
         public static Int32 OnDemandUnloadDelay = 10;
 
         public static Boolean UseManualMemoryManagement = true;
+
+        /// <summary>
+        /// Check whether a <paramref name="body"/> has any on-demand maps associated
+        /// with it.
+        /// </summary>
+        /// <param name="body"></param>
+        /// <returns></returns>
+        public static bool HasMaps(string body)
+        {
+            if (Maps.TryGetValue(body, out var bodyMaps))
+                return bodyMaps?.Count != 0;
+            return false;
+        }
 
         // Add a map to the map-list
         public static void AddMap(String body, ILoadOnDemand map)
@@ -236,6 +251,41 @@ namespace Kopernicus.OnDemand
             return true;
         }
 
+        /// <summary>
+        /// Begin loading <paramref name="entry" /> as the texture type expected by
+        /// the shader property it targets. The shader is inspected to pick the
+        /// matching texture dimension (Tex2D, Tex3D, Tex2DArray, Cube, CubeArray)
+        /// so the returned handle holds the correct concrete texture type for the
+        /// shader slot. Falls back to <see cref="Texture" /> when the shader does
+        /// not expose the property.
+        /// </summary>
+        internal static TextureHandle LoadPropertyTexture(Shader shader, string name, string path)
+        {
+            var options = new TextureLoadOptions
+            {
+                Unreadable = true,
+                Hint = TextureLoadHint.BatchAsynchronous
+            };
+
+            if (shader == null)
+                return TextureLoader.LoadTexture<Texture>(path, options);
+
+            var index = shader.FindPropertyIndex(name);
+            var dim = index == -1
+                ? TextureDimension.Unknown
+                : shader.GetPropertyTextureDimension(index);
+
+            return dim switch
+            {
+                TextureDimension.Tex2D => TextureLoader.LoadTexture<Texture2D>(path, options),
+                TextureDimension.Tex3D => TextureLoader.LoadTexture<Texture3D>(path, options),
+                TextureDimension.Tex2DArray => TextureLoader.LoadTexture<Texture2DArray>(path, options),
+                TextureDimension.Cube => TextureLoader.LoadTexture<Cubemap>(path, options),
+                TextureDimension.CubeArray => TextureLoader.LoadTexture<CubemapArray>(path, options),
+                _ => TextureLoader.LoadTexture<Texture>(path, options),
+            };
+        }
+
         internal static void ActivateMap(ILoadOnDemand map)
         {
             if (!MapBodyNames.TryGetValue(map, out var bodyName))
@@ -251,6 +301,9 @@ namespace Kopernicus.OnDemand
 
             ondemand.Activate();
         }
+
+        internal static List<ILoadOnDemand> GetMaps(string body) =>
+            Maps.TryGetValue(body, out var maps) ? maps : [];
 
         public static Byte[] LoadWholeFile(String path)
         {

--- a/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
+++ b/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
@@ -25,115 +25,143 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using KSPTextureLoader;
 using UnityEngine;
+using Object = UnityEngine.Object;
 using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace Kopernicus.OnDemand
 {
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class PQSMod_OnDemandHandler : PQSMod
+    public class PQSMod_OnDemandHandler : PQSMod, ISerializationCallbackReceiver
     {
+        enum State
+        {
+            Unloaded,
+            AutoLoaded,
+            Preloaded,
+            Loaded
+        }
+
+        struct TextureListener(string property, string path, IOnDemandTextureListener listener)
+        {
+            public readonly string property = property;
+            public readonly string path = path;
+            public readonly IOnDemandTextureListener listener = listener;
+        }
+
         // A minimum frame delay so that we don't unload if there is a large lag spike.
         const int UnloadFrameDelay = 30;
         const int UpdateInterval = 5;
 
         static readonly WaitForEndOfFrame WaitForEndOfFrame = new();
+        static readonly WaitForSecondsRealtime UnloadDelay = new(60);
 
-        // Delayed unload
-        // If non-zero the textures will be unloaded once the timer exceeds the value
+
+        #region PQS
+        // PQS and on-demand MapSO data
+        private List<ILoadOnDemand> mapSOs = [];
+        private State mapSOState;
+        private Coroutine unloadMapSOCoroutine;
+
+        // If non-zero the MapSOs will be unloaded once the timer exceeds the value
         private long _unloadTime;
         private int _unloadFrame;
 
         private int _lastUpdateFrame = 0;
 
-        // State
-        private Coroutine _coroutine;
-
-        private bool IsLoaded => _coroutine is not null;
-
-        long GetUnloadTime()
+        void PreloadMapSOs()
         {
-            if (sphere.isActive)
-                return 0;
-
-            return Stopwatch.GetTimestamp() +
-                   Stopwatch.Frequency * OnDemandStorage.OnDemandUnloadDelay;
-        }
-
-        void UpdateUnloadTime()
-        {
-            if (sphere.isActive)
-            {
-                _unloadTime = 0;
-                _unloadFrame = 0;
-            }
-            else
-            {
-                _unloadTime = Stopwatch.GetTimestamp() +
-                              Stopwatch.Frequency * OnDemandStorage.OnDemandUnloadDelay;
-                _unloadFrame = Time.frameCount + UnloadFrameDelay;
-            }
-
-            _lastUpdateFrame = Time.frameCount;
-        }
-
-        internal void Activate()
-        {
-            if (IsLoaded)
-            {
-                // Refresh unload time at most once every 5 frames per OnDemandHandler.
-                if (_lastUpdateFrame + UpdateInterval >= Time.frameCount)
-                    return;
-            }
-            else
-            {
-                // Occasionally KSP or other mods will call GetSurfaceHeight on an
-                // inactive celestial body. This starts a timer so any MapSOs loaded
-                // as a result of that will get unloaded eventually instead of
-                // hanging around forever.
-
-                _coroutine = StartCoroutine(UnloadWatcher());
-            }
-
-            UpdateUnloadTime();
-        }
-
-        // Enabling
-        public override void OnSphereActive()
-        {
-            Activate();
-
-            // Enable the maps
-            if (!OnDemandStorage.EnableBodyPqs(sphere.name))
+            if (mapSOState >= State.Preloaded)
                 return;
 
-            Debug.Log($"[OD] Enabling Body {sphere.name}");
+            if (unloadMapSOCoroutine != null)
+            {
+                StopCoroutine(unloadMapSOCoroutine);
+                unloadMapSOCoroutine = null;
+            }
+
+            mapSOState = State.Preloaded;
+            foreach (var entry in mapSOs)
+            {
+                if (entry is not IPreloadOnDemand preload)
+                    continue;
+
+                try
+                {
+                    preload.Preload();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
+            }
         }
 
-        public override void OnQuadPreBuild(PQ quad) => Activate();
-
-        public override void OnVertexBuildHeight(PQS.VertexBuildData data) =>
-            Activate();
-
-        IEnumerator UnloadWatcher()
+        void LoadMapSOs()
         {
-            using var guard = new ClearCoroutineGuard(this);
+            if (mapSOState == State.Loaded)
+                return;
+
+            if (unloadMapSOCoroutine != null)
+            {
+                StopCoroutine(unloadMapSOCoroutine);
+                unloadMapSOCoroutine = null;
+            }
+
+            Debug.Log($"[OD] Loading {sphere.name}");
+
+            mapSOState = State.Loaded;
+            foreach (var entry in mapSOs)
+            {
+                try
+                {
+                    entry.Load();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
+            }
+        }
+
+        void UnloadMapSOs()
+        {
+            if (mapSOState == State.Unloaded)
+                return;
+
+            Debug.Log($"[OD] Unloading {sphere.GetCelestialBody().bodyName}");
+
+            mapSOState = State.Unloaded;
+            foreach (var entry in mapSOs)
+            {
+                try
+                {
+                    entry.Unload();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
+            }
+        }
+
+        void StartMapSOUnload()
+        {
+            if (unloadMapSOCoroutine is not null)
+                return;
+
+            unloadMapSOCoroutine = StartCoroutine(UnloadMapWatcher());
+        }
+
+        IEnumerator UnloadMapWatcher()
+        {
+            using var guard = new MapSOCoroutineGuard(this);
 
             while (true)
             {
                 yield return WaitForEndOfFrame;
-
-                // We will never unload ourselves while the PQS sphere is loaded.
-                if (sphere.isActive)
-                {
-                    // Make sure we periodically update the stats so that we don't
-                    // immediately unload the textures when the sphere goes inactive.
-                    if (_lastUpdateFrame + UpdateInterval < Time.frameCount)
-                        UpdateUnloadTime();
-
-                    continue;
-                }
 
                 // If we are the currently active body, do not unload.
                 if (sphere.IsNotNullOrDestroyed() && FlightGlobals.ActiveVessel.IsNotNullOrDestroyed())
@@ -156,13 +184,313 @@ namespace Kopernicus.OnDemand
                 break;
             }
 
-            if (OnDemandStorage.DisableBodyPqs(sphere.name))
-                Debug.Log($"[OD] Disabling Body {sphere.name}");
+            UnloadMapSOs();
         }
 
-        struct ClearCoroutineGuard(PQSMod_OnDemandHandler handler) : IDisposable
+        void UpdateUnloadTime()
         {
-            public void Dispose() => handler._coroutine = null;
+            if (sphere.isActive)
+            {
+                _unloadTime = 0;
+                _unloadFrame = 0;
+            }
+            else
+            {
+                _unloadTime = Stopwatch.GetTimestamp() +
+                              Stopwatch.Frequency * OnDemandStorage.OnDemandUnloadDelay;
+                _unloadFrame = Time.frameCount + UnloadFrameDelay;
+            }
+
+            _lastUpdateFrame = Time.frameCount;
         }
+
+        struct MapSOCoroutineGuard(PQSMod_OnDemandHandler mod) : IDisposable
+        {
+            public void Dispose() => mod.unloadMapSOCoroutine = null;
+        }
+        #endregion
+
+        #region Materials
+        // Material texture data
+        private readonly List<TextureListener> listeners = [];
+        private readonly List<TextureHandle> handles = [];
+        private Coroutine loadCoroutine;
+        private Coroutine unloadCoroutine;
+
+        private bool TexturesLoaded => handles.Count != 0;
+
+        /// <summary>
+        /// Add a new listener that gets notified when the texture load completes.
+        /// </summary>
+        public void AddTextureListener<T>(string property, string path, T listener)
+            where T : UnityEngine.Object, IOnDemandTextureListener
+        {
+            listeners.Add(new(property, path, listener));
+        }
+
+        void StartTextureLoad()
+        {
+            // Cancel any pending unload — keep what's already loaded.
+            if (unloadCoroutine != null)
+            {
+                StopCoroutine(unloadCoroutine);
+                unloadCoroutine = null;
+            }
+
+            // Cancel any in-flight load coroutine. Existing handles are kept
+            // (they may already be partially or fully loaded); we'll restart
+            // the callback coroutine after topping up handles for any
+            // listeners added since the existing handles were created.
+            if (loadCoroutine != null)
+            {
+                StopCoroutine(loadCoroutine);
+                loadCoroutine = null;
+            }
+
+            for (int i = handles.Count; i < listeners.Count; ++i)
+            {
+                var entry = listeners[i];
+                handles.Add(OnDemandStorage.LoadPropertyTexture(
+                    entry.listener.Shader,
+                    entry.property,
+                    entry.path
+                ));
+            }
+
+            if (handles.Count == 0)
+                return;
+
+            loadCoroutine = StartCoroutine(DoTextureCallbacks());
+        }
+
+        void StartTextureUnload()
+        {
+            if (!TexturesLoaded)
+                return;
+
+            if (unloadCoroutine != null)
+                return;
+
+            if (loadCoroutine != null)
+            {
+                StopCoroutine(loadCoroutine);
+                loadCoroutine = null;
+            }
+
+            unloadCoroutine = StartCoroutine(DoUnloadTextures());
+        }
+
+        void UnloadTextures()
+        {
+            if (loadCoroutine != null)
+            {
+                StopCoroutine(loadCoroutine);
+                loadCoroutine = null;
+            }
+            if (unloadCoroutine != null)
+            {
+                StopCoroutine(unloadCoroutine);
+                unloadCoroutine = null;
+            }
+
+            if (!TexturesLoaded)
+                return;
+
+            foreach (var handle in handles)
+                handle?.Dispose();
+            handles.Clear();
+        }
+
+        IEnumerator DoTextureCallbacks()
+        {
+            using var guard = new LoadCoroutineGuard(this);
+
+            bool immediate = false;
+            foreach (var entry in listeners)
+            {
+                if (!entry.listener.Immediate)
+                    continue;
+
+                immediate = true;
+                break;
+            }
+
+            for (int i = 0; i < handles.Count; ++i)
+            {
+                var entry = listeners[i];
+                var handle = handles[i];
+
+                if (!immediate && !handle.IsComplete)
+                    yield return handle;
+
+                try
+                {
+                    var texture = handle.GetTexture();
+                    entry.listener.OnTextureLoaded(entry.property, texture);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[OD] Failed to load texture {handle.Path}");
+                    Debug.LogException(ex);
+                }
+            }
+        }
+
+        IEnumerator DoUnloadTextures()
+        {
+            using var guard = new UnloadCoroutineGuard(this);
+            var minEndFrame = Time.frameCount + UnloadFrameDelay;
+
+            do
+            {
+                yield return UnloadDelay;
+            }
+            while (Time.frameCount < minEndFrame);
+
+            UnloadTextures();
+        }
+
+
+        struct LoadCoroutineGuard(PQSMod_OnDemandHandler mod) : IDisposable
+        {
+            public void Dispose() => mod.loadCoroutine = null;
+        }
+
+        struct UnloadCoroutineGuard(PQSMod_OnDemandHandler mod) : IDisposable
+        {
+            public void Dispose() => mod.unloadCoroutine = null;
+        }
+        #endregion
+
+        #region Events
+        public override void OnSetup()
+        {
+            mapSOs = OnDemandStorage.GetMaps(sphere.name);
+        }
+
+        void OnEnable()
+        {
+            Events.OnPQSSphereStartedPreInit.Add(OnSphereStartedPreInit);
+        }
+
+        void OnDisable()
+        {
+            UnloadMapSOs();
+            UnloadTextures();
+            Events.OnPQSSphereStartedPreInit.Remove(OnSphereStartedPreInit);
+        }
+
+        void OnSphereStartedPreInit(PQS pqs)
+        {
+            if (pqs != sphere)
+                return;
+
+            PreloadMapSOs();
+            StartTextureLoad();
+        }
+
+        public override void OnSphereActive()
+        {
+            PreloadMapSOs();
+            StartTextureLoad();
+        }
+
+        public override void OnSphereInactive()
+        {
+            StartMapSOUnload();
+            StartTextureUnload();
+        }
+
+        public override void OnSphereReset()
+        {
+            StartMapSOUnload();
+            StartTextureUnload();
+        }
+
+        // Enabling
+        public override void OnQuadPreBuild(PQ quad)
+        {
+            if (mapSOState != State.Unloaded)
+                LoadMapSOs();
+
+            UpdateUnloadTime();
+        }
+
+        public override void OnVertexBuildHeight(PQS.VertexBuildData data) =>
+            Activate();
+        #endregion
+
+        internal void Activate()
+        {
+            if (mapSOState != State.Unloaded)
+            {
+                // Refresh unload time at most once every 5 frames per OnDemandHandler.
+                if (_lastUpdateFrame + UpdateInterval >= Time.frameCount)
+                    return;
+            }
+            else
+            {
+                // Occasionally KSP or other mods will call GetSurfaceHeight on an
+                // inactive celestial body. This starts a timer so any MapSOs loaded
+                // as a result of that will get unloaded eventually instead of
+                // hanging around forever.
+
+                StartMapSOUnload();
+                mapSOState = State.AutoLoaded;
+            }
+
+            UpdateUnloadTime();
+        }
+
+        #region Serialization Callbacks
+        // Unity's serializer (used by the prefab→live Instantiate clone in
+        // PSystemSpawn) only handles primitives, strings, UnityEngine.Object
+        // references, and List<T> of those. Mod-DLL [Serializable] structs are
+        // silently dropped, and IOnDemandTextureListener is a plain managed
+        // interface so its references would be lost on the cloned component.
+        // Round trip the subset of listeners whose backing object derives from
+        // UnityEngine.Object through these parallel SerializeField lists.
+        [SerializeField]
+        private readonly List<string> listenerProperties = [];
+        [SerializeField]
+        private readonly List<string> listenerPaths = [];
+        [SerializeField]
+        private readonly List<UnityEngine.Object> listenerObjects = [];
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize()
+        {
+            listenerProperties.Clear();
+            listenerPaths.Clear();
+            listenerObjects.Clear();
+
+            foreach (var entry in listeners)
+            {
+                if (entry.listener is not Object obj)
+                    continue;
+
+                listenerProperties.Add(entry.property);
+                listenerPaths.Add(entry.path);
+                listenerObjects.Add(obj);
+            }
+        }
+
+        void ISerializationCallbackReceiver.OnAfterDeserialize()
+        {
+            listeners.Clear();
+
+            var count = listenerObjects?.Count ?? 0;
+            for (int i = 0; i < count; ++i)
+            {
+                if (listenerObjects[i] is not IOnDemandTextureListener listener)
+                    continue;
+
+                listeners.Add(new TextureListener(
+                    listenerProperties[i],
+                    listenerPaths[i],
+                    listener
+                ));
+            }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
With the new changes to material loading we need more flexibility in how textures are loaded by PQSMod_OnDemandHandler. This expands it to meet that demand.

The big changes are:
* PQSMod_OnDemandTextureHandler now has two different state machines that run independently of each other. One to manage cpu-side PQS textures, and one to manage GPU-side material textures.
* Introduce a way to customize which material loaded textures get applied to, so that PQSMods can subscribe to texture updates if they need it. This takes the form of a "texture listener" that can route the event to the right location.

Like with the actual material loader, we inspect the shader property to determine what the desired texture dimension is and load that.

The design for listeners currently needs them to be an actual component somewhere, so that references to them are properly carried through when the planetary system is instantiated. PQSMod_OnDemandTextureHandler has a custom serialization callback that makes sure all of this works.

Otherwise PQS CPU-side texture continue to work mostly the same, other than there being a few extra helpers so that PQSMod_OnDemandHandler can work directly with the list.