### PR TITLE
Fix an infinite loop in `RuntimeObjects.AsteroidDaemon`

### DIFF
--- a/src/Kopernicus/Configuration/ConfigReader.cs
+++ b/src/Kopernicus/Configuration/ConfigReader.cs
@@ -34,6 +34,13 @@ using UnityEngine;
 
 namespace Kopernicus.Configuration
 {
+    public enum AsteroidSpawner
+    {
+        True,
+        False,
+        Stock
+    }
+
     public class ConfigReader
     {
         [Persistent]
@@ -44,8 +51,8 @@ namespace Kopernicus.Configuration
         public bool WarnShaders = false;
         [Persistent]
         public int EnforcedShaderLevel = 2;
-        [Persistent]
-        public string UseKopernicusAsteroidSystem = "True";
+        // Enum parsing is case-sensitive, so this is loaded manually below.
+        public AsteroidSpawner UseKopernicusAsteroidSystem = AsteroidSpawner.True;
         [Persistent]
         public int SolarRefreshRate = 1;
         [Persistent]
@@ -110,6 +117,14 @@ namespace Kopernicus.Configuration
             try
             {
                 ConfigNode.LoadObjectFromConfig(this, baseConfigs[0].config);
+
+                string rawAsteroidSystem = baseConfigs[0].config.GetValue("UseKopernicusAsteroidSystem");
+                if (!string.IsNullOrEmpty(rawAsteroidSystem)
+                    && Enum.TryParse(rawAsteroidSystem, ignoreCase: true, out AsteroidSpawner parsedAsteroidSystem))
+                {
+                    UseKopernicusAsteroidSystem = parsedAsteroidSystem;
+                }
+
                 Debug.Log("[Kopernicus Configurations] Using: ");
                 Debug.Log("HomeWorldName: " + HomeWorldName);
                 Debug.Log("EnforceShaders: " + EnforceShaders);

--- a/src/Kopernicus/RuntimeUtility/DiscoverableObjects.cs
+++ b/src/Kopernicus/RuntimeUtility/DiscoverableObjects.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Expansions.Missions.Actions;
+using Kopernicus.Configuration;
 using Kopernicus.Configuration.DiscoverableObjects;
 using Kopernicus.Constants;
 using KSPAchievements;
@@ -68,45 +69,40 @@ namespace Kopernicus.RuntimeUtility
         // Startup
         private void Start()
         {
-            if (!RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem.ToLower().Equals("stock"))
+            switch (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem)
             {
-                // Kill old Scenario Discoverable Objects without editing the collection while iterating through the same collection
-                // @Squad: I stab you with a try { } catch { } block.
-
-                if (HighLogic.CurrentGame.RemoveProtoScenarioModule(typeof(ScenarioDiscoverableObjects)))
-                {
-                    // RemoveProtoScenarioModule doesn't remove the actual Scenario; workaround!
-                    foreach (Object o in
-                        Resources.FindObjectsOfTypeAll(typeof(ScenarioDiscoverableObjects)))
-                    {
-                        ScenarioDiscoverableObjects scenario = (ScenarioDiscoverableObjects)o;
-                        scenario.StopAllCoroutines();
-                        Destroy(scenario);
-                    }
-                }
-                if (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem.ToLower().Equals("true"))
-                {
+                case AsteroidSpawner.True:
+                    KillStockScenarioDiscoverableObjects();
                     Debug.Log("[Kopernicus] Using Kopernicus Discoverable Object Spawner.");
                     AsteroidSetup();
                     foreach (var asteroidGroup in Asteroids)
                     {
                         StartCoroutine(AsteroidDaemon(asteroidGroup));
                     }
-                }
-                else if (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem.ToLower().Equals("false"))
-                {
+                    break;
+                case AsteroidSpawner.False:
+                    KillStockScenarioDiscoverableObjects();
                     Debug.Log("[Kopernicus] Discoverable Object Spawners disabled.  Unless external spawner mod is installed no discoverable objects will be spawned.");
-                }
-                else
-                {
-                    Injector.DisplayWarning();
-                    throw new InvalidCastException("Invalid value for Enum UseKopernicusAsteroidSystem.  Valid values are true, false, and stock.");
-                }
-
+                    break;
+                case AsteroidSpawner.Stock:
+                    Debug.Log("[Kopernicus] Using stock Squad Discoverable Object Spawner.");
+                    break;
             }
-            else if (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem.ToLower().Equals("stock"))
+        }
+
+        private static void KillStockScenarioDiscoverableObjects()
+        {
+            // Kill old Scenario Discoverable Objects without editing the collection while iterating through the same collection
+            // @Squad: I stab you with a try { } catch { } block.
+            if (HighLogic.CurrentGame.RemoveProtoScenarioModule(typeof(ScenarioDiscoverableObjects)))
             {
-                Debug.Log("[Kopernicus] Using stock Squad Discoverable Object Spawner.");
+                // RemoveProtoScenarioModule doesn't remove the actual Scenario; workaround!
+                foreach (Object o in Resources.FindObjectsOfTypeAll(typeof(ScenarioDiscoverableObjects)))
+                {
+                    ScenarioDiscoverableObjects scenario = (ScenarioDiscoverableObjects)o;
+                    scenario.StopAllCoroutines();
+                    Destroy(scenario);
+                }
             }
         }
 
@@ -321,7 +317,7 @@ namespace Kopernicus.RuntimeUtility
         {
             while (true)
             {
-                if (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem.ToLower().Equals("true"))
+                if (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem == AsteroidSpawner.True)
                 {
                     // Update Asteroids
                     UpdateAsteroid(asteroidGroup);

--- a/src/Kopernicus/RuntimeUtility/DiscoverableObjects.cs
+++ b/src/Kopernicus/RuntimeUtility/DiscoverableObjects.cs
@@ -312,27 +312,21 @@ namespace Kopernicus.RuntimeUtility
         }
 
         // Asteroid Spawner
-        [SuppressMessage("ReSharper", "IteratorNeverReturns")]
         private IEnumerator<WaitForSecondsRealtime> AsteroidDaemon(Asteroid asteroidGroup)
         {
-            while (true)
+            while (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem == AsteroidSpawner.True)
             {
-                if (RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem == AsteroidSpawner.True)
-                {
-                    // Update Asteroids
-                    UpdateAsteroid(asteroidGroup);
-                    // Don't adjust waiting time if we're in physical timewarp, and don't reduce interval by more than /50 when in on-rails timewarp.
-                    float waitSeconds = TimeWarp.WarpMode == TimeWarp.Modes.LOW
-                        ? Mathf.Max(asteroidGroup.Interval, spawnInterval)
-                        : Mathf.Max(asteroidGroup.Interval / Mathf.Min(TimeWarp.CurrentRate, 50), spawnInterval);
+                UpdateAsteroid(asteroidGroup);
+                // Don't adjust waiting time if we're in physical timewarp, and don't reduce interval by more than /50 when in on-rails timewarp.
+                float waitSeconds = TimeWarp.WarpMode == TimeWarp.Modes.LOW
+                    ? Mathf.Max(asteroidGroup.Interval, spawnInterval)
+                    : Mathf.Max(asteroidGroup.Interval / Mathf.Min(TimeWarp.CurrentRate, 50), spawnInterval);
 
-                    // Add some random jitter to the wait time.
-                    float minMaxJitter = waitSeconds / 4;
-                    waitSeconds = Random.Range(waitSeconds - minMaxJitter, waitSeconds + minMaxJitter);
+                // Add some random jitter to the wait time.
+                float minMaxJitter = waitSeconds / 4;
+                waitSeconds = Random.Range(waitSeconds - minMaxJitter, waitSeconds + minMaxJitter);
 
-                    // Wait
-                    yield return new WaitForSecondsRealtime(waitSeconds);
-                }
+                yield return new WaitForSecondsRealtime(waitSeconds);
             }
         }
 

--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -907,7 +907,7 @@ namespace Kopernicus.RuntimeUtility
         private static void PatchContracts()
         {
             //Small Contract fixer to remove Sentinel Contracts
-            if (ContractSystem.ContractTypes != null && !KopernicusConfig.UseKopernicusAsteroidSystem.ToLower().Equals("stock"))
+            if (ContractSystem.ContractTypes != null && KopernicusConfig.UseKopernicusAsteroidSystem != AsteroidSpawner.Stock)
             {
                 if (ContractSystem.ContractTypes.Remove(typeof(SentinelContract)))
                 {
@@ -1069,12 +1069,8 @@ namespace Kopernicus.RuntimeUtility
                 if (KopernicusConfig.EnforcedShaderLevel != defaults.EnforcedShaderLevel)
                     configFile.WriteLine("\t%EnforcedShaderLevel = " + KopernicusConfig.EnforcedShaderLevel);
 
-                // Validate UseKopernicusAsteroidSystem before comparing
-                string asteroidSystem = KopernicusConfig.UseKopernicusAsteroidSystem;
-                if (!asteroidSystem.ToLower().Equals("true") && !asteroidSystem.ToLower().Equals("false") && !asteroidSystem.ToLower().Equals("stock"))
-                    asteroidSystem = defaults.UseKopernicusAsteroidSystem;
-                if (asteroidSystem != defaults.UseKopernicusAsteroidSystem)
-                    configFile.WriteLine("\t%UseKopernicusAsteroidSystem = " + asteroidSystem);
+                if (KopernicusConfig.UseKopernicusAsteroidSystem != defaults.UseKopernicusAsteroidSystem)
+                    configFile.WriteLine("\t%UseKopernicusAsteroidSystem = " + KopernicusConfig.UseKopernicusAsteroidSystem);
 
                 if (KopernicusConfig.SolarRefreshRate != defaults.SolarRefreshRate)
                     configFile.WriteLine("\t%SolarRefreshRate = " + KopernicusConfig.SolarRefreshRate);

--- a/src/Kopernicus/UI/ToolbarButton.cs
+++ b/src/Kopernicus/UI/ToolbarButton.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using UnityEngine;
 using KSP.UI.Screens;
 using KSP;
+using Kopernicus.Configuration;
 using Kopernicus.RuntimeUtility;
 using Expansions.Missions;
 using static Targeting;
@@ -114,7 +115,16 @@ namespace Kopernicus.UI
             RuntimeUtility.RuntimeUtility.KopernicusConfig.UseOnDemandLoader = GUILayout.Toggle(RuntimeUtility.RuntimeUtility.KopernicusConfig.UseOnDemandLoader, "UseOnDemandLoader: Turning this on can save ram and thus improve perforamnce situationally but will break some mods requiring long distance viewing and also increase stutter.", toggleStyle);
             GUILayout.Label("UseKopernicusAsteroidSystem: Three valid values, True, False, and Stock. True means use the old customizable Kopernicus asteroid generator with no comet support,  False means don't do anything/wait for an external generator. Stock means use the internal games generator.", labelStyle);
             GUILayout.BeginHorizontal();
-            RuntimeUtility.RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem = GUILayout.TextField(RuntimeUtility.RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem.ToString());
+            if (GUILayout.Button(RuntimeUtility.RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem.ToString()))
+            {
+                var current = RuntimeUtility.RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem;
+                RuntimeUtility.RuntimeUtility.KopernicusConfig.UseKopernicusAsteroidSystem = current switch
+                {
+                    AsteroidSpawner.True => AsteroidSpawner.False,
+                    AsteroidSpawner.False => AsteroidSpawner.Stock,
+                    _ => AsteroidSpawner.True,
+                };
+            }
             GUILayout.Label("RESTART REQUIRED WHEN CHANGING ASTEROID SPAWNER", labelStyle);
             GUILayout.EndHorizontal();
 


### PR DESCRIPTION
If the `UseKopernicusAsteroidSystem` setting is ever changed from `true` to anything else then the coroutine for this enters an infinite loop.

This PR does two things:
* Converts `UseKopernicusAsteroidSystem` to use an enum, and the settings menu to have a button that cycles between the options.
* Makes it so `RuntimeObjects.AsteroidDaemon` automatically exits when the enum is not `True`.

Fixes #857 