### PR TITLE
Remove duplicate call to ScaledSpaceOnDemand.Start

### DIFF
--- a/src/Kopernicus/RuntimeUtility/MainMenuFixer.cs
+++ b/src/Kopernicus/RuntimeUtility/MainMenuFixer.cs
@@ -136,7 +136,6 @@ namespace Kopernicus.RuntimeUtility
             ScaledSpaceOnDemand od = planetCb.scaledBody.GetComponentInChildren<ScaledSpaceOnDemand>();
             if (od != null)
             {
-                od.Start();
                 od.LoadTextures();
             }
 


### PR DESCRIPTION
This seems to be something that originally made sense, but since fc0984c1 it no longer does. I think it was originally called on a disabled object. While that might have been questionable but working originally, with the changes to use the active scene object it no longer makes sense.

This just removes the call.

Fixes #861