### PR TITLE
Rename BaseMaterialLoader to MaterialLoader

### DIFF
--- a/src/Kopernicus/Configuration/CoronaLoader.cs
+++ b/src/Kopernicus/Configuration/CoronaLoader.cs
@@ -87,11 +87,11 @@ namespace Kopernicus.Configuration
             set { Value.Rotation = value; }
         }
 
-        private BaseMaterialLoader _material;
+        private MaterialLoader.MaterialLoader _material;
 
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-        public BaseMaterialLoader Material
+        public MaterialLoader.MaterialLoader Material
         {
             get { return _material ??= new ParticleAddSmoothLoader(Value.GetComponent<Renderer>().sharedMaterial); }
             set { _material = value; }
@@ -106,7 +106,7 @@ namespace Kopernicus.Configuration
         // Parser apply event
         void IParserEventSubscriber.Apply(ConfigNode node)
         {
-            Material = BaseMaterialLoader.Create(
+            Material = MaterialLoader.MaterialLoader.Create(
                 node.GetNode("Material")?.GetValue("shader") ?? ParticleAddSmoothLoader.SHADER_NAME,
                 Value.GetComponent<Renderer>().sharedMaterial);
 

--- a/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(AerialTransCutoutLoader.SHADER_NAME)]
-    public class AerialTransCutoutLoader : BaseMaterialLoader
+    public class AerialTransCutoutLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Aerial Cutout";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(AlphaTestDiffuseLoader.SHADER_NAME)]
-    public class AlphaTestDiffuseLoader : BaseMaterialLoader
+    public class AlphaTestDiffuseLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Legacy Shaders/Transparent/Cutout/Diffuse";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/CustomMaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/CustomMaterialLoader.cs
@@ -41,7 +41,7 @@ using UnityEngine.Rendering;
 namespace Kopernicus.Configuration.MaterialLoader;
 
 [RequireConfigType(ConfigType.Node)]
-public class CustomMaterialLoader : BaseMaterialLoader
+public class CustomMaterialLoader : MaterialLoader
 {
     /// <summary>
     /// The shader that will actually be loaded.

--- a/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(DiffuseWrapLoader.SHADER_NAME)]
-    public class DiffuseWrapLoader : BaseMaterialLoader
+    public class DiffuseWrapLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Diffuse Wrapped";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(EmissiveMultiRampSunspotsLoader.SHADER_NAME)]
-    public class EmissiveMultiRampSunspotsLoader : BaseMaterialLoader
+    public class EmissiveMultiRampSunspotsLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Emissive Multi Ramp Sunspots";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
@@ -42,7 +42,7 @@ namespace Kopernicus.Configuration.MaterialLoader
     /// </summary>
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(GasGiantLoader.SHADER_NAME)]
-    public class GasGiantLoader : BaseMaterialLoader
+    public class GasGiantLoader : MaterialLoader
     {
         public const string SHADER_NAME = "Terrain/Gas Giant";
         private static readonly Shader Shader = UnityEngine.Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(KSPBumpedLoader.SHADER_NAME)]
-    public class KSPBumpedLoader : BaseMaterialLoader
+    public class KSPBumpedLoader : MaterialLoader
     {
         public const String SHADER_NAME = "KSP/Bumped";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(KSPBumpedSpecularLoader.SHADER_NAME)]
-    public class KSPBumpedSpecularLoader : BaseMaterialLoader
+    public class KSPBumpedSpecularLoader : MaterialLoader
     {
         public const String SHADER_NAME = "KSP/Bumped Specular";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/MaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/MaterialLoader.cs
@@ -48,7 +48,7 @@ namespace Kopernicus.Configuration.MaterialLoader;
 /// both the raw <c>_X</c> key path (handled by <see cref="PostApply"/>) and the
 /// per-shader friendly aliases route through.
 /// </summary>
-public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
+public abstract class MaterialLoader : BaseLoader, IParserEventSubscriber
 {
     /// <summary>
     /// The material actually loaded by this loader.
@@ -626,12 +626,12 @@ public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
     struct RegistryEntry
     {
         public Type type;
-        public Func<Material, string, BaseMaterialLoader> ctor;
+        public Func<Material, string, MaterialLoader> ctor;
     }
 
     static readonly Dictionary<string, RegistryEntry> Registry = new(StringComparer.Ordinal);
 
-    public static BaseMaterialLoader Create(string shaderName, Material material)
+    public static MaterialLoader Create(string shaderName, Material material)
     {
         if (string.IsNullOrEmpty(shaderName))
             throw new Exception("Could not determine which shader to load as `shader` was not specified in the material loader");
@@ -650,7 +650,7 @@ public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
 
         var types = AssemblyLoader.loadedAssemblies
             .SelectMany(la => la.assembly.GetTypes())
-            .Where(type => typeof(BaseMaterialLoader).IsAssignableFrom(type));
+            .Where(type => typeof(MaterialLoader).IsAssignableFrom(type));
         foreach (var type in types)
         {
             var attrs = type.GetCustomAttributes<MaterialLoaderAttribute>(inherit: false).ToArray();
@@ -661,7 +661,7 @@ public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
             var ctor1 = type.GetConstructor([typeof(Material)]);
             var ctor0 = type.GetConstructor([]);
 
-            Func<Material, string, BaseMaterialLoader> func;
+            Func<Material, string, MaterialLoader> func;
             if (ctor2 is not null)
             {
                 func = (Material material, string shaderName) =>
@@ -675,7 +675,7 @@ public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
                         material = new Material(shader);
                     }
 
-                    return (BaseMaterialLoader)Activator.CreateInstance(type, [material, shaderName]);
+                    return (MaterialLoader)Activator.CreateInstance(type, [material, shaderName]);
                 };
             }
             else if (ctor1 is not null)
@@ -691,12 +691,12 @@ public abstract class BaseMaterialLoader : BaseLoader, IParserEventSubscriber
                         material = new Material(shader);
                     }
 
-                    return (BaseMaterialLoader)Activator.CreateInstance(type, [material]);
+                    return (MaterialLoader)Activator.CreateInstance(type, [material]);
                 };
             }
             else if (ctor0 is not null)
             {
-                func = (Material material, string shaderName) => (BaseMaterialLoader)Activator.CreateInstance(type);
+                func = (Material material, string shaderName) => (MaterialLoader)Activator.CreateInstance(type);
             }
             else
             {

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(NormalBumpedLoader.SHADER_NAME)]
-    public class NormalBumpedLoader : BaseMaterialLoader
+    public class NormalBumpedLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Legacy Shaders/Bumped Diffuse";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(NormalDiffuseDetailLoader.SHADER_NAME)]
-    public class NormalDiffuseDetailLoader : BaseMaterialLoader
+    public class NormalDiffuseDetailLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Legacy Shaders/Diffuse Detail";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(NormalDiffuseLoader.SHADER_NAME)]
-    public class NormalDiffuseLoader : BaseMaterialLoader
+    public class NormalDiffuseLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Legacy Shaders/Diffuse";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainExtrasLoader.SHADER_NAME)]
-    public class PQSMainExtrasLoader : BaseMaterialLoader
+    public class PQSMainExtrasLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main - Extras";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainFastBlendLoader.SHADER_NAME)]
-    public class PQSMainFastBlendLoader : BaseMaterialLoader
+    public class PQSMainFastBlendLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Fast Blend";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainOptimisedFastBlendLoader.SHADER_NAME)]
-    public class PQSMainOptimisedFastBlendLoader : BaseMaterialLoader
+    public class PQSMainOptimisedFastBlendLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised With Fast Blend";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainOptimisedLoader.SHADER_NAME)]
-    public class PQSMainOptimisedLoader : BaseMaterialLoader
+    public class PQSMainOptimisedLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainShaderLoader.SHADER_NAME)]
-    public class PQSMainShaderLoader : BaseMaterialLoader
+    public class PQSMainShaderLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainTriplanarZoomRotationLoader.SHADER_NAME)]
-    public class PQSMainTriplanarZoomRotationLoader : BaseMaterialLoader
+    public class PQSMainTriplanarZoomRotationLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Triplanar Zoom Rotation";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
@@ -37,7 +37,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSOceanSurfaceQuadFallbackLoader.SHADER_NAME)]
-    public class PQSOceanSurfaceQuadFallbackLoader : BaseMaterialLoader
+    public class PQSOceanSurfaceQuadFallbackLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad (Fallback)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSOceanSurfaceQuadLoader.SHADER_NAME)]
-    public class PQSOceanSurfaceQuadLoader : BaseMaterialLoader
+    public class PQSOceanSurfaceQuadLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSProjectionAerialQuadRelativeLoader.SHADER_NAME)]
-    public class PQSProjectionAerialQuadRelativeLoader : BaseMaterialLoader
+    public class PQSProjectionAerialQuadRelativeLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (AP) ";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
@@ -37,7 +37,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSProjectionFallbackLoader.SHADER_NAME)]
-    public class PQSProjectionFallbackLoader : BaseMaterialLoader
+    public class PQSProjectionFallbackLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (Fallback) ";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSProjectionSurfaceQuadLoader.SHADER_NAME)]
-    public class PQSProjectionSurfaceQuadLoader : BaseMaterialLoader
+    public class PQSProjectionSurfaceQuadLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSTriplanarZoomRotationLoader.SHADER_NAME)]
-    public class PQSTriplanarZoomRotationLoader : BaseMaterialLoader
+    public class PQSTriplanarZoomRotationLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
@@ -39,7 +39,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSTriplanarZoomRotationTextureArrayLoader.SHADER_NAME)]
-    public class PQSTriplanarZoomRotationTextureArrayLoader : BaseMaterialLoader
+    public class PQSTriplanarZoomRotationTextureArrayLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation Texture Array";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialMultiKeywordParser.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialMultiKeywordParser.cs
@@ -32,7 +32,7 @@ namespace Kopernicus.Configuration.MaterialLoader.Parsing;
 /// <summary>
 /// A value-holding parser for shader multi-keyword properties (one of N
 /// allowed string keywords). Validation against the allowed set lives on
-/// <see cref="BaseMaterialLoader.SetMultiKeyword"/> so the property setter
+/// <see cref="MaterialLoader.SetMultiKeyword"/> so the property setter
 /// only has to forward.
 /// </summary>
 [RequireConfigType(ConfigType.Value)]

--- a/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialTextureParser.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/Parsing/MaterialTextureParser.cs
@@ -31,7 +31,7 @@ namespace Kopernicus.Configuration.MaterialLoader.Parsing;
 
 /// <summary>
 /// A value-holding parser for shader texture properties. The parsed string
-/// path is preserved so <see cref="BaseMaterialLoader.SetTexture(string, MaterialTextureParser)"/>
+/// path is preserved so <see cref="MaterialLoader.SetTexture(string, MaterialTextureParser)"/>
 /// can route through the on-demand pipeline, BUILTIN/ lookups, or
 /// synchronous loading as needed.
 /// </summary>

--- a/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ParticleAddSmoothLoader.SHADER_NAME)]
-    public class ParticleAddSmoothLoader : BaseMaterialLoader
+    public class ParticleAddSmoothLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Legacy Shaders/Particles/Additive (Soft)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetRimAerialLoader.SHADER_NAME)]
-    public class ScaledPlanetRimAerialLoader : BaseMaterialLoader
+    public class ScaledPlanetRimAerialLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetRimAerialStandardLoader.SHADER_NAME)]
-    public class ScaledPlanetRimAerialStandardLoader : BaseMaterialLoader
+    public class ScaledPlanetRimAerialStandardLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial) Standard";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetRimLightLoader.SHADER_NAME)]
-    public class ScaledPlanetRimLightLoader : BaseMaterialLoader
+    public class ScaledPlanetRimLightLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (RimLight)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetSimpleLoader.SHADER_NAME)]
-    public class ScaledPlanetSimpleLoader : BaseMaterialLoader
+    public class ScaledPlanetSimpleLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (Simple)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(StandardLoader.SHADER_NAME)]
-    public class StandardLoader : BaseMaterialLoader
+    public class StandardLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Standard";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(StandardSpecularLoader.SHADER_NAME)]
-    public class StandardSpecularLoader : BaseMaterialLoader
+    public class StandardSpecularLoader : MaterialLoader
     {
         public const String SHADER_NAME = "Standard (Specular setup)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/ModLoader/LandControl.cs
+++ b/src/Kopernicus/Configuration/ModLoader/LandControl.cs
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.ModLoader
 
             // Backing storage for the parsed material loader. Committed to
             // Value.material in PostApply.
-            private BaseMaterialLoader _material;
+            private MaterialLoader.MaterialLoader _material;
 
             private Material CurrentMaterial => _material?.Value ?? Value.material;
 
@@ -141,7 +141,7 @@ namespace Kopernicus.Configuration.ModLoader
             // the [PreApply] Type setter or by the IParserApplyEventSubscriber
             // Apply hook below.
             [ParserTarget("Material", AllowMerge = true)]
-            public BaseMaterialLoader Material
+            public MaterialLoader.MaterialLoader Material
             {
                 get => _material;
                 set => _material = value;
@@ -166,7 +166,7 @@ namespace Kopernicus.Configuration.ModLoader
             // so subsequent edits preserve the material's existing textures and
             // properties. Returns null for unknown shaders — caller must supply
             // a loader some other way (materialType= or Material{shader=}).
-            private static BaseMaterialLoader WrapExistingMaterial(Material existing)
+            private static MaterialLoader.MaterialLoader WrapExistingMaterial(Material existing)
             {
                 if (existing == null)
                     return null;
@@ -494,7 +494,7 @@ namespace Kopernicus.Configuration.ModLoader
             {
                 var shaderName = node.GetNode("Material")?.GetValue("shader")
                                  ?? MaterialTypeToShaderName(Type.Value);
-                _material = BaseMaterialLoader.Create(shaderName, Value.material);
+                _material = MaterialLoader.MaterialLoader.Create(shaderName, Value.material);
             }
 
             private static string MaterialTypeToShaderName(ScatterMaterialType type) => type switch

--- a/src/Kopernicus/Configuration/OceanLoader.cs
+++ b/src/Kopernicus/Configuration/OceanLoader.cs
@@ -173,7 +173,7 @@ namespace Kopernicus.Configuration
         // Surface Material of the PQS
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public BaseMaterialLoader SurfaceMaterial
+        public MaterialLoader.MaterialLoader SurfaceMaterial
         {
             get => field ??= new PQSOceanSurfaceQuadLoader(BasicSurfaceMaterial);
             set => field = value;
@@ -182,7 +182,7 @@ namespace Kopernicus.Configuration
         // Fallback Material of the PQS
         [ParserTarget("FallbackMaterial", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public BaseMaterialLoader FallbackMaterial
+        public MaterialLoader.MaterialLoader FallbackMaterial
         {
             get => field ??= new PQSOceanSurfaceQuadFallbackLoader(Value.fallbackMaterial);
             set => field = value;
@@ -396,10 +396,10 @@ namespace Kopernicus.Configuration
             Parser.SetState("Kopernicus:pqsVersion", () => Value);
             Parser.SetState("Kopernicus:pqsOnDemandHandler", () => handler);
 
-            SurfaceMaterial = BaseMaterialLoader.Create(
+            SurfaceMaterial = MaterialLoader.MaterialLoader.Create(
                 node.GetNode("Material")?.GetValue("shader") ?? PQSOceanSurfaceQuadLoader.SHADER_NAME,
                 BasicSurfaceMaterial);
-            FallbackMaterial = BaseMaterialLoader.Create(
+            FallbackMaterial = MaterialLoader.MaterialLoader.Create(
                 node.GetNode("FallbackMaterial")?.GetValue("shader") ?? PQSOceanSurfaceQuadFallbackLoader.SHADER_NAME,
                 Value.fallbackMaterial);
 

--- a/src/Kopernicus/Configuration/PQSLoader.cs
+++ b/src/Kopernicus/Configuration/PQSLoader.cs
@@ -174,12 +174,12 @@ namespace Kopernicus.Configuration
         // Surface Material of the PQS.
         [ParserTarget("Material", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public BaseMaterialLoader SurfaceMaterial { get; set; }
+        public MaterialLoader.MaterialLoader SurfaceMaterial { get; set; }
 
         // Fallback Material of the PQS.
         [ParserTarget("FallbackMaterial", AllowMerge = true, GetChild = false)]
         [KittopiaUntouchable]
-        public BaseMaterialLoader FallbackMaterial
+        public MaterialLoader.MaterialLoader FallbackMaterial
         {
             get => field ??= new PQSProjectionFallbackLoader(Value.fallbackMaterial);
             set => field = value;
@@ -481,7 +481,7 @@ namespace Kopernicus.Configuration
             Parser.SetState("Kopernicus:pqsOnDemandHandler", () => handler);
 
             SurfaceMaterial = GetInitialSurfaceMaterialLoader(node.GetNode("Material"));
-            FallbackMaterial = BaseMaterialLoader.Create(
+            FallbackMaterial = MaterialLoader.MaterialLoader.Create(
                 node.GetNode("FallbackMaterial")?.GetValue("shader") ?? PQSProjectionFallbackLoader.SHADER_NAME,
                 Value.fallbackMaterial);
 
@@ -547,12 +547,12 @@ namespace Kopernicus.Configuration
             _ => null,
         };
 
-        BaseMaterialLoader GetInitialSurfaceMaterialLoader(ConfigNode node)
+        MaterialLoader.MaterialLoader GetInitialSurfaceMaterialLoader(ConfigNode node)
         {
             var material = BasicSurfaceMaterial;
             var materialType = NewMaterialType?.Value ?? GetInitialMaterialType();
             var shaderName = node?.GetValue("shader") ?? MaterialTypeToShaderName(materialType);
-            return BaseMaterialLoader.Create(shaderName, material);
+            return MaterialLoader.MaterialLoader.Create(shaderName, material);
         }
 
     }

--- a/src/Kopernicus/Configuration/ScaledVersionLoader.cs
+++ b/src/Kopernicus/Configuration/ScaledVersionLoader.cs
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration
         public CelestialBody Value { get; set; }
 
         [RequireConfigType(ConfigType.Node)]
-        public class OnDemandConfig(BaseMaterialLoader loader)
+        public class OnDemandConfig(MaterialLoader.MaterialLoader loader)
         {
             [ParserTarget("texture")]
             [ParserTarget("mainTex")]
@@ -201,7 +201,7 @@ namespace Kopernicus.Configuration
 
         [ParserTarget("Material", AllowMerge = true)]
         [KittopiaUntouchable]
-        public BaseMaterialLoader Material { get; set; }
+        public MaterialLoader.MaterialLoader Material { get; set; }
 
         static string MaterialTypeToShaderName(ScaledMaterialType? type) => type switch
         {
@@ -357,10 +357,10 @@ namespace Kopernicus.Configuration
             return ScaledMaterialType.Custom;
         }
 
-        BaseMaterialLoader GetScaledMaterialLoader(ConfigNode node)
+        MaterialLoader.MaterialLoader GetScaledMaterialLoader(ConfigNode node)
         {
             string shaderName = node?.GetValue("shader") ?? MaterialTypeToShaderName(Type.Value);
-            return BaseMaterialLoader.Create(shaderName, CurrentMaterial);
+            return MaterialLoader.MaterialLoader.Create(shaderName, CurrentMaterial);
         }
 
         /// <summary>

--- a/src/Kopernicus/Injector.cs
+++ b/src/Kopernicus/Injector.cs
@@ -150,7 +150,7 @@ namespace Kopernicus
 #endif
 
                 // Find all material loaders
-                BaseMaterialLoader.BuildRegistry();
+                MaterialLoader.BuildRegistry();
 
                 // Backup the old prefab
                 StockSystemPrefab = PSystemManager.Instance.systemPrefab;


### PR DESCRIPTION
This better reflects what it's actually doing anyways, and since it is the entry point for all custom material loaders it is better to give it a more useful name.