### PR TITLE
Allow shaders to be chosen by name in Material nodes

### DIFF
--- a/src/Kopernicus/Configuration/Attributes/MaterialLoaderAttribute.cs
+++ b/src/Kopernicus/Configuration/Attributes/MaterialLoaderAttribute.cs
@@ -1,0 +1,47 @@
+/**
+ * Kopernicus Planetary System Modifier
+ * -------------------------------------------------------------
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ *
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright of TakeTwo Interactive. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ *
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using UnityEngine;
+
+namespace Kopernicus.Configuration.Attributes;
+
+/// <summary>
+/// Use this attribute to indicate that your class is a material loader for
+/// <paramref name="shader"/>.
+/// </summary>
+/// <param name="shader">the name of a shader that this loader can be used for.</param>
+/// 
+/// <remarks>
+/// Any type using this attribute must have either a constructor that takes a
+/// <see cref="Material" />, or a two-argument constructor that takes both a
+/// <see cref="Material" /> and a <see cref="string" />. The string will contain
+/// the name of the shader that is being loaded.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+public sealed class MaterialLoaderAttribute(string shader) : Attribute
+{
+    public string Shader { get; } = shader;
+}

--- a/src/Kopernicus/Configuration/CoronaLoader.cs
+++ b/src/Kopernicus/Configuration/CoronaLoader.cs
@@ -87,11 +87,11 @@ namespace Kopernicus.Configuration
             set { Value.Rotation = value; }
         }
 
-        private ParticleAddSmoothLoader _material;
+        private BaseMaterialLoader _material;
 
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-        public ParticleAddSmoothLoader Material
+        public BaseMaterialLoader Material
         {
             get { return _material ??= new ParticleAddSmoothLoader(Value.GetComponent<Renderer>().sharedMaterial); }
             set { _material = value; }
@@ -106,6 +106,10 @@ namespace Kopernicus.Configuration
         // Parser apply event
         void IParserEventSubscriber.Apply(ConfigNode node)
         {
+            Material = BaseMaterialLoader.Create(
+                node.GetNode("Material")?.GetValue("shader") ?? ParticleAddSmoothLoader.SHADER_NAME,
+                Value.GetComponent<Renderer>().sharedMaterial);
+
             Events.OnCoronaLoaderApply.Fire(this, node);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(AerialTransCutoutLoader.SHADER_NAME)]
     public class AerialTransCutoutLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/Aerial Cutout";
+        public const String SHADER_NAME = "Terrain/PQS/Aerial Cutout";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(AlphaTestDiffuseLoader.SHADER_NAME)]
     public class AlphaTestDiffuseLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Legacy Shaders/Transparent/Cutout/Diffuse";
+        public const String SHADER_NAME = "Legacy Shaders/Transparent/Cutout/Diffuse";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/BaseMaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/BaseMaterialLoader.cs
@@ -26,11 +26,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Kopernicus.Components;
 using Kopernicus.ConfigParser;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Interfaces;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.OnDemand;
@@ -78,8 +80,7 @@ public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
 
     public virtual void Apply(ConfigNode node)
     {
-        var shader = ShaderParser.Value;
-
+        var shader = ShaderParser?.Value;
         if (shader is null)
         {
             Logger.Active.LogWarning("No shader specified for material. An error shader will be used instead.");
@@ -620,4 +621,104 @@ public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
                 return LoadTexture<Texture>(key, path);
         }
     }
+
+    #region Registry
+    struct RegistryEntry
+    {
+        public Type type;
+        public Func<Material, string, BaseMaterialLoader> ctor;
+    }
+
+    static readonly Dictionary<string, RegistryEntry> Registry = new(StringComparer.Ordinal);
+
+    public static BaseMaterialLoader Create(string shaderName, Material material)
+    {
+        if (string.IsNullOrEmpty(shaderName))
+            throw new Exception("Could not determine which shader to load as `shader` was not specified in the material loader");
+        if (Registry.TryGetValue(shaderName, out var entry))
+            return entry.ctor(material, shaderName);
+
+        // Explicitly exclude the material. The existing properties likely don't
+        // make sense and we want the user to configure anything that isn't the
+        // shader defaults.
+        return new CustomMaterialLoader();
+    }
+
+    internal static void BuildRegistry()
+    {
+        Registry.Clear();
+
+        var types = AssemblyLoader.loadedAssemblies
+            .SelectMany(la => la.assembly.GetTypes())
+            .Where(type => typeof(BaseMaterialLoader).IsAssignableFrom(type));
+        foreach (var type in types)
+        {
+            var attrs = type.GetCustomAttributes<MaterialLoaderAttribute>(inherit: false).ToArray();
+            if (attrs.Length == 0)
+                continue;
+
+            var ctor2 = type.GetConstructor([typeof(Material), typeof(string)]);
+            var ctor1 = type.GetConstructor([typeof(Material)]);
+            var ctor0 = type.GetConstructor([]);
+
+            Func<Material, string, BaseMaterialLoader> func;
+            if (ctor2 is not null)
+            {
+                func = (Material material, string shaderName) =>
+                {
+                    if (material == null)
+                    {
+                        var shader = Shader.Find(shaderName);
+                        if (shader == null)
+                            throw new Exception($"Shader `{shaderName}` does not exist.");
+
+                        material = new Material(shader);
+                    }
+
+                    return (BaseMaterialLoader)Activator.CreateInstance(type, [material, shaderName]);
+                };
+            }
+            else if (ctor1 is not null)
+            {
+                func = (Material material, string shaderName) =>
+                {
+                    if (material == null)
+                    {
+                        var shader = Shader.Find(shaderName);
+                        if (shader == null)
+                            throw new Exception($"Shader `{shaderName}` does not exist.");
+
+                        material = new Material(shader);
+                    }
+
+                    return (BaseMaterialLoader)Activator.CreateInstance(type, [material]);
+                };
+            }
+            else if (ctor0 is not null)
+            {
+                func = (Material material, string shaderName) => (BaseMaterialLoader)Activator.CreateInstance(type);
+            }
+            else
+            {
+                var message = $"Material loader {type.Name} has no suitable constructor and will not be used. See the wiki docs for more info.";
+                Logger.Active.LogError(message);
+                Debug.LogError($"[Kopernicus] {message}");
+                continue;
+            }
+
+            foreach (var attr in attrs)
+            {
+                if (Registry.TryGetValue(attr.Shader, out var other))
+                {
+                    var message = $"Multiple loaders for shader `{attr.Shader}` exist ({other.type.Name} and {type.Name}). Only {other.type.Name} will be used.";
+                    Logger.Active.LogError(message);
+                    Debug.LogError($"[Kopernicus] {message}");
+                    continue;
+                }
+
+                Registry.Add(attr.Shader, new RegistryEntry { type = type, ctor = func });
+            }
+        }
+    }
+    #endregion
 }

--- a/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(DiffuseWrapLoader.SHADER_NAME)]
     public class DiffuseWrapLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Diffuse Wrapped";
+        public const String SHADER_NAME = "Diffuse Wrapped";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(EmissiveMultiRampSunspotsLoader.SHADER_NAME)]
     public class EmissiveMultiRampSunspotsLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Emissive Multi Ramp Sunspots";
+        public const String SHADER_NAME = "Emissive Multi Ramp Sunspots";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
@@ -26,6 +26,7 @@
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -40,9 +41,10 @@ namespace Kopernicus.Configuration.MaterialLoader
     /// frame and clamps the speed properties.
     /// </summary>
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(GasGiantLoader.SHADER_NAME)]
     public class GasGiantLoader : BaseMaterialLoader
     {
-        private const string SHADER_NAME = "Terrain/Gas Giant";
+        public const string SHADER_NAME = "Terrain/Gas Giant";
         private static readonly Shader Shader = UnityEngine.Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(KSPBumpedLoader.SHADER_NAME)]
     public class KSPBumpedLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "KSP/Bumped";
+        public const String SHADER_NAME = "KSP/Bumped";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(KSPBumpedSpecularLoader.SHADER_NAME)]
     public class KSPBumpedSpecularLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "KSP/Bumped Specular";
+        public const String SHADER_NAME = "KSP/Bumped Specular";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(NormalBumpedLoader.SHADER_NAME)]
     public class NormalBumpedLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Legacy Shaders/Bumped Diffuse";
+        public const String SHADER_NAME = "Legacy Shaders/Bumped Diffuse";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(NormalDiffuseDetailLoader.SHADER_NAME)]
     public class NormalDiffuseDetailLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Legacy Shaders/Diffuse Detail";
+        public const String SHADER_NAME = "Legacy Shaders/Diffuse Detail";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(NormalDiffuseLoader.SHADER_NAME)]
     public class NormalDiffuseLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Legacy Shaders/Diffuse";
+        public const String SHADER_NAME = "Legacy Shaders/Diffuse";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -36,9 +37,10 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSMainExtrasLoader.SHADER_NAME)]
     public class PQSMainExtrasLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Main - Extras";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Main - Extras";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSMainFastBlendLoader.SHADER_NAME)]
     public class PQSMainFastBlendLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Fast Blend";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Fast Blend";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSMainOptimisedFastBlendLoader.SHADER_NAME)]
     public class PQSMainOptimisedFastBlendLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised With Fast Blend";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised With Fast Blend";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -36,9 +37,10 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSMainOptimisedLoader.SHADER_NAME)]
     public class PQSMainOptimisedLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -36,9 +37,10 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSMainShaderLoader.SHADER_NAME)]
     public class PQSMainShaderLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Main Shader";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSMainTriplanarZoomRotationLoader.SHADER_NAME)]
     public class PQSMainTriplanarZoomRotationLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Triplanar Zoom Rotation";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Triplanar Zoom Rotation";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.OnDemand;
@@ -35,9 +36,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSOceanSurfaceQuadFallbackLoader.SHADER_NAME)]
     public class PQSOceanSurfaceQuadFallbackLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad (Fallback)";
+        public const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad (Fallback)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -36,9 +37,10 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSOceanSurfaceQuadLoader.SHADER_NAME)]
     public class PQSOceanSurfaceQuadLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad";
+        public const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -36,9 +37,10 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSProjectionAerialQuadRelativeLoader.SHADER_NAME)]
     public class PQSProjectionAerialQuadRelativeLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (AP) ";
+        public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (AP) ";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.OnDemand;
@@ -35,9 +36,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSProjectionFallbackLoader.SHADER_NAME)]
     public class PQSProjectionFallbackLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (Fallback) ";
+        public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (Fallback) ";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSProjectionSurfaceQuadLoader.SHADER_NAME)]
     public class PQSProjectionSurfaceQuadLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD";
+        public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSTriplanarZoomRotationLoader.SHADER_NAME)]
     public class PQSTriplanarZoomRotationLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -37,9 +38,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(PQSTriplanarZoomRotationTextureArrayLoader.SHADER_NAME)]
     public class PQSTriplanarZoomRotationTextureArrayLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation Texture Array";
+        public const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation Texture Array";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
 
         // The texture-atlas mod (see ModLoader/TextureAtlas.cs) hot-swaps the shader to one of

--- a/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(ParticleAddSmoothLoader.SHADER_NAME)]
     public class ParticleAddSmoothLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Legacy Shaders/Particles/Additive (Soft)";
+        public const String SHADER_NAME = "Legacy Shaders/Particles/Additive (Soft)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -36,9 +37,10 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(ScaledPlanetRimAerialLoader.SHADER_NAME)]
     public class ScaledPlanetRimAerialLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial)";
+        public const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using Kopernicus.UI;
@@ -36,9 +37,10 @@ using Gradient = Kopernicus.Configuration.Parsing.Gradient;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(ScaledPlanetRimAerialStandardLoader.SHADER_NAME)]
     public class ScaledPlanetRimAerialStandardLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial) Standard";
+        public const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial) Standard";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(ScaledPlanetRimLightLoader.SHADER_NAME)]
     public class ScaledPlanetRimLightLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/Scaled Planet (RimLight)";
+        public const String SHADER_NAME = "Terrain/Scaled Planet (RimLight)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(ScaledPlanetSimpleLoader.SHADER_NAME)]
     public class ScaledPlanetSimpleLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Terrain/Scaled Planet (Simple)";
+        public const String SHADER_NAME = "Terrain/Scaled Planet (Simple)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(StandardLoader.SHADER_NAME)]
     public class StandardLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Standard";
+        public const String SHADER_NAME = "Standard";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
@@ -27,6 +27,7 @@ using System;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.BuiltinTypeParsers;
 using Kopernicus.ConfigParser.Enumerations;
+using Kopernicus.Configuration.Attributes;
 using Kopernicus.Configuration.MaterialLoader.Parsing;
 using Kopernicus.Configuration.Parsing;
 using UnityEngine;
@@ -34,9 +35,10 @@ using UnityEngine;
 namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
+    [MaterialLoader(StandardSpecularLoader.SHADER_NAME)]
     public class StandardSpecularLoader : BaseMaterialLoader
     {
-        private const String SHADER_NAME = "Standard (Specular setup)";
+        public const String SHADER_NAME = "Standard (Specular setup)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);
         public static bool UsesSameShader(Material m) => m != null && m.shader.name == SHADER_NAME;
 

--- a/src/Kopernicus/Configuration/ModLoader/LandControl.cs
+++ b/src/Kopernicus/Configuration/ModLoader/LandControl.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.ModLoader
         // Loader for a Ground Scatter
         [RequireConfigType(ConfigType.Node)]
         [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
-        public class LandClassScatterLoader : IPatchable, ITypeParser<PQSLandControl.LandClassScatter>, IParserPostApplyEventSubscriber
+        public class LandClassScatterLoader : IPatchable, ITypeParser<PQSLandControl.LandClassScatter>, IParserApplyEventSubscriber, IParserPostApplyEventSubscriber
         {
             // The value we are editing
             public PQSLandControl.LandClassScatter Value { get; set; }
@@ -103,97 +103,48 @@ namespace Kopernicus.Configuration.ModLoader
             [ParserTarget("materialType")]
             public EnumParser<ScatterMaterialType> Type
             {
-                get
-                {
-                    Material material = CurrentMaterial;
-
-                    if (NormalDiffuse.UsesSameShader(material))
-                        return ScatterMaterialType.Diffuse;
-                    if (NormalBumped.UsesSameShader(material))
-                        return ScatterMaterialType.BumpedDiffuse;
-                    if (NormalDiffuseDetail.UsesSameShader(material))
-                        return ScatterMaterialType.DiffuseDetail;
-                    if (DiffuseWrap.UsesSameShader(material))
-                        return ScatterMaterialType.DiffuseWrapped;
-                    if (AlphaTestDiffuse.UsesSameShader(material))
-                        return ScatterMaterialType.CutoutDiffuse;
-                    if (AerialTransCutout.UsesSameShader(material))
-                        return ScatterMaterialType.AerialCutout;
-                    if (Standard.UsesSameShader(material))
-                        return ScatterMaterialType.Standard;
-                    if (StandardSpecular.UsesSameShader(material))
-                        return ScatterMaterialType.StandardSpecular;
-                    if (KSPBumped.UsesSameShader(material))
-                        return ScatterMaterialType.KSPBumped;
-                    if (KSPBumpedSpecular.UsesSameShader(material))
-                        return ScatterMaterialType.KSPBumpedSpecular;
-
-                    throw new Exception("The shader '" + material.shader.name + "' is not supported.");
-                }
-                set
-                {
-                    if (UsesScatterShader(value.Value, CurrentMaterial))
-                        return;
-
-                    _material = value.Value switch
-                    {
-                        ScatterMaterialType.Diffuse => new NormalDiffuseLoader(),
-                        ScatterMaterialType.BumpedDiffuse => new NormalBumpedLoader(),
-                        ScatterMaterialType.DiffuseDetail => new NormalDiffuseDetailLoader(),
-                        ScatterMaterialType.DiffuseWrapped => new DiffuseWrapLoader(),
-                        ScatterMaterialType.CutoutDiffuse => new AlphaTestDiffuseLoader(),
-                        ScatterMaterialType.AerialCutout => new AerialTransCutoutLoader(),
-                        ScatterMaterialType.Standard => new StandardLoader(),
-                        ScatterMaterialType.StandardSpecular => new StandardSpecularLoader(),
-                        ScatterMaterialType.KSPBumped => new KSPBumpedLoader(),
-                        ScatterMaterialType.KSPBumpedSpecular => new KSPBumpedSpecularLoader(),
-                        _ => _material,
-                    };
-                }
+                get => field ??= GetInitialMaterialType();
+                set => field = value;
             }
 
-            private static Boolean UsesScatterShader(ScatterMaterialType type, Material material) => type switch
+            private ScatterMaterialType GetInitialMaterialType()
             {
-                ScatterMaterialType.Diffuse => NormalDiffuse.UsesSameShader(material),
-                ScatterMaterialType.BumpedDiffuse => NormalBumped.UsesSameShader(material),
-                ScatterMaterialType.DiffuseDetail => NormalDiffuseDetail.UsesSameShader(material),
-                ScatterMaterialType.DiffuseWrapped => DiffuseWrap.UsesSameShader(material),
-                ScatterMaterialType.CutoutDiffuse => AlphaTestDiffuse.UsesSameShader(material),
-                ScatterMaterialType.AerialCutout => AerialTransCutout.UsesSameShader(material),
-                ScatterMaterialType.Standard => Standard.UsesSameShader(material),
-                ScatterMaterialType.StandardSpecular => StandardSpecular.UsesSameShader(material),
-                ScatterMaterialType.KSPBumped => KSPBumped.UsesSameShader(material),
-                ScatterMaterialType.KSPBumpedSpecular => KSPBumpedSpecular.UsesSameShader(material),
-                _ => false,
-            };
+                Material material = CurrentMaterial;
 
-            // Custom scatter material
+                if (NormalDiffuse.UsesSameShader(material))
+                    return ScatterMaterialType.Diffuse;
+                if (NormalBumped.UsesSameShader(material))
+                    return ScatterMaterialType.BumpedDiffuse;
+                if (NormalDiffuseDetail.UsesSameShader(material))
+                    return ScatterMaterialType.DiffuseDetail;
+                if (DiffuseWrap.UsesSameShader(material))
+                    return ScatterMaterialType.DiffuseWrapped;
+                if (AlphaTestDiffuse.UsesSameShader(material))
+                    return ScatterMaterialType.CutoutDiffuse;
+                if (AerialTransCutout.UsesSameShader(material))
+                    return ScatterMaterialType.AerialCutout;
+                if (Standard.UsesSameShader(material))
+                    return ScatterMaterialType.Standard;
+                if (StandardSpecular.UsesSameShader(material))
+                    return ScatterMaterialType.StandardSpecular;
+                if (KSPBumped.UsesSameShader(material))
+                    return ScatterMaterialType.KSPBumped;
+                if (KSPBumpedSpecular.UsesSameShader(material))
+                    return ScatterMaterialType.KSPBumpedSpecular;
+
+                var shaderName = material?.shader?.name ?? "<null>";
+                throw new Exception("The shader '" + shaderName + "' is not supported.");
+            }
+
+            // Custom scatter material. Initialized up front by the constructor
+            // (wrapping any existing scatter material) and possibly replaced by
+            // the [PreApply] Type setter or by the IParserApplyEventSubscriber
+            // Apply hook below.
             [ParserTarget("Material", AllowMerge = true)]
             public BaseMaterialLoader Material
             {
-                get
-                {
-                    if (_material != null)
-                        return _material;
-
-                    Material existing = Value.material;
-                    _material = Type.Value switch
-                    {
-                        ScatterMaterialType.Diffuse => new NormalDiffuseLoader(existing),
-                        ScatterMaterialType.BumpedDiffuse => new NormalBumpedLoader(existing),
-                        ScatterMaterialType.DiffuseDetail => new NormalDiffuseDetailLoader(existing),
-                        ScatterMaterialType.DiffuseWrapped => new DiffuseWrapLoader(existing),
-                        ScatterMaterialType.CutoutDiffuse => new AlphaTestDiffuseLoader(existing),
-                        ScatterMaterialType.AerialCutout => new AerialTransCutoutLoader(existing),
-                        ScatterMaterialType.Standard => new StandardLoader(existing),
-                        ScatterMaterialType.StandardSpecular => new StandardSpecularLoader(existing),
-                        ScatterMaterialType.KSPBumped => new KSPBumpedLoader(existing),
-                        ScatterMaterialType.KSPBumpedSpecular => new KSPBumpedSpecularLoader(existing),
-                        _ => throw new Exception("Unsupported scatter material type: " + Type.Value),
-                    };
-                    return _material;
-                }
-                set { _material = value; }
+                get => _material;
+                set => _material = value;
             }
 
             // Stock material
@@ -207,8 +158,41 @@ namespace Kopernicus.Configuration.ModLoader
                     if (stock == null)
                         return;
                     Value.material = stock;
-                    _material = null;
+                    _material = WrapExistingMaterial(stock);
                 }
+            }
+
+            // Wrap an existing scatter material with the matching loader type
+            // so subsequent edits preserve the material's existing textures and
+            // properties. Returns null for unknown shaders — caller must supply
+            // a loader some other way (materialType= or Material{shader=}).
+            private static BaseMaterialLoader WrapExistingMaterial(Material existing)
+            {
+                if (existing == null)
+                    return null;
+
+                if (NormalDiffuse.UsesSameShader(existing))
+                    return new NormalDiffuseLoader(existing);
+                if (NormalBumped.UsesSameShader(existing))
+                    return new NormalBumpedLoader(existing);
+                if (NormalDiffuseDetail.UsesSameShader(existing))
+                    return new NormalDiffuseDetailLoader(existing);
+                if (DiffuseWrap.UsesSameShader(existing))
+                    return new DiffuseWrapLoader(existing);
+                if (AlphaTestDiffuse.UsesSameShader(existing))
+                    return new AlphaTestDiffuseLoader(existing);
+                if (AerialTransCutout.UsesSameShader(existing))
+                    return new AerialTransCutoutLoader(existing);
+                if (Standard.UsesSameShader(existing))
+                    return new StandardLoader(existing);
+                if (StandardSpecular.UsesSameShader(existing))
+                    return new StandardSpecularLoader(existing);
+                if (KSPBumped.UsesSameShader(existing))
+                    return new KSPBumpedLoader(existing);
+                if (KSPBumpedSpecular.UsesSameShader(existing))
+                    return new KSPBumpedSpecularLoader(existing);
+
+                return null;
             }
 
             // The biome list of the landclass
@@ -433,6 +417,7 @@ namespace Kopernicus.Configuration.ModLoader
             public LandClassScatterLoader(PQSLandControl.LandClassScatter value)
             {
                 Value = value;
+                _material = WrapExistingMaterial(value.material);
 
                 // Get the Scatter-Parent
                 GameObject scatterParent = typeof(PQSLandControl.LandClassScatter)
@@ -498,6 +483,34 @@ namespace Kopernicus.Configuration.ModLoader
             {
                 return new LandClassScatterLoader(value);
             }
+
+            // Build the material loader from whatever signal is available —
+            // `Material { shader = X }` wins, otherwise the [PreApply] Type
+            // (either explicitly parsed or lazily deduced from the existing
+            // material via GetInitialMaterialType). The Material and
+            // StockMaterial parser targets run after this and may overwrite
+            // _material / Value.material to suit the user's intent.
+            void IParserApplyEventSubscriber.Apply(ConfigNode node)
+            {
+                var shaderName = node.GetNode("Material")?.GetValue("shader")
+                                 ?? MaterialTypeToShaderName(Type.Value);
+                _material = BaseMaterialLoader.Create(shaderName, Value.material);
+            }
+
+            private static string MaterialTypeToShaderName(ScatterMaterialType type) => type switch
+            {
+                ScatterMaterialType.Diffuse => NormalDiffuseLoader.SHADER_NAME,
+                ScatterMaterialType.BumpedDiffuse => NormalBumpedLoader.SHADER_NAME,
+                ScatterMaterialType.DiffuseDetail => NormalDiffuseDetailLoader.SHADER_NAME,
+                ScatterMaterialType.DiffuseWrapped => DiffuseWrapLoader.SHADER_NAME,
+                ScatterMaterialType.CutoutDiffuse => AlphaTestDiffuseLoader.SHADER_NAME,
+                ScatterMaterialType.AerialCutout => AerialTransCutoutLoader.SHADER_NAME,
+                ScatterMaterialType.Standard => StandardLoader.SHADER_NAME,
+                ScatterMaterialType.StandardSpecular => StandardSpecularLoader.SHADER_NAME,
+                ScatterMaterialType.KSPBumped => KSPBumpedLoader.SHADER_NAME,
+                ScatterMaterialType.KSPBumpedSpecular => KSPBumpedSpecularLoader.SHADER_NAME,
+                _ => null,
+            };
 
             void IParserPostApplyEventSubscriber.PostApply(ConfigNode node)
             {

--- a/src/Kopernicus/Configuration/OceanLoader.cs
+++ b/src/Kopernicus/Configuration/OceanLoader.cs
@@ -173,16 +173,16 @@ namespace Kopernicus.Configuration
         // Surface Material of the PQS
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public PQSOceanSurfaceQuadLoader SurfaceMaterial
+        public BaseMaterialLoader SurfaceMaterial
         {
             get => field ??= new PQSOceanSurfaceQuadLoader(BasicSurfaceMaterial);
             set => field = value;
         }
 
-        // Fallback Material of the PQS (its always the same material)
+        // Fallback Material of the PQS
         [ParserTarget("FallbackMaterial", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public PQSOceanSurfaceQuadFallbackLoader FallbackMaterial
+        public BaseMaterialLoader FallbackMaterial
         {
             get => field ??= new PQSOceanSurfaceQuadFallbackLoader(Value.fallbackMaterial);
             set => field = value;
@@ -388,6 +388,13 @@ namespace Kopernicus.Configuration
             // Share the current PQS
             Parser.SetState("Kopernicus:pqsVersion", () => Value);
             Parser.SetState("Kopernicus:pqsOnDemandHandler", () => handler);
+
+            SurfaceMaterial = BaseMaterialLoader.Create(
+                node.GetNode("Material")?.GetValue("shader") ?? PQSOceanSurfaceQuadLoader.SHADER_NAME,
+                BasicSurfaceMaterial);
+            FallbackMaterial = BaseMaterialLoader.Create(
+                node.GetNode("FallbackMaterial")?.GetValue("shader") ?? PQSOceanSurfaceQuadFallbackLoader.SHADER_NAME,
+                Value.fallbackMaterial);
 
             // Event
             Events.OnOceanLoaderApply.Fire(this, node);

--- a/src/Kopernicus/Configuration/PQSLoader.cs
+++ b/src/Kopernicus/Configuration/PQSLoader.cs
@@ -169,25 +169,17 @@ namespace Kopernicus.Configuration
         // Type of surface material used by the PQS.
         [PreApply]
         [ParserTarget("materialType")]
-        public EnumParser<NewShaderSurfaceMaterialType> NewMaterialType
-        {
-            get => field ??= GetInitialMaterialType();
-            set => field = value;
-        }
+        public EnumParser<NewShaderSurfaceMaterialType> NewMaterialType { get; set; }
 
         // Surface Material of the PQS.
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public BaseMaterialLoader SurfaceMaterial
-        {
-            get => field ??= GetInitialSurfaceMaterialLoader();
-            set => field = value;
-        }
+        public BaseMaterialLoader SurfaceMaterial { get; set; }
 
-        // Fallback Material of the PQS (its always the same shader).
+        // Fallback Material of the PQS.
         [ParserTarget("FallbackMaterial", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public PQSProjectionFallbackLoader FallbackMaterial
+        public BaseMaterialLoader FallbackMaterial
         {
             get => field ??= new PQSProjectionFallbackLoader(Value.fallbackMaterial);
             set => field = value;
@@ -488,6 +480,11 @@ namespace Kopernicus.Configuration
             Parser.SetState("Kopernicus:pqsVersion", () => Value);
             Parser.SetState("Kopernicus:pqsOnDemandHandler", () => handler);
 
+            SurfaceMaterial = GetInitialSurfaceMaterialLoader(node.GetNode("Material"));
+            FallbackMaterial = BaseMaterialLoader.Create(
+                node.GetNode("FallbackMaterial")?.GetValue("shader") ?? PQSProjectionFallbackLoader.SHADER_NAME,
+                Value.fallbackMaterial);
+
             Events.OnPQSLoaderApply.Fire(this, node);
         }
 
@@ -535,19 +532,28 @@ namespace Kopernicus.Configuration
             throw new Exception("The shader '" + material.shader.name + "' is not supported.");
         }
 
-        BaseMaterialLoader GetInitialSurfaceMaterialLoader() => NewMaterialType.Value switch
+        static string MaterialTypeToShaderName(NewShaderSurfaceMaterialType? type) => type switch
         {
-            NewShaderSurfaceMaterialType.Vacuum => new PQSProjectionSurfaceQuadLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.Basic => new PQSProjectionAerialQuadRelativeLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.Main => new PQSMainShaderLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.Optimized => new PQSMainOptimisedLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.Extra => new PQSMainExtrasLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.MainFastBlend => new PQSMainFastBlendLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.OptimizedFastBlend => new PQSMainOptimisedFastBlendLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.Triplanar => new PQSTriplanarZoomRotationLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.TriplanarAtlas => new PQSTriplanarZoomRotationTextureArrayLoader(BasicSurfaceMaterial),
-            NewShaderSurfaceMaterialType.MainTriplanarZoomRotation => new PQSMainTriplanarZoomRotationLoader(BasicSurfaceMaterial),
-            _ => throw new Exception("Unsupported surface material type: " + NewMaterialType.Value),
+            NewShaderSurfaceMaterialType.Vacuum => PQSProjectionSurfaceQuadLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.Basic => PQSProjectionAerialQuadRelativeLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.Main => PQSMainShaderLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.Optimized => PQSMainOptimisedLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.Extra => PQSMainExtrasLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.MainFastBlend => PQSMainFastBlendLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.OptimizedFastBlend => PQSMainOptimisedFastBlendLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.Triplanar => PQSTriplanarZoomRotationLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.TriplanarAtlas => PQSTriplanarZoomRotationTextureArrayLoader.SHADER_NAME,
+            NewShaderSurfaceMaterialType.MainTriplanarZoomRotation => PQSMainTriplanarZoomRotationLoader.SHADER_NAME,
+            _ => null,
         };
+
+        BaseMaterialLoader GetInitialSurfaceMaterialLoader(ConfigNode node)
+        {
+            var material = BasicSurfaceMaterial;
+            var materialType = NewMaterialType?.Value ?? GetInitialMaterialType();
+            var shaderName = node?.GetValue("shader") ?? MaterialTypeToShaderName(materialType);
+            return BaseMaterialLoader.Create(shaderName, material);
+        }
+
     }
 }

--- a/src/Kopernicus/Configuration/ScaledVersionLoader.cs
+++ b/src/Kopernicus/Configuration/ScaledVersionLoader.cs
@@ -201,19 +201,19 @@ namespace Kopernicus.Configuration
 
         [ParserTarget("Material", AllowMerge = true)]
         [KittopiaUntouchable]
-        public BaseMaterialLoader Material
+        public BaseMaterialLoader Material { get; set; }
+
+        static string MaterialTypeToShaderName(ScaledMaterialType? type) => type switch
         {
-            get => field ??= Type.Value switch
-            {
-                ScaledMaterialType.Vacuum => new ScaledPlanetSimpleLoader(CurrentMaterial),
-                ScaledMaterialType.Atmospheric => new ScaledPlanetSimpleLoader(CurrentMaterial),
-                ScaledMaterialType.AtmosphericStandard => new ScaledPlanetRimAerialStandardLoader(CurrentMaterial),
-                ScaledMaterialType.Star => new EmissiveMultiRampSunspotsLoader(CurrentMaterial),
-                ScaledMaterialType.GasGiant => new GasGiantLoader(CurrentMaterial),
-                _ => new CustomMaterialLoader(),
-            };
-            set => field = value;
-        }
+            // Atmospheric historically routed through ScaledPlanetSimpleLoader rather than
+            // ScaledPlanetRimAerialLoader; preserve that mapping until/unless we decide to fix it.
+            ScaledMaterialType.Vacuum => ScaledPlanetSimpleLoader.SHADER_NAME,
+            ScaledMaterialType.Atmospheric => ScaledPlanetSimpleLoader.SHADER_NAME,
+            ScaledMaterialType.AtmosphericStandard => ScaledPlanetRimAerialStandardLoader.SHADER_NAME,
+            ScaledMaterialType.Star => EmissiveMultiRampSunspotsLoader.SHADER_NAME,
+            ScaledMaterialType.GasGiant => GasGiantLoader.SHADER_NAME,
+            _ => null,
+        };
 
         [ParserTarget("OnDemand", AllowMerge = true)]
         [KittopiaUntouchable]
@@ -295,6 +295,8 @@ namespace Kopernicus.Configuration
                 }
             }
 
+            Material = GetScaledMaterialLoader(node.GetNode("Material"));
+
             // Event
             Events.OnScaledVersionLoaderApply.Fire(this, node);
         }
@@ -353,6 +355,12 @@ namespace Kopernicus.Configuration
             if (GasGiantLoader.UsesSameShader(material))
                 return ScaledMaterialType.GasGiant;
             return ScaledMaterialType.Custom;
+        }
+
+        BaseMaterialLoader GetScaledMaterialLoader(ConfigNode node)
+        {
+            string shaderName = node?.GetValue("shader") ?? MaterialTypeToShaderName(Type.Value);
+            return BaseMaterialLoader.Create(shaderName, CurrentMaterial);
         }
 
         /// <summary>

--- a/src/Kopernicus/Injector.cs
+++ b/src/Kopernicus/Injector.cs
@@ -26,6 +26,7 @@
 using HarmonyLib;
 using Kopernicus.ConfigParser;
 using Kopernicus.Configuration;
+using Kopernicus.Configuration.MaterialLoader;
 using Kopernicus.Constants;
 using Kopernicus.OnDemand;
 using KSPTextureLoader;
@@ -147,6 +148,9 @@ namespace Kopernicus
                     }
                 }
 #endif
+
+                // Find all material loaders
+                BaseMaterialLoader.BuildRegistry();
 
                 // Backup the old prefab
                 StockSystemPrefab = PSystemManager.Instance.systemPrefab;

--- a/src/Kopernicus/Logger.cs
+++ b/src/Kopernicus/Logger.cs
@@ -111,6 +111,16 @@ namespace Kopernicus
             }
         }
 
+        public void LogError(Object o)
+        {
+            if (_loggerStream == null)
+                return;
+
+            _loggerStream.WriteLine($"[ERR {DateTime.Now.ToString("HH:mm:ss")}]: {o}");
+            if (_autoFlush)
+                _loggerStream.Flush();
+        }
+
         // Write text to the log
         public void LogException(Exception e)
         {


### PR DESCRIPTION
With this commit we finally have what I was aiming for in the first place. You can now specifiy a custom shader in Material node, and that will automatically be used to find the appropriate custom loader type for that shader. If no material type is found you get a CustomMaterialLoader that does everything BaseMaterialLoader does + additional support for keywords.

The way this works is like this:
* Each material loader is annotated with a new attribute: `[MaterialLoader("Shader Name")]`.
* At the start of `Injector` Kopernicus builds a registry of these.
* When determining what material loader to use we first check the shader key, if that is not set we fall back to the default behaviour.

The end result is that anyone can use any loaded shaders for a planet, and beyond that, if they need to, they can use the material apply hooks to add any control behaviours they need as well.

Here's an example of what that might look like
```
Material
{
    shader = Hidden/InvalidShader
    _PropA = 1
    _PropB = Path/To/PluginData/Texture.dds
}
```
and this works _everywhere_ there is an existing material block.