### PR TITLE
Fix some issues causing scaled space and PQS textures to load incorrectly

### DIFF
--- a/src/Kopernicus/Configuration/OceanLoader.cs
+++ b/src/Kopernicus/Configuration/OceanLoader.cs
@@ -380,8 +380,10 @@ namespace Kopernicus.Configuration
         // Apply Event
         void IParserEventSubscriber.Apply(ConfigNode node)
         {
-            // Add an on-demand handler for stuff to register with.
-            var handler = Utility.AddMod<PQSMod_OnDemandHandler>(Value, 0);
+            // Reuse an existing on-demand handler from the cloned template when
+            // present so we don't end up with a duplicate PQSMod on the sphere.
+            var handler = Utility.GetMod<PQSMod_OnDemandHandler>(Value)
+                          ?? Utility.AddMod<PQSMod_OnDemandHandler>(Value, 0);
 
             // Share the current PQS
             Parser.SetState("Kopernicus:pqsVersion", () => Value);

--- a/src/Kopernicus/Configuration/PQSLoader.cs
+++ b/src/Kopernicus/Configuration/PQSLoader.cs
@@ -487,8 +487,10 @@ namespace Kopernicus.Configuration
         // Apply Event
         void IParserEventSubscriber.Apply(ConfigNode node)
         {
-            // Add an on-demand handler for stuff to register with.
-            var handler = Utility.AddMod<PQSMod_OnDemandHandler>(Value, 0);
+            // Reuse the on-demand handler added by the constructor when present
+            // so the parser doesn't end up with a duplicate PQSMod on the sphere.
+            var handler = Utility.GetMod<PQSMod_OnDemandHandler>(Value)
+                          ?? Utility.AddMod<PQSMod_OnDemandHandler>(Value, 0);
 
             // Share the current PQS
             Parser.SetState("Kopernicus:pqsVersion", () => Value);

--- a/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
+++ b/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
@@ -451,11 +451,11 @@ namespace Kopernicus.OnDemand
         // Round trip the subset of listeners whose backing object derives from
         // UnityEngine.Object through these parallel SerializeField lists.
         [SerializeField]
-        private readonly List<string> listenerProperties = [];
+        private List<string> listenerProperties = [];
         [SerializeField]
-        private readonly List<string> listenerPaths = [];
+        private List<string> listenerPaths = [];
         [SerializeField]
-        private readonly List<UnityEngine.Object> listenerObjects = [];
+        private List<UnityEngine.Object> listenerObjects = [];
 
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {

--- a/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
+++ b/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
@@ -58,8 +58,8 @@ namespace Kopernicus.OnDemand
         // ScaledSpace MeshRenderer
         public MeshRenderer scaledRenderer;
 
-        // State of the texture
-        public Boolean isLoaded = true;
+        // State of the texture.
+        public Boolean isLoaded = false;
 
         // If non-zero the textures will be unloaded once the timer exceeds the value
         private Int64 _unloadTime;
@@ -261,12 +261,15 @@ namespace Kopernicus.OnDemand
         }
 
         #region Serialization Callbacks
+#pragma warning disable IDE0044 // Add readonly modifier
         // Unity's serializer won't serialize OnDemandTextureEntry so we need
         // to unpack it into something that it will serialize.
         [SerializeField]
         private List<string> entryKeys = [];
+
         [SerializeField]
         private List<string> entryPaths = [];
+#pragma warning restore IDE0044 // Add readonly modifier
 
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {

--- a/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
+++ b/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
@@ -169,7 +169,8 @@ namespace Kopernicus.OnDemand
                     handle.Dispose();
             }
 
-            var shader = scaledRenderer.sharedMaterial.shader;
+            var material = scaledRenderer.sharedMaterial;
+            var shader = material.shader;
             foreach (var entry in Entries)
             {
                 var handle = OnDemandStorage.LoadPropertyTexture(shader, entry.Key, entry.Path);
@@ -178,23 +179,17 @@ namespace Kopernicus.OnDemand
                 Handles.Add(handle);
             }
 
-            MaterialPropertyBlock block = new();
-            scaledRenderer.GetPropertyBlock(block);
-
             for (int i = 0; i < Handles.Count; ++i)
             {
                 var handle = Handles[i];
                 var entry = Entries[i];
 
                 if (!handle.IsComplete)
-                {
-                    scaledRenderer.SetPropertyBlock(block);
                     yield return handle;
-                }
 
                 try
                 {
-                    block.SetTexture(entry.Id, handle.GetTexture());
+                    material.SetTexture(entry.Id, handle.GetTexture());
                 }
                 catch (Exception ex)
                 {
@@ -202,8 +197,6 @@ namespace Kopernicus.OnDemand
                     Debug.LogException(ex);
                 }
             }
-
-            scaledRenderer.SetPropertyBlock(block);
 
             // Events
             Events.OnScaledSpaceLoad.Fire(this);

--- a/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
+++ b/src/Kopernicus/OnDemand/ScaledSpaceOnDemand.cs
@@ -264,9 +264,9 @@ namespace Kopernicus.OnDemand
         // Unity's serializer won't serialize OnDemandTextureEntry so we need
         // to unpack it into something that it will serialize.
         [SerializeField]
-        private readonly List<string> entryKeys = [];
+        private List<string> entryKeys = [];
         [SerializeField]
-        private readonly List<string> entryPaths = [];
+        private List<string> entryPaths = [];
 
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {


### PR DESCRIPTION
* Unity will not deserialize to `readonly` fields.
* There are multiple things trying to use `MaterialPropertyBlock` on scaled space objects and attempting to set textures through one results in those textures being stomped over.

This should prevent any reappearances of Minmok and Jool-styled Sarnus.