### PR TITLE
fix: Hide rings in the main menu

### DIFF
--- a/src/Kopernicus/RuntimeUtility/MainMenuFixer.cs
+++ b/src/Kopernicus/RuntimeUtility/MainMenuFixer.cs
@@ -150,6 +150,10 @@ namespace Kopernicus.RuntimeUtility
             DestroyImmediate(menuPlanet.GetComponent<SphereCollider>());
             DestroyImmediate(menuPlanet.GetComponentInChildren<AtmosphereFromGround>());
             DestroyImmediate(menuPlanet.GetComponent<MaterialSetDirection>());
+            foreach (Components.Ring ring in menuPlanet.GetComponentsInChildren<Components.Ring>(true))
+            {
+                DestroyImmediate(ring.gameObject);
+            }
 
             // That sounds funny
             Rotato planetRotato = menuPlanet.AddComponent<Rotato>();


### PR DESCRIPTION
So the ring shader appears to render over top of the main menu. This is rather problematic and for now the best solution seems to be to hide the rings in the main menu.

Image for context
<img width="2398" height="1289" alt="image" src="https://github.com/user-attachments/assets/f53d9dcf-2fcd-4835-971d-e09ccd175100" />
