### PR TITLE
Throw an error if PQS or scaled space shaders are used wrongly

### DIFF
--- a/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(EmissiveMultiRampSunspotsLoader.SHADER_NAME)]
-    public class EmissiveMultiRampSunspotsLoader : MaterialLoader
+    public class EmissiveMultiRampSunspotsLoader : ScaledMaterialLoader
     {
         public const String SHADER_NAME = "Emissive Multi Ramp Sunspots";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
@@ -42,7 +42,7 @@ namespace Kopernicus.Configuration.MaterialLoader
     /// </summary>
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(GasGiantLoader.SHADER_NAME)]
-    public class GasGiantLoader : MaterialLoader
+    public class GasGiantLoader : ScaledMaterialLoader
     {
         public const string SHADER_NAME = "Terrain/Gas Giant";
         private static readonly Shader Shader = UnityEngine.Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainExtrasLoader.SHADER_NAME)]
-    public class PQSMainExtrasLoader : MaterialLoader
+    public class PQSMainExtrasLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main - Extras";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainFastBlendLoader.SHADER_NAME)]
-    public class PQSMainFastBlendLoader : MaterialLoader
+    public class PQSMainFastBlendLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Fast Blend";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainOptimisedFastBlendLoader.SHADER_NAME)]
-    public class PQSMainOptimisedFastBlendLoader : MaterialLoader
+    public class PQSMainOptimisedFastBlendLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised With Fast Blend";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainOptimisedLoader.SHADER_NAME)]
-    public class PQSMainOptimisedLoader : MaterialLoader
+    public class PQSMainOptimisedLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main - Optimised";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainShaderLoader.SHADER_NAME)]
-    public class PQSMainShaderLoader : MaterialLoader
+    public class PQSMainShaderLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSMainTriplanarZoomRotationLoader.SHADER_NAME)]
-    public class PQSMainTriplanarZoomRotationLoader : MaterialLoader
+    public class PQSMainTriplanarZoomRotationLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Main Shader - Triplanar Zoom Rotation";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMaterialLoader.cs
@@ -1,0 +1,47 @@
+/**
+ * Kopernicus Planetary System Modifier
+ * -------------------------------------------------------------
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ *
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright of TakeTwo Interactive. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ *
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using Kopernicus.Components;
+using Kopernicus.OnDemand;
+using UnityEngine;
+
+namespace Kopernicus.Configuration.MaterialLoader;
+
+/// <summary>
+/// Intermediate base for material loaders that target a <see cref="PQS"/>
+/// (surface, fallback, or ocean). Refuses to be applied to a PQS mod scatter
+/// or to a <c>ScaledVersion</c> renderer.
+/// </summary>
+public abstract class PQSMaterialLoader : MaterialLoader
+{
+    public override void OnParentApply(IPQSModWithMaterial mod, PQSMod_OnDemandHandler handler)
+        => throw new InvalidOperationException(
+            $"Material loader `{GetType().Name}` is for PQS materials and cannot be used as a PQS mod scatter material");
+
+    public override void OnParentApply(GameObject scaledBody)
+        => throw new InvalidOperationException(
+            $"Material loader `{GetType().Name}` is for PQS materials and cannot be used as a ScaledVersion material");
+}

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
@@ -37,7 +37,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSOceanSurfaceQuadFallbackLoader.SHADER_NAME)]
-    public class PQSOceanSurfaceQuadFallbackLoader : MaterialLoader
+    public class PQSOceanSurfaceQuadFallbackLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad (Fallback)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSOceanSurfaceQuadLoader.SHADER_NAME)]
-    public class PQSOceanSurfaceQuadLoader : MaterialLoader
+    public class PQSOceanSurfaceQuadLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Ocean Surface Quad";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSProjectionAerialQuadRelativeLoader.SHADER_NAME)]
-    public class PQSProjectionAerialQuadRelativeLoader : MaterialLoader
+    public class PQSProjectionAerialQuadRelativeLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (AP) ";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
@@ -37,7 +37,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSProjectionFallbackLoader.SHADER_NAME)]
-    public class PQSProjectionFallbackLoader : MaterialLoader
+    public class PQSProjectionFallbackLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD (Fallback) ";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSProjectionSurfaceQuadLoader.SHADER_NAME)]
-    public class PQSProjectionSurfaceQuadLoader : MaterialLoader
+    public class PQSProjectionSurfaceQuadLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/Sphere Projection SURFACE QUAD";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSTriplanarZoomRotationLoader.SHADER_NAME)]
-    public class PQSTriplanarZoomRotationLoader : MaterialLoader
+    public class PQSTriplanarZoomRotationLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
@@ -39,7 +39,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(PQSTriplanarZoomRotationTextureArrayLoader.SHADER_NAME)]
-    public class PQSTriplanarZoomRotationTextureArrayLoader : MaterialLoader
+    public class PQSTriplanarZoomRotationTextureArrayLoader : PQSMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/PQS/PQS Triplanar Zoom Rotation Texture Array";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledMaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledMaterialLoader.cs
@@ -1,0 +1,46 @@
+/**
+ * Kopernicus Planetary System Modifier
+ * -------------------------------------------------------------
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ *
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright of TakeTwo Interactive. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ *
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using Kopernicus.Components;
+using Kopernicus.OnDemand;
+
+namespace Kopernicus.Configuration.MaterialLoader;
+
+/// <summary>
+/// Intermediate base for material loaders that target a <c>ScaledVersion</c>
+/// renderer. Refuses to be applied to a <see cref="PQS"/> surface/fallback
+/// material or to a PQS mod scatter.
+/// </summary>
+public abstract class ScaledMaterialLoader : MaterialLoader
+{
+    public override void OnParentApply(PQS pqs, PQSMod_OnDemandHandler handler)
+        => throw new InvalidOperationException(
+            $"Material loader `{GetType().Name}` is for ScaledVersion materials and cannot be used as a PQS material");
+
+    public override void OnParentApply(IPQSModWithMaterial mod, PQSMod_OnDemandHandler handler)
+        => throw new InvalidOperationException(
+            $"Material loader `{GetType().Name}` is for ScaledVersion materials and cannot be used as a PQS mod scatter material");
+}

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetRimAerialLoader.SHADER_NAME)]
-    public class ScaledPlanetRimAerialLoader : MaterialLoader
+    public class ScaledPlanetRimAerialLoader : ScaledMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
@@ -38,7 +38,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetRimAerialStandardLoader.SHADER_NAME)]
-    public class ScaledPlanetRimAerialStandardLoader : MaterialLoader
+    public class ScaledPlanetRimAerialStandardLoader : ScaledMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (RimAerial) Standard";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetRimLightLoader.SHADER_NAME)]
-    public class ScaledPlanetRimLightLoader : MaterialLoader
+    public class ScaledPlanetRimLightLoader : ScaledMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (RimLight)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 {
     [RequireConfigType(ConfigType.Node)]
     [MaterialLoader(ScaledPlanetSimpleLoader.SHADER_NAME)]
-    public class ScaledPlanetSimpleLoader : MaterialLoader
+    public class ScaledPlanetSimpleLoader : ScaledMaterialLoader
     {
         public const String SHADER_NAME = "Terrain/Scaled Planet (Simple)";
         private static readonly Shader Shader = Shader.Find(SHADER_NAME);


### PR DESCRIPTION
Attempting to use a PQS terrain shader on a rock is almost always going to be an error anyways, this just makes it so.