### PR TITLE
fix: Assign cloned oceans to the correct layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Kopernicus Changelog
 
+## Unreleased
+1. Fixed a bug where custom oceans were not assigned to the right layer, causing them to glow orange during reentry.
+
 ## 244
 1. Restore NativeByteArray class, because some major mods still use it (RSS).
 

--- a/src/Kopernicus/Configuration/OceanLoader.cs
+++ b/src/Kopernicus/Configuration/OceanLoader.cs
@@ -233,6 +233,9 @@ namespace Kopernicus.Configuration
 
                     Utility.CopyObjectFields(oceans[i], Value);
 
+                    // Make sure to set the ocean's layer appropriately
+                    controllerRoot.layer = oceans[i].gameObject.layer;
+
                     // Create the material (always the same shader)
                     BasicSurfaceMaterial = new PQSOceanSurfaceQuad(oceans[i].surfaceMaterial);
                     Value.fallbackMaterial = new PQSOceanSurfaceQuadFallback(oceans[i].fallbackMaterial);


### PR DESCRIPTION
I discovered while testing that if you are getting reentry FX on tekto then the entire ocean turns orange. The root cause for this turns out to be that when a config uses `removeOcean = true` then Kopernicus copies the fields from Laythe's ocean, but does not copy the layer.

The end result is that the ocean gets left in the default layer, and is not excluded from most lighting. This manifests as the ocean turning orange when getting reentry FX on Tekto.

The fix is just to copy the layer over appropriately.

Before
<img width="2253" height="1104" alt="image" src="https://github.com/user-attachments/assets/5fe54a65-ec19-4abb-ab75-bd8af2c78ca6" />

After
<img width="1602" height="1001" alt="image" src="https://github.com/user-attachments/assets/80e3f282-878e-4b9a-a43b-284b22ebe0e6" />
