### PR TITLE
Key MapSOs by PQS sphere name, not celestial body name

### DIFF
--- a/src/Kopernicus/Configuration/Parsing/MapSOParsers.cs
+++ b/src/Kopernicus/Configuration/Parsing/MapSOParsers.cs
@@ -27,6 +27,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Kopernicus.Components;
+using Kopernicus.ConfigParser;
 using Kopernicus.ConfigParser.Attributes;
 using Kopernicus.ConfigParser.Enumerations;
 using Kopernicus.ConfigParser.Interfaces;
@@ -50,6 +51,24 @@ public abstract class MapSOParserBase<T> : BaseLoader, IParsable, ITypeParser<T>
     public T Value { get; set; }
 
     private protected abstract MapSO.MapDepth Depth { get; }
+
+    // The name of the PQS sphere we are parsing in. This may be more specific
+    // than just the body, because ocean PQS instances can have textures too.
+    private string CurrentSphereName
+    {
+        get
+        {
+            try
+            {
+                var pqs = Parser.GetState<PQS>("Kopernicus:pqsVersion");
+                if (pqs != null)
+                    return pqs.name;
+            }
+            catch { }
+
+            return generatedBody.name;
+        }
+    }
 
     private protected MapSOParserBase() { }
 
@@ -105,7 +124,7 @@ public abstract class MapSOParserBase<T> : BaseLoader, IParsable, ITypeParser<T>
             map.Path = s;
             map.Depth = Depth;
             map.AutoLoad = OnDemandStorage.OnDemandLoadOnMissing;
-            OnDemandStorage.AddMap(generatedBody.name, map);
+            OnDemandStorage.AddMap(CurrentSphereName, map);
             Value = (T)(MapSO)map;
             return;
         }

--- a/src/Kopernicus/OnDemand/OnDemandStorage.cs
+++ b/src/Kopernicus/OnDemand/OnDemandStorage.cs
@@ -42,7 +42,7 @@ namespace Kopernicus.OnDemand
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public static class OnDemandStorage
     {
-        // Lists
+        // Maps registered against a PQS sphere, keyed by the sphere's name.
         private static readonly Dictionary<String, List<ILoadOnDemand>> Maps = [];
 
         // We store body names as strings here because we only have references to
@@ -99,11 +99,11 @@ namespace Kopernicus.OnDemand
                 MapBodyNames[map] = body;
 
                 // Log
-                Debug.Log("[OD] Adding for body " + body + " map named " + map.Name + " of path = " + map.Path);
+                Debug.Log($"[OD] Adding for sphere {body} map named {map.Path}");
             }
             else
             {
-                Debug.Log("[OD] WARNING: trying to add a map but is already tracked! Current body is " + body +
+                Debug.Log("[OD] WARNING: trying to add a map but is already tracked! Current sphere is " + body +
                           " and map name is " + map.Name + " and path is " + map.Path);
             }
         }

--- a/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
+++ b/src/Kopernicus/OnDemand/PQSMod_OnDemandHandler.cs
@@ -140,7 +140,7 @@ namespace Kopernicus.OnDemand
             if (mapSOState == State.Unloaded)
                 return;
 
-            Debug.Log($"[OD] Unloading {sphere.GetCelestialBody().bodyName}");
+            Debug.Log($"[OD] Unloading {sphere.name}");
 
             mapSOState = State.Unloaded;
             foreach (var entry in mapSOs)
@@ -458,19 +458,17 @@ namespace Kopernicus.OnDemand
         }
 
         #region Serialization Callbacks
-        // Unity's serializer (used by the prefab→live Instantiate clone in
-        // PSystemSpawn) only handles primitives, strings, UnityEngine.Object
-        // references, and List<T> of those. Mod-DLL [Serializable] structs are
-        // silently dropped, and IOnDemandTextureListener is a plain managed
-        // interface so its references would be lost on the cloned component.
-        // Round trip the subset of listeners whose backing object derives from
-        // UnityEngine.Object through these parallel SerializeField lists.
+#pragma warning disable IDE0044 // Add readonly modifier
+        // Unity's serializer doesn't handle the TextureListener type because
+        // it is not defined at startup time. We unpack these ourselves so
+        // that we can survive across serialization callbacks.
         [SerializeField]
         private List<string> listenerProperties = [];
         [SerializeField]
         private List<string> listenerPaths = [];
         [SerializeField]
         private List<UnityEngine.Object> listenerObjects = [];
+#pragma warning restore IDE0044 // Add readonly modifier
 
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {


### PR DESCRIPTION
For most cases this is the same, but now ocean spheres have their MapSOs (if any) tied to their own name.