### PR TITLE
Drop `Setter` suffixes on material loader properties

### DIFF
--- a/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB) Trans (A), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -74,7 +74,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Alpha cutoff, default = 0.5
         [ParserTarget("texCutoff")]
-        public NumericParser<float> TexCutoffSetter
+        public NumericParser<float> TexCutoff
         {
             get => GetFloat("_texCutoff");
             set => SetFloat("_texCutoff", value);
@@ -82,7 +82,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Fog Color, default = (0,0,1,1)
         [ParserTarget("fogColor")]
-        public ColorParser FogColorSetter
+        public ColorParser FogColor
         {
             get => GetColor("_fogColor");
             set => SetColor("_fogColor", value);
@@ -90,7 +90,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Height Fall Off, default = 1
         [ParserTarget("heightFallOff")]
-        public NumericParser<float> HeightFallOffSetter
+        public NumericParser<float> HeightFallOff
         {
             get => GetFloat("_heightFallOff");
             set => SetFloat("_heightFallOff", value);
@@ -98,7 +98,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -106,7 +106,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Atmosphere Depth, default = 1
         [ParserTarget("atmosphereDepth")]
-        public NumericParser<float> AtmosphereDepthSetter
+        public NumericParser<float> AtmosphereDepth
         {
             get => GetFloat("_atmosphereDepth");
             set => SetFloat("_atmosphereDepth", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB) Trans (A), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -74,7 +74,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Alpha cutoff, default = 0.5
         [ParserTarget("cutoff")]
-        public NumericParser<float> CutoffSetter
+        public NumericParser<float> Cutoff
         {
             get => GetFloat("_Cutoff");
             set => SetFloat("_Cutoff", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
@@ -44,21 +44,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -66,7 +66,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -74,7 +74,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Diffuse, default = 2
         [ParserTarget("diff")]
-        public NumericParser<float> DiffSetter
+        public NumericParser<float> Diff
         {
             get => GetFloat("_Diff");
             set => SetFloat("_Diff", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
@@ -44,21 +44,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ramp Map (RGBA), default = "white" { }
         [ParserTarget("rampMap")]
-        public MaterialTextureParser RampMapSetter
+        public MaterialTextureParser RampMap
         {
-            get => null;
+            get => GetTexture("_RampMap")?.name;
             set => SetTexture("_RampMap", value);
         }
 
         [ParserTarget("rampMapScale")]
-        public Vector2Parser RampMapScaleSetter
+        public Vector2Parser RampMapScale
         {
             get => GetTextureScale("_RampMap");
             set => SetTextureScale("_RampMap", value);
         }
 
         [ParserTarget("rampMapOffset")]
-        public Vector2Parser RampMapOffsetSetter
+        public Vector2Parser RampMapOffset
         {
             get => GetTextureOffset("_RampMap");
             set => SetTextureOffset("_RampMap", value);
@@ -66,21 +66,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Noise Map (RGBA), default = "white" { }
         [ParserTarget("noiseMap")]
-        public MaterialTextureParser NoiseMapSetter
+        public MaterialTextureParser NoiseMap
         {
-            get => null;
+            get => GetTexture("_NoiseMap")?.name;
             set => SetTexture("_NoiseMap", value);
         }
 
         [ParserTarget("noiseMapScale")]
-        public Vector2Parser NoiseMapScaleSetter
+        public Vector2Parser NoiseMapScale
         {
             get => GetTextureScale("_NoiseMap");
             set => SetTextureScale("_NoiseMap", value);
         }
 
         [ParserTarget("noiseMapOffset")]
-        public Vector2Parser NoiseMapOffsetSetter
+        public Vector2Parser NoiseMapOffset
         {
             get => GetTextureOffset("_NoiseMap");
             set => SetTextureOffset("_NoiseMap", value);
@@ -88,7 +88,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Emission Color 0, default = (1,1,1,1)
         [ParserTarget("emitColor0")]
-        public ColorParser EmitColor0Setter
+        public ColorParser EmitColor0
         {
             get => GetColor("_EmitColor0");
             set => SetColor("_EmitColor0", value);
@@ -96,7 +96,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Emission Color 1, default = (1,1,1,1)
         [ParserTarget("emitColor1")]
-        public ColorParser EmitColor1Setter
+        public ColorParser EmitColor1
         {
             get => GetColor("_EmitColor1");
             set => SetColor("_EmitColor1", value);
@@ -104,21 +104,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Sunspot Map (R), default = "white" { }
         [ParserTarget("sunspotTex")]
-        public MaterialTextureParser SunspotTexSetter
+        public MaterialTextureParser SunspotTex
         {
-            get => null;
+            get => GetTexture("_SunspotTex")?.name;
             set => SetTexture("_SunspotTex", value);
         }
 
         [ParserTarget("sunspotTexScale")]
-        public Vector2Parser SunspotTexScaleSetter
+        public Vector2Parser SunspotTexScale
         {
             get => GetTextureScale("_SunspotTex");
             set => SetTextureScale("_SunspotTex", value);
         }
 
         [ParserTarget("sunspotTexOffset")]
-        public Vector2Parser SunspotTexOffsetSetter
+        public Vector2Parser SunspotTexOffset
         {
             get => GetTextureOffset("_SunspotTex");
             set => SetTextureOffset("_SunspotTex", value);
@@ -126,7 +126,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Sunspot Power, default = 1
         [ParserTarget("sunspotPower")]
-        public NumericParser<float> SunspotPowerSetter
+        public NumericParser<float> SunspotPower
         {
             get => GetFloat("_SunspotPower");
             set => SetFloat("_SunspotPower", value);
@@ -134,7 +134,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Sunspot Color, default = (0,0,0,0)
         [ParserTarget("sunspotColor")]
-        public ColorParser SunspotColorSetter
+        public ColorParser SunspotColor
         {
             get => GetColor("_SunspotColor");
             set => SetColor("_SunspotColor", value);
@@ -142,7 +142,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rimlight Color, default = (1,1,1,1)
         [ParserTarget("rimColor")]
-        public ColorParser RimColorSetter
+        public ColorParser RimColor
         {
             get => GetColor("_RimColor");
             set => SetColor("_RimColor", value);
@@ -150,7 +150,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rimlight Power, default = 0.2
         [ParserTarget("rimPower")]
-        public NumericParser<float> RimPowerSetter
+        public NumericParser<float> RimPower
         {
             get => GetFloat("_RimPower");
             set => SetFloat("_RimPower", value);
@@ -158,7 +158,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rimlight Blend, default = 0.2
         [ParserTarget("rimBlend")]
-        public NumericParser<float> RimBlendSetter
+        public NumericParser<float> RimBlend
         {
             get => GetFloat("_RimBlend");
             set => SetFloat("_RimBlend", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // movement speed, blue blends between the two band texture reads, and
         // alpha controls the swirl pan speed.
         [ParserTarget("movementControlTexture")]
-        public MaterialTextureParser MovementTextureSetter
+        public MaterialTextureParser MovementTexture
         {
-            get => null;
+            get => GetTexture("_MovementTexture")?.name;
             set => SetTexture("_MovementTexture", value);
         }
 
         [ParserTarget("movementControlTextureScale")]
-        public Vector2Parser MovementTextureScaleSetter
+        public Vector2Parser MovementTextureScale
         {
             get => GetTextureScale("_MovementTexture");
             set => SetTextureScale("_MovementTexture", value);
         }
 
         [ParserTarget("movementControlTextureOffset")]
-        public Vector2Parser MovementTextureOffsetSetter
+        public Vector2Parser MovementTextureOffset
         {
             get => GetTextureOffset("_MovementTexture");
             set => SetTextureOffset("_MovementTexture", value);
@@ -75,21 +75,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Swirl control texture. Red/green channels are the uv position of the
         // centre of rotation, blue is the swirl rotation amount.
         [ParserTarget("swirlControlTexture")]
-        public MaterialTextureParser SwirlRotationControlTextureSetter
+        public MaterialTextureParser SwirlRotationControlTexture
         {
-            get => null;
+            get => GetTexture("_SwirlRotationControlTexture")?.name;
             set => SetTexture("_SwirlRotationControlTexture", value);
         }
 
         [ParserTarget("swirlControlTextureScale")]
-        public Vector2Parser SwirlRotationControlTextureScaleSetter
+        public Vector2Parser SwirlRotationControlTextureScale
         {
             get => GetTextureScale("_SwirlRotationControlTexture");
             set => SetTextureScale("_SwirlRotationControlTexture", value);
         }
 
         [ParserTarget("swirlControlTextureOffset")]
-        public Vector2Parser SwirlRotationControlTextureOffsetSetter
+        public Vector2Parser SwirlRotationControlTextureOffset
         {
             get => GetTextureOffset("_SwirlRotationControlTexture");
             set => SetTextureOffset("_SwirlRotationControlTexture", value);
@@ -99,21 +99,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // channel, then blended with cloudColorMap2 by the pattern's green
         // channel.
         [ParserTarget("colorMap")]
-        public MaterialTextureParser CloudColorMapSetter
+        public MaterialTextureParser CloudColorMap
         {
-            get => null;
+            get => GetTexture("_CloudColorMap")?.name;
             set => SetTexture("_CloudColorMap", value);
         }
 
         [ParserTarget("colorMapScale")]
-        public Vector2Parser CloudColorMapScaleSetter
+        public Vector2Parser CloudColorMapScale
         {
             get => GetTextureScale("_CloudColorMap");
             set => SetTextureScale("_CloudColorMap", value);
         }
 
         [ParserTarget("colorMapOffset")]
-        public Vector2Parser CloudColorMapOffsetSetter
+        public Vector2Parser CloudColorMapOffset
         {
             get => GetTextureOffset("_CloudColorMap");
             set => SetTextureOffset("_CloudColorMap", value);
@@ -121,21 +121,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Second far-texturing colour ramp; blended against colorMap.
         [ParserTarget("colorMap2")]
-        public MaterialTextureParser CloudColorMap2Setter
+        public MaterialTextureParser CloudColorMap2
         {
-            get => null;
+            get => GetTexture("_CloudColorMap2")?.name;
             set => SetTexture("_CloudColorMap2", value);
         }
 
         [ParserTarget("colorMap2Scale")]
-        public Vector2Parser CloudColorMap2ScaleSetter
+        public Vector2Parser CloudColorMap2Scale
         {
             get => GetTextureScale("_CloudColorMap2");
             set => SetTextureScale("_CloudColorMap2", value);
         }
 
         [ParserTarget("colorMap2Offset")]
-        public Vector2Parser CloudColorMap2OffsetSetter
+        public Vector2Parser CloudColorMap2Offset
         {
             get => GetTextureOffset("_CloudColorMap2");
             set => SetTextureOffset("_CloudColorMap2", value);
@@ -143,21 +143,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near-texturing colour ramp; sampled with the detail cloud pattern.
         [ParserTarget("detailColorMap")]
-        public MaterialTextureParser DetailCloudColorMapSetter
+        public MaterialTextureParser DetailCloudColorMap
         {
-            get => null;
+            get => GetTexture("_DetailCloudColorMap")?.name;
             set => SetTexture("_DetailCloudColorMap", value);
         }
 
         [ParserTarget("detailColorMapScale")]
-        public Vector2Parser DetailCloudColorMapScaleSetter
+        public Vector2Parser DetailCloudColorMapScale
         {
             get => GetTextureScale("_DetailCloudColorMap");
             set => SetTextureScale("_DetailCloudColorMap", value);
         }
 
         [ParserTarget("detailColorMapOffset")]
-        public Vector2Parser DetailCloudColorMapOffsetSetter
+        public Vector2Parser DetailCloudColorMapOffset
         {
             get => GetTextureOffset("_DetailCloudColorMap");
             set => SetTextureOffset("_DetailCloudColorMap", value);
@@ -166,21 +166,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Far-texturing pattern. Red channel is the pattern, green channel
         // controls the blend between colorMap and colorMap2.
         [ParserTarget("cloudPatternMap")]
-        public MaterialTextureParser CloudPatternTextureSetter
+        public MaterialTextureParser CloudPatternTexture
         {
-            get => null;
+            get => GetTexture("_CloudPatternTexture")?.name;
             set => SetTexture("_CloudPatternTexture", value);
         }
 
         [ParserTarget("cloudPatternMapScale")]
-        public Vector2Parser CloudPatternTextureScaleSetter
+        public Vector2Parser CloudPatternTextureScale
         {
             get => GetTextureScale("_CloudPatternTexture");
             set => SetTextureScale("_CloudPatternTexture", value);
         }
 
         [ParserTarget("cloudPatternMapOffset")]
-        public Vector2Parser CloudPatternTextureOffsetSetter
+        public Vector2Parser CloudPatternTextureOffset
         {
             get => GetTextureOffset("_CloudPatternTexture");
             set => SetTextureOffset("_CloudPatternTexture", value);
@@ -188,21 +188,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near-texturing pattern. Only the red channel is read.
         [ParserTarget("detailCloudPatternMap")]
-        public MaterialTextureParser DetailCloudPatternTextureSetter
+        public MaterialTextureParser DetailCloudPatternTexture
         {
-            get => null;
+            get => GetTexture("_DetailCloudPatternTexture")?.name;
             set => SetTexture("_DetailCloudPatternTexture", value);
         }
 
         [ParserTarget("detailCloudPatternMapScale")]
-        public Vector2Parser DetailCloudPatternTextureScaleSetter
+        public Vector2Parser DetailCloudPatternTextureScale
         {
             get => GetTextureScale("_DetailCloudPatternTexture");
             set => SetTextureScale("_DetailCloudPatternTexture", value);
         }
 
         [ParserTarget("detailCloudPatternMapOffset")]
-        public Vector2Parser DetailCloudPatternTextureOffsetSetter
+        public Vector2Parser DetailCloudPatternTextureOffset
         {
             get => GetTextureOffset("_DetailCloudPatternTexture");
             set => SetTextureOffset("_DetailCloudPatternTexture", value);
@@ -212,21 +212,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("normalMap")]
         [ParserTarget("normals")]
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser NormalMapSetter
+        public MaterialTextureParser NormalMap
         {
-            get => null;
+            get => GetTexture("_NormalMap")?.name;
             set => SetTexture("_NormalMap", value);
         }
 
         [ParserTarget("normalMapScale")]
-        public Vector2Parser NormalMapScaleSetter
+        public Vector2Parser NormalMapScale
         {
             get => GetTextureScale("_NormalMap");
             set => SetTextureScale("_NormalMap", value);
         }
 
         [ParserTarget("normalMapOffset")]
-        public Vector2Parser NormalMapOffsetSetter
+        public Vector2Parser NormalMapOffset
         {
             get => GetTextureOffset("_NormalMap");
             set => SetTextureOffset("_NormalMap", value);
@@ -234,21 +234,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near normal map.
         [ParserTarget("detailNormalMap")]
-        public MaterialTextureParser DetailNormalMapSetter
+        public MaterialTextureParser DetailNormalMap
         {
-            get => null;
+            get => GetTexture("_DetailNormalMap")?.name;
             set => SetTexture("_DetailNormalMap", value);
         }
 
         [ParserTarget("detailNormalMapScale")]
-        public Vector2Parser DetailNormalMapScaleSetter
+        public Vector2Parser DetailNormalMapScale
         {
             get => GetTextureScale("_DetailNormalMap");
             set => SetTextureScale("_DetailNormalMap", value);
         }
 
         [ParserTarget("detailNormalMapOffset")]
-        public Vector2Parser DetailNormalMapOffsetSetter
+        public Vector2Parser DetailNormalMapOffset
         {
             get => GetTextureOffset("_DetailNormalMap");
             set => SetTextureOffset("_DetailNormalMap", value);
@@ -256,7 +256,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // UV scale applied to the far uvs to produce the detail uvs.
         [ParserTarget("detailTiling")]
-        public NumericParser<float> DetailTilingSetter
+        public NumericParser<float> DetailTiling
         {
             get => GetFloat("_DetailTiling");
             set => SetFloat("_DetailTiling", value);
@@ -265,7 +265,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Camera distance at which detail texturing is at full nearDetail
         // strength.
         [ParserTarget("nearDetailDistance")]
-        public NumericParser<float> NearDistanceForDetailSetter
+        public NumericParser<float> NearDistanceForDetail
         {
             get => GetFloat("_NearDistanceForDetail");
             set => SetFloat("_NearDistanceForDetail", value);
@@ -274,7 +274,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Camera distance at which detail texturing is at full farDetail
         // strength. Detail blends between the two distances.
         [ParserTarget("farDetailDistance")]
-        public NumericParser<float> FarDistanceForDetailSetter
+        public NumericParser<float> FarDistanceForDetail
         {
             get => GetFloat("_FarDistanceForDetail");
             set => SetFloat("_FarDistanceForDetail", value);
@@ -282,7 +282,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Maximum strength of the detail texturing when zoomed in.
         [ParserTarget("nearDetailStrength")]
-        public NumericParser<float> NearDetailSetter
+        public NumericParser<float> NearDetail
         {
             get => GetFloat("_NearDetail");
             set => SetFloat("_NearDetail", value);
@@ -290,7 +290,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Maximum strength of the detail texturing when zoomed out.
         [ParserTarget("farDetailStrength")]
-        public NumericParser<float> FarDetailSetter
+        public NumericParser<float> FarDetail
         {
             get => GetFloat("_FarDetail");
             set => SetFloat("_FarDetail", value);
@@ -298,7 +298,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Band scroll speed. GasGiantMaterialControls clamps this to [-10, 10].
         [ParserTarget("bandMovementSpeed")]
-        public NumericParser<float> BandMovementSpeedSetter
+        public NumericParser<float> BandMovementSpeed
         {
             get => GetFloat("_BandMovementSpeed");
             set => SetFloat("_BandMovementSpeed", value);
@@ -306,7 +306,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Swirl rotation rate. GasGiantMaterialControls clamps this to [0, 10].
         [ParserTarget("swirlRotationSpeed")]
-        public NumericParser<float> SwirlRotationSpeedSetter
+        public NumericParser<float> SwirlRotationSpeed
         {
             get => GetFloat("_SwirlRotationSpeed");
             set => SetFloat("_SwirlRotationSpeed", value);
@@ -314,7 +314,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Final extent of the swirl rotation. Clamped to [-10, 10] at runtime.
         [ParserTarget("swirlRotationSwirliness")]
-        public NumericParser<float> SwirlRotationSwirlinessSetter
+        public NumericParser<float> SwirlRotationSwirliness
         {
             get => GetFloat("_SwirlRotationSwirliness");
             set => SetFloat("_SwirlRotationSwirliness", value);
@@ -322,7 +322,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Swirl pan speed. Clamped to [-10, 10] at runtime.
         [ParserTarget("swirlPanSpeed")]
-        public NumericParser<float> SwirlPanSpeedSetter
+        public NumericParser<float> SwirlPanSpeed
         {
             get => GetFloat("_SwirlPanSpeed");
             set => SetFloat("_SwirlPanSpeed", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
@@ -44,21 +44,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -66,21 +66,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -88,7 +88,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -96,7 +96,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<float> OpacitySetter
+        public NumericParser<float> Opacity
         {
             get => GetFloat("_Opacity");
             set => SetFloat("_Opacity", value);
@@ -104,7 +104,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _RimFalloff, default = 0.1
         [ParserTarget("rimFalloff")]
-        public NumericParser<float> RimFalloffSetter
+        public NumericParser<float> RimFalloff
         {
             get => GetFloat("_RimFalloff");
             set => SetFloat("_RimFalloff", value);
@@ -112,7 +112,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _RimColor, default = (0,0,0,0)
         [ParserTarget("rimColor")]
-        public ColorParser RimColorSetter
+        public ColorParser RimColor
         {
             get => GetColor("_RimColor");
             set => SetColor("_RimColor", value);
@@ -120,7 +120,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _TemperatureColor, default = (0,0,0,0)
         [ParserTarget("temperatureColor")]
-        public ColorParser TemperatureColorSetter
+        public ColorParser TemperatureColor
         {
             get => GetColor("_TemperatureColor");
             set => SetColor("_TemperatureColor", value);
@@ -128,7 +128,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Burn Color, default = (1,1,1,1)
         [ParserTarget("burnColor")]
-        public ColorParser BurnColorSetter
+        public ColorParser BurnColor
         {
             get => GetColor("_BurnColor");
             set => SetColor("_BurnColor", value);
@@ -136,7 +136,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Underwater Fog Factor, default = 0
         [ParserTarget("underwaterFogFactor")]
-        public NumericParser<float> UnderwaterFogFactorSetter
+        public NumericParser<float> UnderwaterFogFactor
         {
             get => GetFloat("_UnderwaterFogFactor");
             set => SetFloat("_UnderwaterFogFactor", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
@@ -44,21 +44,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -66,21 +66,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -88,7 +88,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -96,7 +96,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _SpecColor, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
-        public ColorParser SpecColorSetter
+        public ColorParser SpecColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -104,7 +104,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _Shininess, default = 1
         [ParserTarget("shininess")]
-        public NumericParser<float> ShininessSetter
+        public NumericParser<float> Shininess
         {
             get => GetFloat("_Shininess");
             set => SetFloat("_Shininess", value);
@@ -112,7 +112,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<float> OpacitySetter
+        public NumericParser<float> Opacity
         {
             get => GetFloat("_Opacity");
             set => SetFloat("_Opacity", value);
@@ -120,7 +120,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _RimFalloff, default = 0.1
         [ParserTarget("rimFalloff")]
-        public NumericParser<float> RimFalloffSetter
+        public NumericParser<float> RimFalloff
         {
             get => GetFloat("_RimFalloff");
             set => SetFloat("_RimFalloff", value);
@@ -128,7 +128,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _RimColor, default = (0,0,0,0)
         [ParserTarget("rimColor")]
-        public ColorParser RimColorSetter
+        public ColorParser RimColor
         {
             get => GetColor("_RimColor");
             set => SetColor("_RimColor", value);
@@ -136,7 +136,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // _TemperatureColor, default = (0,0,0,0)
         [ParserTarget("temperatureColor")]
-        public ColorParser TemperatureColorSetter
+        public ColorParser TemperatureColor
         {
             get => GetColor("_TemperatureColor");
             set => SetColor("_TemperatureColor", value);
@@ -144,7 +144,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Burn Color, default = (1,1,1,1)
         [ParserTarget("burnColor")]
-        public ColorParser BurnColorSetter
+        public ColorParser BurnColor
         {
             get => GetColor("_BurnColor");
             set => SetColor("_BurnColor", value);
@@ -152,7 +152,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Underwater Fog Factor, default = 0
         [ParserTarget("underwaterFogFactor")]
-        public NumericParser<float> UnderwaterFogFactorSetter
+        public NumericParser<float> UnderwaterFogFactor
         {
             get => GetFloat("_UnderwaterFogFactor");
             set => SetFloat("_UnderwaterFogFactor", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -74,21 +74,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -74,21 +74,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Detail (RGB), default = "gray" { }
         [ParserTarget("detail")]
-        public MaterialTextureParser DetailSetter
+        public MaterialTextureParser Detail
         {
-            get => null;
+            get => GetTexture("_Detail")?.name;
             set => SetTexture("_Detail", value);
         }
 
         [ParserTarget("detailScale")]
-        public Vector2Parser DetailScaleSetter
+        public Vector2Parser DetailScale
         {
             get => GetTextureScale("_Detail");
             set => SetTextureScale("_Detail", value);
         }
 
         [ParserTarget("detailOffset")]
-        public Vector2Parser DetailOffsetSetter
+        public Vector2Parser DetailOffset
         {
             get => GetTextureOffset("_Detail");
             set => SetTextureOffset("_Detail", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -70,7 +70,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<float> PowerNearSetter
+        public NumericParser<float> PowerNear
         {
             get => GetFloat("_powerNear");
             set => SetFloat("_powerNear", value);
@@ -78,7 +78,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<float> PowerFarSetter
+        public NumericParser<float> PowerFar
         {
             get => GetFloat("_powerFar");
             set => SetFloat("_powerFar", value);
@@ -86,7 +86,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -94,7 +94,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -102,7 +102,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -110,7 +110,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -118,7 +118,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -126,21 +126,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" {}
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -148,21 +148,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" {}
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -170,7 +170,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<float> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTiling
         {
             get => GetFloat("_steepNearTiling");
             set => SetFloat("_steepNearTiling", value);
@@ -178,7 +178,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -186,21 +186,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Texture, default = "white" {}
         [ParserTarget("lowTex")]
-        public MaterialTextureParser LowTexSetter
+        public MaterialTextureParser LowTex
         {
-            get => null;
+            get => GetTexture("_lowTex")?.name;
             set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
-        public Vector2Parser LowTexScaleSetter
+        public Vector2Parser LowTexScale
         {
             get => GetTextureScale("_lowTex");
             set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
-        public Vector2Parser LowTexOffsetSetter
+        public Vector2Parser LowTexOffset
         {
             get => GetTextureOffset("_lowTex");
             set => SetTextureOffset("_lowTex", value);
@@ -208,21 +208,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Map, default = "bump" {}
         [ParserTarget("lowBumpMap")]
-        public MaterialTextureParser LowBumpMapSetter
+        public MaterialTextureParser LowBumpMap
         {
-            get => null;
+            get => GetTexture("_lowBumpMap")?.name;
             set => SetTexture("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapScale")]
-        public Vector2Parser LowBumpMapScaleSetter
+        public Vector2Parser LowBumpMapScale
         {
             get => GetTextureScale("_lowBumpMap");
             set => SetTextureScale("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapOffset")]
-        public Vector2Parser LowBumpMapOffsetSetter
+        public Vector2Parser LowBumpMapOffset
         {
             get => GetTextureOffset("_lowBumpMap");
             set => SetTextureOffset("_lowBumpMap", value);
@@ -230,7 +230,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<float> LowNearTilingSetter
+        public NumericParser<float> LowNearTiling
         {
             get => GetFloat("_lowNearTiling");
             set => SetFloat("_lowNearTiling", value);
@@ -238,7 +238,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<float> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactor
         {
             get => GetFloat("_lowMultiFactor");
             set => SetFloat("_lowMultiFactor", value);
@@ -246,7 +246,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Near Tiling, default = 1
         [ParserTarget("lowBumpNearTiling")]
-        public NumericParser<float> LowBumpNearTilingSetter
+        public NumericParser<float> LowBumpNearTiling
         {
             get => GetFloat("_lowBumpNearTiling");
             set => SetFloat("_lowBumpNearTiling", value);
@@ -254,7 +254,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Far Tiling, default = 1
         [ParserTarget("lowBumpFarTiling")]
-        public NumericParser<float> LowBumpFarTilingSetter
+        public NumericParser<float> LowBumpFarTiling
         {
             get => GetFloat("_lowBumpFarTiling");
             set => SetFloat("_lowBumpFarTiling", value);
@@ -262,21 +262,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Texture, default = "white" {}
         [ParserTarget("midTex")]
-        public MaterialTextureParser MidTexSetter
+        public MaterialTextureParser MidTex
         {
-            get => null;
+            get => GetTexture("_midTex")?.name;
             set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
-        public Vector2Parser MidTexScaleSetter
+        public Vector2Parser MidTexScale
         {
             get => GetTextureScale("_midTex");
             set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
-        public Vector2Parser MidTexOffsetSetter
+        public Vector2Parser MidTexOffset
         {
             get => GetTextureOffset("_midTex");
             set => SetTextureOffset("_midTex", value);
@@ -284,21 +284,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Map, default = "bump" {}
         [ParserTarget("midBumpMap")]
-        public MaterialTextureParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMap
         {
-            get => null;
+            get => GetTexture("_midBumpMap")?.name;
             set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
-        public Vector2Parser MidBumpMapScaleSetter
+        public Vector2Parser MidBumpMapScale
         {
             get => GetTextureScale("_midBumpMap");
             set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
-        public Vector2Parser MidBumpMapOffsetSetter
+        public Vector2Parser MidBumpMapOffset
         {
             get => GetTextureOffset("_midBumpMap");
             set => SetTextureOffset("_midBumpMap", value);
@@ -306,7 +306,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<float> MidNearTilingSetter
+        public NumericParser<float> MidNearTiling
         {
             get => GetFloat("_midNearTiling");
             set => SetFloat("_midNearTiling", value);
@@ -314,7 +314,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<float> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactor
         {
             get => GetFloat("_midMultiFactor");
             set => SetFloat("_midMultiFactor", value);
@@ -322,7 +322,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<float> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTiling
         {
             get => GetFloat("_midBumpNearTiling");
             set => SetFloat("_midBumpNearTiling", value);
@@ -330,7 +330,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Far Tiling, default = 1
         [ParserTarget("midBumpFarTiling")]
-        public NumericParser<float> MidBumpFarTilingSetter
+        public NumericParser<float> MidBumpFarTiling
         {
             get => GetFloat("_midBumpFarTiling");
             set => SetFloat("_midBumpFarTiling", value);
@@ -338,21 +338,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Texture, default = "white" {}
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -360,21 +360,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Map, default = "bump" {}
         [ParserTarget("highBumpMap")]
-        public MaterialTextureParser HighBumpMapSetter
+        public MaterialTextureParser HighBumpMap
         {
-            get => null;
+            get => GetTexture("_highBumpMap")?.name;
             set => SetTexture("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapScale")]
-        public Vector2Parser HighBumpMapScaleSetter
+        public Vector2Parser HighBumpMapScale
         {
             get => GetTextureScale("_highBumpMap");
             set => SetTextureScale("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapOffset")]
-        public Vector2Parser HighBumpMapOffsetSetter
+        public Vector2Parser HighBumpMapOffset
         {
             get => GetTextureOffset("_highBumpMap");
             set => SetTextureOffset("_highBumpMap", value);
@@ -382,7 +382,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<float> HighNearTilingSetter
+        public NumericParser<float> HighNearTiling
         {
             get => GetFloat("_highNearTiling");
             set => SetFloat("_highNearTiling", value);
@@ -390,7 +390,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<float> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactor
         {
             get => GetFloat("_highMultiFactor");
             set => SetFloat("_highMultiFactor", value);
@@ -398,7 +398,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Near Tiling, default = 1
         [ParserTarget("highBumpNearTiling")]
-        public NumericParser<float> HighBumpNearTilingSetter
+        public NumericParser<float> HighBumpNearTiling
         {
             get => GetFloat("_highBumpNearTiling");
             set => SetFloat("_highBumpNearTiling", value);
@@ -406,7 +406,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Far Tiling, default = 1
         [ParserTarget("highBumpFarTiling")]
-        public NumericParser<float> HighBumpFarTilingSetter
+        public NumericParser<float> HighBumpFarTiling
         {
             get => GetFloat("_highBumpFarTiling");
             set => SetFloat("_highBumpFarTiling", value);
@@ -414,7 +414,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<float> LowStartSetter
+        public NumericParser<float> LowStart
         {
             get => GetFloat("_lowStart");
             set => SetFloat("_lowStart", value);
@@ -422,7 +422,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<float> LowEndSetter
+        public NumericParser<float> LowEnd
         {
             get => GetFloat("_lowEnd");
             set => SetFloat("_lowEnd", value);
@@ -430,7 +430,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<float> HighStartSetter
+        public NumericParser<float> HighStart
         {
             get => GetFloat("_highStart");
             set => SetFloat("_highStart", value);
@@ -438,7 +438,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<float> HighEndSetter
+        public NumericParser<float> HighEnd
         {
             get => GetFloat("_highEnd");
             set => SetFloat("_highEnd", value);
@@ -446,7 +446,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -454,29 +454,29 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" {}
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("FogColorRamp")]
         [KittopiaHideOption]
-        public Gradient FogColorRampGradientSetter
+        public Gradient FogColorRampGradient
         {
             set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -484,7 +484,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -492,7 +492,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<float> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistance
         {
             get => GetFloat("_oceanFogDistance");
             set => SetFloat("_oceanFogDistance", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -52,7 +52,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<float> PowerNearSetter
+        public NumericParser<float> PowerNear
         {
             get => GetFloat("_powerNear");
             set => SetFloat("_powerNear", value);
@@ -76,7 +76,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<float> PowerFarSetter
+        public NumericParser<float> PowerFar
         {
             get => GetFloat("_powerFar");
             set => SetFloat("_powerFar", value);
@@ -84,7 +84,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -92,7 +92,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -100,7 +100,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -108,7 +108,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -124,21 +124,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -146,21 +146,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -168,7 +168,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<float> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTiling
         {
             get => GetFloat("_steepNearTiling");
             set => SetFloat("_steepNearTiling", value);
@@ -176,7 +176,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -184,21 +184,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public MaterialTextureParser LowTexSetter
+        public MaterialTextureParser LowTex
         {
-            get => null;
+            get => GetTexture("_lowTex")?.name;
             set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
-        public Vector2Parser LowTexScaleSetter
+        public Vector2Parser LowTexScale
         {
             get => GetTextureScale("_lowTex");
             set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
-        public Vector2Parser LowTexOffsetSetter
+        public Vector2Parser LowTexOffset
         {
             get => GetTextureOffset("_lowTex");
             set => SetTextureOffset("_lowTex", value);
@@ -206,21 +206,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Map, default = "bump" { }
         [ParserTarget("lowBumpMap")]
-        public MaterialTextureParser LowBumpMapSetter
+        public MaterialTextureParser LowBumpMap
         {
-            get => null;
+            get => GetTexture("_lowBumpMap")?.name;
             set => SetTexture("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapScale")]
-        public Vector2Parser LowBumpMapScaleSetter
+        public Vector2Parser LowBumpMapScale
         {
             get => GetTextureScale("_lowBumpMap");
             set => SetTextureScale("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapOffset")]
-        public Vector2Parser LowBumpMapOffsetSetter
+        public Vector2Parser LowBumpMapOffset
         {
             get => GetTextureOffset("_lowBumpMap");
             set => SetTextureOffset("_lowBumpMap", value);
@@ -228,7 +228,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<float> LowNearTilingSetter
+        public NumericParser<float> LowNearTiling
         {
             get => GetFloat("_lowNearTiling");
             set => SetFloat("_lowNearTiling", value);
@@ -236,7 +236,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<float> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactor
         {
             get => GetFloat("_lowMultiFactor");
             set => SetFloat("_lowMultiFactor", value);
@@ -244,7 +244,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Near Tiling, default = 1
         [ParserTarget("lowBumpNearTiling")]
-        public NumericParser<float> LowBumpNearTilingSetter
+        public NumericParser<float> LowBumpNearTiling
         {
             get => GetFloat("_lowBumpNearTiling");
             set => SetFloat("_lowBumpNearTiling", value);
@@ -252,7 +252,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Far Tiling, default = 1
         [ParserTarget("lowBumpMultiFactor")]
-        public NumericParser<float> LowBumpMultiFactorSetter
+        public NumericParser<float> LowBumpMultiFactor
         {
             get => GetFloat("_lowBumpMultiFactor");
             set => SetFloat("_lowBumpMultiFactor", value);
@@ -260,21 +260,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public MaterialTextureParser MidTexSetter
+        public MaterialTextureParser MidTex
         {
-            get => null;
+            get => GetTexture("_midTex")?.name;
             set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
-        public Vector2Parser MidTexScaleSetter
+        public Vector2Parser MidTexScale
         {
             get => GetTextureScale("_midTex");
             set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
-        public Vector2Parser MidTexOffsetSetter
+        public Vector2Parser MidTexOffset
         {
             get => GetTextureOffset("_midTex");
             set => SetTextureOffset("_midTex", value);
@@ -282,21 +282,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public MaterialTextureParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMap
         {
-            get => null;
+            get => GetTexture("_midBumpMap")?.name;
             set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
-        public Vector2Parser MidBumpMapScaleSetter
+        public Vector2Parser MidBumpMapScale
         {
             get => GetTextureScale("_midBumpMap");
             set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
-        public Vector2Parser MidBumpMapOffsetSetter
+        public Vector2Parser MidBumpMapOffset
         {
             get => GetTextureOffset("_midBumpMap");
             set => SetTextureOffset("_midBumpMap", value);
@@ -304,7 +304,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<float> MidNearTilingSetter
+        public NumericParser<float> MidNearTiling
         {
             get => GetFloat("_midNearTiling");
             set => SetFloat("_midNearTiling", value);
@@ -312,7 +312,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<float> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactor
         {
             get => GetFloat("_midMultiFactor");
             set => SetFloat("_midMultiFactor", value);
@@ -320,7 +320,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<float> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTiling
         {
             get => GetFloat("_midBumpNearTiling");
             set => SetFloat("_midBumpNearTiling", value);
@@ -328,21 +328,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -350,21 +350,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Map, default = "bump" { }
         [ParserTarget("highBumpMap")]
-        public MaterialTextureParser HighBumpMapSetter
+        public MaterialTextureParser HighBumpMap
         {
-            get => null;
+            get => GetTexture("_highBumpMap")?.name;
             set => SetTexture("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapScale")]
-        public Vector2Parser HighBumpMapScaleSetter
+        public Vector2Parser HighBumpMapScale
         {
             get => GetTextureScale("_highBumpMap");
             set => SetTextureScale("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapOffset")]
-        public Vector2Parser HighBumpMapOffsetSetter
+        public Vector2Parser HighBumpMapOffset
         {
             get => GetTextureOffset("_highBumpMap");
             set => SetTextureOffset("_highBumpMap", value);
@@ -372,7 +372,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<float> HighNearTilingSetter
+        public NumericParser<float> HighNearTiling
         {
             get => GetFloat("_highNearTiling");
             set => SetFloat("_highNearTiling", value);
@@ -380,7 +380,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<float> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactor
         {
             get => GetFloat("_highMultiFactor");
             set => SetFloat("_highMultiFactor", value);
@@ -388,7 +388,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Near Tiling, default = 1000
         [ParserTarget("highBumpNearTiling")]
-        public NumericParser<float> HighBumpNearTilingSetter
+        public NumericParser<float> HighBumpNearTiling
         {
             get => GetFloat("_highBumpNearTiling");
             set => SetFloat("_highBumpNearTiling", value);
@@ -396,7 +396,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Far Tiling, default = 1
         [ParserTarget("highBumpMultiFactor")]
-        public NumericParser<float> HighBumpMultiFactorSetter
+        public NumericParser<float> HighBumpMultiFactor
         {
             get => GetFloat("_highBumpMultiFactor");
             set => SetFloat("_highBumpMultiFactor", value);
@@ -404,7 +404,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<float> LowStartSetter
+        public NumericParser<float> LowStart
         {
             get => GetFloat("_lowStart");
             set => SetFloat("_lowStart", value);
@@ -412,7 +412,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<float> LowEndSetter
+        public NumericParser<float> LowEnd
         {
             get => GetFloat("_lowEnd");
             set => SetFloat("_lowEnd", value);
@@ -420,7 +420,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<float> HighStartSetter
+        public NumericParser<float> HighStart
         {
             get => GetFloat("_highStart");
             set => SetFloat("_highStart", value);
@@ -428,7 +428,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<float> HighEndSetter
+        public NumericParser<float> HighEnd
         {
             get => GetFloat("_highEnd");
             set => SetFloat("_highEnd", value);
@@ -436,7 +436,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -444,21 +444,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -466,7 +466,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -474,7 +474,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<float> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistance
         {
             get => GetFloat("_oceanFogDistance");
             set => SetFloat("_oceanFogDistance", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -52,7 +52,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<float> PowerNearSetter
+        public NumericParser<float> PowerNear
         {
             get => GetFloat("_powerNear");
             set => SetFloat("_powerNear", value);
@@ -76,7 +76,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<float> PowerFarSetter
+        public NumericParser<float> PowerFar
         {
             get => GetFloat("_powerFar");
             set => SetFloat("_powerFar", value);
@@ -84,7 +84,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -92,7 +92,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -100,7 +100,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -108,7 +108,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -124,21 +124,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -146,21 +146,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -168,7 +168,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<float> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTiling
         {
             get => GetFloat("_steepNearTiling");
             set => SetFloat("_steepNearTiling", value);
@@ -176,7 +176,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -184,21 +184,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public MaterialTextureParser LowTexSetter
+        public MaterialTextureParser LowTex
         {
-            get => null;
+            get => GetTexture("_lowTex")?.name;
             set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
-        public Vector2Parser LowTexScaleSetter
+        public Vector2Parser LowTexScale
         {
             get => GetTextureScale("_lowTex");
             set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
-        public Vector2Parser LowTexOffsetSetter
+        public Vector2Parser LowTexOffset
         {
             get => GetTextureOffset("_lowTex");
             set => SetTextureOffset("_lowTex", value);
@@ -206,7 +206,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<float> LowNearTilingSetter
+        public NumericParser<float> LowNearTiling
         {
             get => GetFloat("_lowNearTiling");
             set => SetFloat("_lowNearTiling", value);
@@ -214,7 +214,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<float> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactor
         {
             get => GetFloat("_lowMultiFactor");
             set => SetFloat("_lowMultiFactor", value);
@@ -222,21 +222,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public MaterialTextureParser MidTexSetter
+        public MaterialTextureParser MidTex
         {
-            get => null;
+            get => GetTexture("_midTex")?.name;
             set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
-        public Vector2Parser MidTexScaleSetter
+        public Vector2Parser MidTexScale
         {
             get => GetTextureScale("_midTex");
             set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
-        public Vector2Parser MidTexOffsetSetter
+        public Vector2Parser MidTexOffset
         {
             get => GetTextureOffset("_midTex");
             set => SetTextureOffset("_midTex", value);
@@ -244,21 +244,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public MaterialTextureParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMap
         {
-            get => null;
+            get => GetTexture("_midBumpMap")?.name;
             set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
-        public Vector2Parser MidBumpMapScaleSetter
+        public Vector2Parser MidBumpMapScale
         {
             get => GetTextureScale("_midBumpMap");
             set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
-        public Vector2Parser MidBumpMapOffsetSetter
+        public Vector2Parser MidBumpMapOffset
         {
             get => GetTextureOffset("_midBumpMap");
             set => SetTextureOffset("_midBumpMap", value);
@@ -266,7 +266,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<float> MidNearTilingSetter
+        public NumericParser<float> MidNearTiling
         {
             get => GetFloat("_midNearTiling");
             set => SetFloat("_midNearTiling", value);
@@ -274,7 +274,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<float> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactor
         {
             get => GetFloat("_midMultiFactor");
             set => SetFloat("_midMultiFactor", value);
@@ -282,7 +282,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<float> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTiling
         {
             get => GetFloat("_midBumpNearTiling");
             set => SetFloat("_midBumpNearTiling", value);
@@ -290,21 +290,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -312,7 +312,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<float> HighNearTilingSetter
+        public NumericParser<float> HighNearTiling
         {
             get => GetFloat("_highNearTiling");
             set => SetFloat("_highNearTiling", value);
@@ -320,7 +320,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<float> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactor
         {
             get => GetFloat("_highMultiFactor");
             set => SetFloat("_highMultiFactor", value);
@@ -328,7 +328,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<float> LowStartSetter
+        public NumericParser<float> LowStart
         {
             get => GetFloat("_lowStart");
             set => SetFloat("_lowStart", value);
@@ -336,7 +336,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<float> LowEndSetter
+        public NumericParser<float> LowEnd
         {
             get => GetFloat("_lowEnd");
             set => SetFloat("_lowEnd", value);
@@ -344,7 +344,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<float> HighStartSetter
+        public NumericParser<float> HighStart
         {
             get => GetFloat("_highStart");
             set => SetFloat("_highStart", value);
@@ -352,7 +352,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<float> HighEndSetter
+        public NumericParser<float> HighEnd
         {
             get => GetFloat("_highEnd");
             set => SetFloat("_highEnd", value);
@@ -360,7 +360,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -368,21 +368,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -390,7 +390,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -398,7 +398,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<float> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistance
         {
             get => GetFloat("_oceanFogDistance");
             set => SetFloat("_oceanFogDistance", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -70,7 +70,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<float> PowerNearSetter
+        public NumericParser<float> PowerNear
         {
             get => GetFloat("_powerNear");
             set => SetFloat("_powerNear", value);
@@ -78,7 +78,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<float> PowerFarSetter
+        public NumericParser<float> PowerFar
         {
             get => GetFloat("_powerFar");
             set => SetFloat("_powerFar", value);
@@ -86,7 +86,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -94,7 +94,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -102,7 +102,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -110,7 +110,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -118,7 +118,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -126,21 +126,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -148,21 +148,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -170,7 +170,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<float> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTiling
         {
             get => GetFloat("_steepNearTiling");
             set => SetFloat("_steepNearTiling", value);
@@ -178,7 +178,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -186,21 +186,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public MaterialTextureParser LowTexSetter
+        public MaterialTextureParser LowTex
         {
-            get => null;
+            get => GetTexture("_lowTex")?.name;
             set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
-        public Vector2Parser LowTexScaleSetter
+        public Vector2Parser LowTexScale
         {
             get => GetTextureScale("_lowTex");
             set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
-        public Vector2Parser LowTexOffsetSetter
+        public Vector2Parser LowTexOffset
         {
             get => GetTextureOffset("_lowTex");
             set => SetTextureOffset("_lowTex", value);
@@ -208,7 +208,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<float> LowNearTilingSetter
+        public NumericParser<float> LowNearTiling
         {
             get => GetFloat("_lowNearTiling");
             set => SetFloat("_lowNearTiling", value);
@@ -216,7 +216,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<float> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactor
         {
             get => GetFloat("_lowMultiFactor");
             set => SetFloat("_lowMultiFactor", value);
@@ -224,21 +224,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public MaterialTextureParser MidTexSetter
+        public MaterialTextureParser MidTex
         {
-            get => null;
+            get => GetTexture("_midTex")?.name;
             set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
-        public Vector2Parser MidTexScaleSetter
+        public Vector2Parser MidTexScale
         {
             get => GetTextureScale("_midTex");
             set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
-        public Vector2Parser MidTexOffsetSetter
+        public Vector2Parser MidTexOffset
         {
             get => GetTextureOffset("_midTex");
             set => SetTextureOffset("_midTex", value);
@@ -246,21 +246,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public MaterialTextureParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMap
         {
-            get => null;
+            get => GetTexture("_midBumpMap")?.name;
             set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
-        public Vector2Parser MidBumpMapScaleSetter
+        public Vector2Parser MidBumpMapScale
         {
             get => GetTextureScale("_midBumpMap");
             set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
-        public Vector2Parser MidBumpMapOffsetSetter
+        public Vector2Parser MidBumpMapOffset
         {
             get => GetTextureOffset("_midBumpMap");
             set => SetTextureOffset("_midBumpMap", value);
@@ -268,7 +268,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<float> MidNearTilingSetter
+        public NumericParser<float> MidNearTiling
         {
             get => GetFloat("_midNearTiling");
             set => SetFloat("_midNearTiling", value);
@@ -276,7 +276,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<float> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactor
         {
             get => GetFloat("_midMultiFactor");
             set => SetFloat("_midMultiFactor", value);
@@ -284,7 +284,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<float> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTiling
         {
             get => GetFloat("_midBumpNearTiling");
             set => SetFloat("_midBumpNearTiling", value);
@@ -292,21 +292,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -314,7 +314,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<float> HighNearTilingSetter
+        public NumericParser<float> HighNearTiling
         {
             get => GetFloat("_highNearTiling");
             set => SetFloat("_highNearTiling", value);
@@ -322,7 +322,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<float> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactor
         {
             get => GetFloat("_highMultiFactor");
             set => SetFloat("_highMultiFactor", value);
@@ -330,7 +330,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<float> LowStartSetter
+        public NumericParser<float> LowStart
         {
             get => GetFloat("_lowStart");
             set => SetFloat("_lowStart", value);
@@ -338,7 +338,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<float> LowEndSetter
+        public NumericParser<float> LowEnd
         {
             get => GetFloat("_lowEnd");
             set => SetFloat("_lowEnd", value);
@@ -346,7 +346,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<float> HighStartSetter
+        public NumericParser<float> HighStart
         {
             get => GetFloat("_highStart");
             set => SetFloat("_highStart", value);
@@ -354,7 +354,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<float> HighEndSetter
+        public NumericParser<float> HighEnd
         {
             get => GetFloat("_highEnd");
             set => SetFloat("_highEnd", value);
@@ -362,7 +362,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -370,29 +370,29 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("FogColorRamp")]
         [KittopiaHideOption]
-        public Gradient FogColorRampGradientSetter
+        public Gradient FogColorRampGradient
         {
             set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -400,7 +400,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -408,7 +408,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<float> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistance
         {
             get => GetFloat("_oceanFogDistance");
             set => SetFloat("_oceanFogDistance", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -70,7 +70,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("powerNear")]
-        public NumericParser<float> PowerNearSetter
+        public NumericParser<float> PowerNear
         {
             get => GetFloat("_powerNear");
             set => SetFloat("_powerNear", value);
@@ -78,7 +78,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("powerFar")]
-        public NumericParser<float> PowerFarSetter
+        public NumericParser<float> PowerFar
         {
             get => GetFloat("_powerFar");
             set => SetFloat("_powerFar", value);
@@ -86,7 +86,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -94,7 +94,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar End, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -102,7 +102,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -110,7 +110,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -118,7 +118,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -126,21 +126,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -148,21 +148,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -170,7 +170,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<float> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTiling
         {
             get => GetFloat("_steepNearTiling");
             set => SetFloat("_steepNearTiling", value);
@@ -178,7 +178,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -186,21 +186,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public MaterialTextureParser LowTexSetter
+        public MaterialTextureParser LowTex
         {
-            get => null;
+            get => GetTexture("_lowTex")?.name;
             set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
-        public Vector2Parser LowTexScaleSetter
+        public Vector2Parser LowTexScale
         {
             get => GetTextureScale("_lowTex");
             set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
-        public Vector2Parser LowTexOffsetSetter
+        public Vector2Parser LowTexOffset
         {
             get => GetTextureOffset("_lowTex");
             set => SetTextureOffset("_lowTex", value);
@@ -208,21 +208,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Map, default = "bump" { }
         [ParserTarget("lowBumpMap")]
-        public MaterialTextureParser LowBumpMapSetter
+        public MaterialTextureParser LowBumpMap
         {
-            get => null;
+            get => GetTexture("_lowBumpMap")?.name;
             set => SetTexture("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapScale")]
-        public Vector2Parser LowBumpMapScaleSetter
+        public Vector2Parser LowBumpMapScale
         {
             get => GetTextureScale("_lowBumpMap");
             set => SetTextureScale("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapOffset")]
-        public Vector2Parser LowBumpMapOffsetSetter
+        public Vector2Parser LowBumpMapOffset
         {
             get => GetTextureOffset("_lowBumpMap");
             set => SetTextureOffset("_lowBumpMap", value);
@@ -230,7 +230,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Near Tiling, default = 1000
         [ParserTarget("lowNearTiling")]
-        public NumericParser<float> LowNearTilingSetter
+        public NumericParser<float> LowNearTiling
         {
             get => GetFloat("_lowNearTiling");
             set => SetFloat("_lowNearTiling", value);
@@ -238,7 +238,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Far Tiling, default = 10
         [ParserTarget("lowMultiFactor")]
-        public NumericParser<float> LowMultiFactorSetter
+        public NumericParser<float> LowMultiFactor
         {
             get => GetFloat("_lowMultiFactor");
             set => SetFloat("_lowMultiFactor", value);
@@ -246,7 +246,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Near Tiling, default = 1
         [ParserTarget("lowBumpNearTiling")]
-        public NumericParser<float> LowBumpNearTilingSetter
+        public NumericParser<float> LowBumpNearTiling
         {
             get => GetFloat("_lowBumpNearTiling");
             set => SetFloat("_lowBumpNearTiling", value);
@@ -254,7 +254,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Far Tiling, default = 1
         [ParserTarget("lowBumpFarTiling")]
-        public NumericParser<float> LowBumpFarTilingSetter
+        public NumericParser<float> LowBumpFarTiling
         {
             get => GetFloat("_lowBumpFarTiling");
             set => SetFloat("_lowBumpFarTiling", value);
@@ -262,21 +262,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public MaterialTextureParser MidTexSetter
+        public MaterialTextureParser MidTex
         {
-            get => null;
+            get => GetTexture("_midTex")?.name;
             set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
-        public Vector2Parser MidTexScaleSetter
+        public Vector2Parser MidTexScale
         {
             get => GetTextureScale("_midTex");
             set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
-        public Vector2Parser MidTexOffsetSetter
+        public Vector2Parser MidTexOffset
         {
             get => GetTextureOffset("_midTex");
             set => SetTextureOffset("_midTex", value);
@@ -284,21 +284,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public MaterialTextureParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMap
         {
-            get => null;
+            get => GetTexture("_midBumpMap")?.name;
             set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
-        public Vector2Parser MidBumpMapScaleSetter
+        public Vector2Parser MidBumpMapScale
         {
             get => GetTextureScale("_midBumpMap");
             set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
-        public Vector2Parser MidBumpMapOffsetSetter
+        public Vector2Parser MidBumpMapOffset
         {
             get => GetTextureOffset("_midBumpMap");
             set => SetTextureOffset("_midBumpMap", value);
@@ -306,7 +306,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Near Tiling, default = 1000
         [ParserTarget("midNearTiling")]
-        public NumericParser<float> MidNearTilingSetter
+        public NumericParser<float> MidNearTiling
         {
             get => GetFloat("_midNearTiling");
             set => SetFloat("_midNearTiling", value);
@@ -314,7 +314,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Far Tiling, default = 10
         [ParserTarget("midMultiFactor")]
-        public NumericParser<float> MidMultiFactorSetter
+        public NumericParser<float> MidMultiFactor
         {
             get => GetFloat("_midMultiFactor");
             set => SetFloat("_midMultiFactor", value);
@@ -322,7 +322,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Near Tiling, default = 1
         [ParserTarget("midBumpNearTiling")]
-        public NumericParser<float> MidBumpNearTilingSetter
+        public NumericParser<float> MidBumpNearTiling
         {
             get => GetFloat("_midBumpNearTiling");
             set => SetFloat("_midBumpNearTiling", value);
@@ -330,7 +330,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Far Tiling, default = 1
         [ParserTarget("midBumpFarTiling")]
-        public NumericParser<float> MidBumpFarTilingSetter
+        public NumericParser<float> MidBumpFarTiling
         {
             get => GetFloat("_midBumpFarTiling");
             set => SetFloat("_midBumpFarTiling", value);
@@ -338,21 +338,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -360,21 +360,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Map, default = "bump" { }
         [ParserTarget("highBumpMap")]
-        public MaterialTextureParser HighBumpMapSetter
+        public MaterialTextureParser HighBumpMap
         {
-            get => null;
+            get => GetTexture("_highBumpMap")?.name;
             set => SetTexture("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapScale")]
-        public Vector2Parser HighBumpMapScaleSetter
+        public Vector2Parser HighBumpMapScale
         {
             get => GetTextureScale("_highBumpMap");
             set => SetTextureScale("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapOffset")]
-        public Vector2Parser HighBumpMapOffsetSetter
+        public Vector2Parser HighBumpMapOffset
         {
             get => GetTextureOffset("_highBumpMap");
             set => SetTextureOffset("_highBumpMap", value);
@@ -382,7 +382,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Near Tiling, default = 1000
         [ParserTarget("highNearTiling")]
-        public NumericParser<float> HighNearTilingSetter
+        public NumericParser<float> HighNearTiling
         {
             get => GetFloat("_highNearTiling");
             set => SetFloat("_highNearTiling", value);
@@ -390,7 +390,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Far Tiling, default = 10
         [ParserTarget("highMultiFactor")]
-        public NumericParser<float> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactor
         {
             get => GetFloat("_highMultiFactor");
             set => SetFloat("_highMultiFactor", value);
@@ -398,7 +398,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Near Tiling, default = 1
         [ParserTarget("highBumpNearTiling")]
-        public NumericParser<float> HighBumpNearTilingSetter
+        public NumericParser<float> HighBumpNearTiling
         {
             get => GetFloat("_highBumpNearTiling");
             set => SetFloat("_highBumpNearTiling", value);
@@ -406,7 +406,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Far Tiling, default = 1
         [ParserTarget("highBumpFarTiling")]
-        public NumericParser<float> HighBumpFarTilingSetter
+        public NumericParser<float> HighBumpFarTiling
         {
             get => GetFloat("_highBumpFarTiling");
             set => SetFloat("_highBumpFarTiling", value);
@@ -414,7 +414,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<float> LowStartSetter
+        public NumericParser<float> LowStart
         {
             get => GetFloat("_lowStart");
             set => SetFloat("_lowStart", value);
@@ -422,7 +422,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<float> LowEndSetter
+        public NumericParser<float> LowEnd
         {
             get => GetFloat("_lowEnd");
             set => SetFloat("_lowEnd", value);
@@ -430,7 +430,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<float> HighStartSetter
+        public NumericParser<float> HighStart
         {
             get => GetFloat("_highStart");
             set => SetFloat("_highStart", value);
@@ -438,7 +438,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<float> HighEndSetter
+        public NumericParser<float> HighEnd
         {
             get => GetFloat("_highEnd");
             set => SetFloat("_highEnd", value);
@@ -446,7 +446,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -454,29 +454,29 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("FogColorRamp")]
         [KittopiaHideOption]
-        public Gradient FogColorRampGradientSetter
+        public Gradient FogColorRampGradient
         {
             set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -484,7 +484,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor, default = 10
         [ParserTarget("factor")]
-        public NumericParser<float> FactorSetter
+        public NumericParser<float> Factor
         {
             get => GetFloat("_factor");
             set => SetFloat("_factor", value);
@@ -52,7 +52,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor Blend Width, default = 0.1
         [ParserTarget("factorBlendWidth")]
-        public NumericParser<float> FactorBlendWidthSetter
+        public NumericParser<float> FactorBlendWidth
         {
             get => GetFloat("_factorBlendWidth");
             set => SetFloat("_factorBlendWidth", value);
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor Rotation, default = 30
         [ParserTarget("factorRotation")]
-        public NumericParser<float> FactorRotationSetter
+        public NumericParser<float> FactorRotation
         {
             get => GetFloat("_factorRotation");
             set => SetFloat("_factorRotation", value);
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -76,7 +76,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -84,7 +84,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -92,7 +92,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (0.2,0.2,0.2,0.2)
         [ParserTarget("specularColor")]
-        public ColorParser SpecularColorSetter
+        public ColorParser SpecularColor
         {
             get => GetColor("_specularColor");
             set => SetColor("_specularColor", value);
@@ -100,7 +100,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Brightness, default = 2
         [ParserTarget("albedoBrightness")]
-        public NumericParser<float> AlbedoBrightnessSetter
+        public NumericParser<float> AlbedoBrightness
         {
             get => GetFloat("_albedoBrightness");
             set => SetFloat("_albedoBrightness", value);
@@ -108,7 +108,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -116,21 +116,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -138,7 +138,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -146,21 +146,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -168,7 +168,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Tiling, default = 1
         [ParserTarget("steepBumpTiling")]
-        public NumericParser<float> SteepBumpTilingSetter
+        public NumericParser<float> SteepBumpTiling
         {
             get => GetFloat("_steepBumpTiling");
             set => SetFloat("_steepBumpTiling", value);
@@ -176,21 +176,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public MaterialTextureParser LowTexSetter
+        public MaterialTextureParser LowTex
         {
-            get => null;
+            get => GetTexture("_lowTex")?.name;
             set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
-        public Vector2Parser LowTexScaleSetter
+        public Vector2Parser LowTexScale
         {
             get => GetTextureScale("_lowTex");
             set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
-        public Vector2Parser LowTexOffsetSetter
+        public Vector2Parser LowTexOffset
         {
             get => GetTextureOffset("_lowTex");
             set => SetTextureOffset("_lowTex", value);
@@ -198,7 +198,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Tiling, default = 100000
         [ParserTarget("lowTiling")]
-        public NumericParser<float> LowTilingSetter
+        public NumericParser<float> LowTiling
         {
             get => GetFloat("_lowTiling");
             set => SetFloat("_lowTiling", value);
@@ -206,21 +206,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Map, default = "bump" { }
         [ParserTarget("lowBumpMap")]
-        public MaterialTextureParser LowBumpMapSetter
+        public MaterialTextureParser LowBumpMap
         {
-            get => null;
+            get => GetTexture("_lowBumpMap")?.name;
             set => SetTexture("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapScale")]
-        public Vector2Parser LowBumpMapScaleSetter
+        public Vector2Parser LowBumpMapScale
         {
             get => GetTextureScale("_lowBumpMap");
             set => SetTextureScale("_lowBumpMap", value);
         }
 
         [ParserTarget("lowBumpMapOffset")]
-        public Vector2Parser LowBumpMapOffsetSetter
+        public Vector2Parser LowBumpMapOffset
         {
             get => GetTextureOffset("_lowBumpMap");
             set => SetTextureOffset("_lowBumpMap", value);
@@ -228,7 +228,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Bump Tiling, default = 100000
         [ParserTarget("lowBumpTiling")]
-        public NumericParser<float> LowBumpTilingSetter
+        public NumericParser<float> LowBumpTiling
         {
             get => GetFloat("_lowBumpTiling");
             set => SetFloat("_lowBumpTiling", value);
@@ -236,21 +236,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public MaterialTextureParser MidTexSetter
+        public MaterialTextureParser MidTex
         {
-            get => null;
+            get => GetTexture("_midTex")?.name;
             set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
-        public Vector2Parser MidTexScaleSetter
+        public Vector2Parser MidTexScale
         {
             get => GetTextureScale("_midTex");
             set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
-        public Vector2Parser MidTexOffsetSetter
+        public Vector2Parser MidTexOffset
         {
             get => GetTextureOffset("_midTex");
             set => SetTextureOffset("_midTex", value);
@@ -258,7 +258,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Tiling, default = 100000
         [ParserTarget("midTiling")]
-        public NumericParser<float> MidTilingSetter
+        public NumericParser<float> MidTiling
         {
             get => GetFloat("_midTiling");
             set => SetFloat("_midTiling", value);
@@ -266,21 +266,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public MaterialTextureParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMap
         {
-            get => null;
+            get => GetTexture("_midBumpMap")?.name;
             set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
-        public Vector2Parser MidBumpMapScaleSetter
+        public Vector2Parser MidBumpMapScale
         {
             get => GetTextureScale("_midBumpMap");
             set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
-        public Vector2Parser MidBumpMapOffsetSetter
+        public Vector2Parser MidBumpMapOffset
         {
             get => GetTextureOffset("_midBumpMap");
             set => SetTextureOffset("_midBumpMap", value);
@@ -288,7 +288,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Tiling, default = 100000
         [ParserTarget("midBumpTiling")]
-        public NumericParser<float> MidBumpTilingSetter
+        public NumericParser<float> MidBumpTiling
         {
             get => GetFloat("_midBumpTiling");
             set => SetFloat("_midBumpTiling", value);
@@ -296,21 +296,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -318,7 +318,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Tiling, default = 100000
         [ParserTarget("highTiling")]
-        public NumericParser<float> HighTilingSetter
+        public NumericParser<float> HighTiling
         {
             get => GetFloat("_highTiling");
             set => SetFloat("_highTiling", value);
@@ -326,21 +326,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Map, default = "bump" { }
         [ParserTarget("highBumpMap")]
-        public MaterialTextureParser HighBumpMapSetter
+        public MaterialTextureParser HighBumpMap
         {
-            get => null;
+            get => GetTexture("_highBumpMap")?.name;
             set => SetTexture("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapScale")]
-        public Vector2Parser HighBumpMapScaleSetter
+        public Vector2Parser HighBumpMapScale
         {
             get => GetTextureScale("_highBumpMap");
             set => SetTextureScale("_highBumpMap", value);
         }
 
         [ParserTarget("highBumpMapOffset")]
-        public Vector2Parser HighBumpMapOffsetSetter
+        public Vector2Parser HighBumpMapOffset
         {
             get => GetTextureOffset("_highBumpMap");
             set => SetTextureOffset("_highBumpMap", value);
@@ -348,7 +348,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Bump Tiling, default = 100000
         [ParserTarget("highBumpTiling")]
-        public NumericParser<float> HighBumpTilingSetter
+        public NumericParser<float> HighBumpTiling
         {
             get => GetFloat("_highBumpTiling");
             set => SetFloat("_highBumpTiling", value);
@@ -356,7 +356,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<float> LowStartSetter
+        public NumericParser<float> LowStart
         {
             get => GetFloat("_lowStart");
             set => SetFloat("_lowStart", value);
@@ -364,7 +364,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<float> LowEndSetter
+        public NumericParser<float> LowEnd
         {
             get => GetFloat("_lowEnd");
             set => SetFloat("_lowEnd", value);
@@ -372,7 +372,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<float> HighStartSetter
+        public NumericParser<float> HighStart
         {
             get => GetFloat("_highStart");
             set => SetFloat("_highStart", value);
@@ -380,7 +380,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<float> HighEndSetter
+        public NumericParser<float> HighEnd
         {
             get => GetFloat("_highEnd");
             set => SetFloat("_highEnd", value);
@@ -388,7 +388,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -396,21 +396,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -418,7 +418,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -426,7 +426,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<float> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistance
         {
             get => GetFloat("_oceanFogDistance");
             set => SetFloat("_oceanFogDistance", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
@@ -45,7 +45,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -53,7 +53,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Color From Space, default = (1,1,1,1)
         [ParserTarget("colorFromSpace")]
-        public ColorParser ColorFromSpaceSetter
+        public ColorParser ColorFromSpace
         {
             get => GetColor("_ColorFromSpace");
             set => SetColor("_ColorFromSpace", value);
@@ -61,7 +61,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (1,1,1,1)
         [ParserTarget("specColor")]
-        public ColorParser SpecColorSetter
+        public ColorParser SpecColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -69,7 +69,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<float> ShininessSetter
+        public NumericParser<float> Shininess
         {
             get => GetFloat("_Shininess");
             set => SetFloat("_Shininess", value);
@@ -77,7 +77,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Gloss, default = 0.078125
         [ParserTarget("gloss")]
-        public NumericParser<float> GlossSetter
+        public NumericParser<float> Gloss
         {
             get => GetFloat("_Gloss");
             set => SetFloat("_Gloss", value);
@@ -85,7 +85,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Tex Tiling, default = 1
         [ParserTarget("tiling")]
-        public NumericParser<float> TilingSetter
+        public NumericParser<float> Tiling
         {
             get => GetFloat("_tiling");
             set => SetFloat("_tiling", value);
@@ -93,21 +93,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Tex0, default = "white" { }
         [ParserTarget("waterTex")]
-        public MaterialTextureParser WaterTexSetter
+        public MaterialTextureParser WaterTex
         {
-            get => null;
+            get => GetTexture("_WaterTex")?.name;
             set => SetTexture("_WaterTex", value);
         }
 
         [ParserTarget("waterTexScale")]
-        public Vector2Parser WaterTexScaleSetter
+        public Vector2Parser WaterTexScale
         {
             get => GetTextureScale("_WaterTex");
             set => SetTextureScale("_WaterTex", value);
         }
 
         [ParserTarget("waterTexOffset")]
-        public Vector2Parser WaterTexOffsetSetter
+        public Vector2Parser WaterTexOffset
         {
             get => GetTextureOffset("_WaterTex");
             set => SetTextureOffset("_WaterTex", value);
@@ -115,21 +115,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Tex1, default = "white" { }
         [ParserTarget("waterTex1")]
-        public MaterialTextureParser WaterTex1Setter
+        public MaterialTextureParser WaterTex1
         {
-            get => null;
+            get => GetTexture("_WaterTex1")?.name;
             set => SetTexture("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Scale")]
-        public Vector2Parser WaterTex1ScaleSetter
+        public Vector2Parser WaterTex1Scale
         {
             get => GetTextureScale("_WaterTex1");
             set => SetTextureScale("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Offset")]
-        public Vector2Parser WaterTex1OffsetSetter
+        public Vector2Parser WaterTex1Offset
         {
             get => GetTextureOffset("_WaterTex1");
             set => SetTextureOffset("_WaterTex1", value);
@@ -137,7 +137,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FadeStart, default = 1
         [ParserTarget("fadeStart")]
-        public NumericParser<float> FadeStartSetter
+        public NumericParser<float> FadeStart
         {
             get => GetFloat("_fadeStart");
             set => SetFloat("_fadeStart", value);
@@ -145,7 +145,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FadeEnd, default = 1
         [ParserTarget("fadeEnd")]
-        public NumericParser<float> FadeEndSetter
+        public NumericParser<float> FadeEnd
         {
             get => GetFloat("_fadeEnd");
             set => SetFloat("_fadeEnd", value);
@@ -153,7 +153,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Color From Space, default = (1,1,1,1)
         [ParserTarget("colorFromSpace")]
-        public ColorParser ColorFromSpaceSetter
+        public ColorParser ColorFromSpace
         {
             get => GetColor("_ColorFromSpace");
             set => SetColor("_ColorFromSpace", value);
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (1,1,1,1)
         [ParserTarget("specColor")]
-        public ColorParser SpecColorSetter
+        public ColorParser SpecColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -70,7 +70,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<float> ShininessSetter
+        public NumericParser<float> Shininess
         {
             get => GetFloat("_Shininess");
             set => SetFloat("_Shininess", value);
@@ -78,7 +78,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Gloss, default = 0.078125
         [ParserTarget("gloss")]
-        public NumericParser<float> GlossSetter
+        public NumericParser<float> Gloss
         {
             get => GetFloat("_Gloss");
             set => SetFloat("_Gloss", value);
@@ -86,7 +86,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Tex Tiling, default = 1
         [ParserTarget("tiling")]
-        public NumericParser<float> TilingSetter
+        public NumericParser<float> Tiling
         {
             get => GetFloat("_tiling");
             set => SetFloat("_tiling", value);
@@ -94,21 +94,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Tex0, default = "white" { }
         [ParserTarget("waterTex")]
-        public MaterialTextureParser WaterTexSetter
+        public MaterialTextureParser WaterTex
         {
-            get => null;
+            get => GetTexture("_WaterTex")?.name;
             set => SetTexture("_WaterTex", value);
         }
 
         [ParserTarget("waterTexScale")]
-        public Vector2Parser WaterTexScaleSetter
+        public Vector2Parser WaterTexScale
         {
             get => GetTextureScale("_WaterTex");
             set => SetTextureScale("_WaterTex", value);
         }
 
         [ParserTarget("waterTexOffset")]
-        public Vector2Parser WaterTexOffsetSetter
+        public Vector2Parser WaterTexOffset
         {
             get => GetTextureOffset("_WaterTex");
             set => SetTextureOffset("_WaterTex", value);
@@ -116,21 +116,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Tex1, default = "white" { }
         [ParserTarget("waterTex1")]
-        public MaterialTextureParser WaterTex1Setter
+        public MaterialTextureParser WaterTex1
         {
-            get => null;
+            get => GetTexture("_WaterTex1")?.name;
             set => SetTexture("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Scale")]
-        public Vector2Parser WaterTex1ScaleSetter
+        public Vector2Parser WaterTex1Scale
         {
             get => GetTextureScale("_WaterTex1");
             set => SetTextureScale("_WaterTex1", value);
         }
 
         [ParserTarget("waterTex1Offset")]
-        public Vector2Parser WaterTex1OffsetSetter
+        public Vector2Parser WaterTex1Offset
         {
             get => GetTextureOffset("_WaterTex1");
             set => SetTextureOffset("_WaterTex1", value);
@@ -138,7 +138,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal Tiling, default = 1
         [ParserTarget("bTiling")]
-        public NumericParser<float> BTilingSetter
+        public NumericParser<float> BTiling
         {
             get => GetFloat("_bTiling");
             set => SetFloat("_bTiling", value);
@@ -146,21 +146,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -168,7 +168,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Water Movement, default = 1
         [ParserTarget("displacement")]
-        public NumericParser<float> DisplacementSetter
+        public NumericParser<float> Displacement
         {
             get => GetFloat("_displacement");
             set => SetFloat("_displacement", value);
@@ -176,7 +176,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Texture Displacement, default = 1
         [ParserTarget("texDisplacement")]
-        public NumericParser<float> TexDisplacementSetter
+        public NumericParser<float> TexDisplacement
         {
             get => GetFloat("_texDisplacement");
             set => SetFloat("_texDisplacement", value);
@@ -184,7 +184,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Water Freq, default = 1
         [ParserTarget("dispFreq")]
-        public NumericParser<float> DispFreqSetter
+        public NumericParser<float> DispFreq
         {
             get => GetFloat("_dispFreq");
             set => SetFloat("_dispFreq", value);
@@ -192,7 +192,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mix, default = 1
         [ParserTarget("mix")]
-        public NumericParser<float> MixSetter
+        public NumericParser<float> Mix
         {
             get => GetFloat("_Mix");
             set => SetFloat("_Mix", value);
@@ -200,7 +200,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Opacity, default = 1
         [ParserTarget("oceanOpacity")]
-        public NumericParser<float> OceanOpacitySetter
+        public NumericParser<float> OceanOpacity
         {
             get => GetFloat("_oceanOpacity");
             set => SetFloat("_oceanOpacity", value);
@@ -208,7 +208,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Falloff Power, default = 1
         [ParserTarget("falloffPower")]
-        public NumericParser<float> FalloffPowerSetter
+        public NumericParser<float> FalloffPower
         {
             get => GetFloat("_falloffPower");
             set => SetFloat("_falloffPower", value);
@@ -216,7 +216,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Falloff Exp, default = 2
         [ParserTarget("falloffExp")]
-        public NumericParser<float> FalloffExpSetter
+        public NumericParser<float> FalloffExp
         {
             get => GetFloat("_falloffExp");
             set => SetFloat("_falloffExp", value);
@@ -224,7 +224,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Fog Color, default = (0,0,1,1)
         [ParserTarget("fogColor")]
-        public ColorParser FogColorSetter
+        public ColorParser FogColor
         {
             get => GetColor("_fogColor");
             set => SetColor("_fogColor", value);
@@ -232,7 +232,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Height Fall Off, default = 1
         [ParserTarget("heightFallOff")]
-        public NumericParser<float> HeightFallOffSetter
+        public NumericParser<float> HeightFallOff
         {
             get => GetFloat("_heightFallOff");
             set => SetFloat("_heightFallOff", value);
@@ -240,7 +240,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -248,7 +248,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Atmosphere Depth, default = 1
         [ParserTarget("atmosphereDepth")]
-        public NumericParser<float> AtmosphereDepthSetter
+        public NumericParser<float> AtmosphereDepth
         {
             get => GetFloat("_atmosphereDepth");
             set => SetFloat("_atmosphereDepth", value);
@@ -256,29 +256,29 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("FogColorRamp")]
         [KittopiaHideOption]
-        public Gradient FogColorRampGradientSetter
+        public Gradient FogColorRampGradient
         {
             set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -286,7 +286,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FadeStart, default = 1
         [ParserTarget("fadeStart")]
-        public NumericParser<float> FadeStartSetter
+        public NumericParser<float> FadeStart
         {
             get => GetFloat("_fadeStart");
             set => SetFloat("_fadeStart", value);
@@ -294,7 +294,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FadeEnd, default = 1
         [ParserTarget("fadeEnd")]
-        public NumericParser<float> FadeEndSetter
+        public NumericParser<float> FadeEnd
         {
             get => GetFloat("_fadeEnd");
             set => SetFloat("_fadeEnd", value);
@@ -302,7 +302,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -310,7 +310,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NormalXYFudge, default = 0.1
         [ParserTarget("normalXYFudge")]
-        public NumericParser<float> NormalXyFudgeSetter
+        public NumericParser<float> NormalXyFudge
         {
             get => GetFloat("_NormalXYFudge");
             set => SetFloat("_NormalXYFudge", value);
@@ -318,7 +318,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NormalZFudge, default = 1.1
         [ParserTarget("normalZFudge")]
-        public NumericParser<float> NormalZFudgeSetter
+        public NumericParser<float> NormalZFudge
         {
             get => GetFloat("_NormalZFudge");
             set => SetFloat("_NormalZFudge", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -70,7 +70,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Tiling, default = 1000
         [ParserTarget("texTiling")]
-        public NumericParser<float> TexTilingSetter
+        public NumericParser<float> TexTiling
         {
             get => GetFloat("_texTiling");
             set => SetFloat("_texTiling", value);
@@ -78,7 +78,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("texPower")]
-        public NumericParser<float> TexPowerSetter
+        public NumericParser<float> TexPower
         {
             get => GetFloat("_texPower");
             set => SetFloat("_texPower", value);
@@ -86,7 +86,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("multiPower")]
-        public NumericParser<float> MultiPowerSetter
+        public NumericParser<float> MultiPower
         {
             get => GetFloat("_multiPower");
             set => SetFloat("_multiPower", value);
@@ -94,7 +94,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -102,7 +102,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -110,7 +110,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -118,7 +118,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -126,7 +126,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -134,7 +134,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -142,21 +142,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep ground, default = "white" { }
         [ParserTarget("deepTex")]
-        public MaterialTextureParser DeepTexSetter
+        public MaterialTextureParser DeepTex
         {
-            get => null;
+            get => GetTexture("_deepTex")?.name;
             set => SetTexture("_deepTex", value);
         }
 
         [ParserTarget("deepTexScale")]
-        public Vector2Parser DeepTexScaleSetter
+        public Vector2Parser DeepTexScale
         {
             get => GetTextureScale("_deepTex");
             set => SetTextureScale("_deepTex", value);
         }
 
         [ParserTarget("deepTexOffset")]
-        public Vector2Parser DeepTexOffsetSetter
+        public Vector2Parser DeepTexOffset
         {
             get => GetTextureOffset("_deepTex");
             set => SetTextureOffset("_deepTex", value);
@@ -164,21 +164,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep MT, default = "white" { }
         [ParserTarget("deepMultiTex")]
-        public MaterialTextureParser DeepMultiTexSetter
+        public MaterialTextureParser DeepMultiTex
         {
-            get => null;
+            get => GetTexture("_deepMultiTex")?.name;
             set => SetTexture("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexScale")]
-        public Vector2Parser DeepMultiTexScaleSetter
+        public Vector2Parser DeepMultiTexScale
         {
             get => GetTextureScale("_deepMultiTex");
             set => SetTextureScale("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexOffset")]
-        public Vector2Parser DeepMultiTexOffsetSetter
+        public Vector2Parser DeepMultiTexOffset
         {
             get => GetTextureOffset("_deepMultiTex");
             set => SetTextureOffset("_deepMultiTex", value);
@@ -186,7 +186,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep MT Tiling, default = 1
         [ParserTarget("deepMultiFactor")]
-        public NumericParser<float> DeepMultiFactorSetter
+        public NumericParser<float> DeepMultiFactor
         {
             get => GetFloat("_deepMultiFactor");
             set => SetFloat("_deepMultiFactor", value);
@@ -194,21 +194,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_mainTex")?.name;
             set => SetTexture("_mainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_mainTex");
             set => SetTextureScale("_mainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_mainTex");
             set => SetTextureOffset("_mainTex", value);
@@ -216,21 +216,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main MT, default = "white" { }
         [ParserTarget("mainMultiTex")]
-        public MaterialTextureParser MainMultiTexSetter
+        public MaterialTextureParser MainMultiTex
         {
-            get => null;
+            get => GetTexture("_mainMultiTex")?.name;
             set => SetTexture("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexScale")]
-        public Vector2Parser MainMultiTexScaleSetter
+        public Vector2Parser MainMultiTexScale
         {
             get => GetTextureScale("_mainMultiTex");
             set => SetTextureScale("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexOffset")]
-        public Vector2Parser MainMultiTexOffsetSetter
+        public Vector2Parser MainMultiTexOffset
         {
             get => GetTextureOffset("_mainMultiTex");
             set => SetTextureOffset("_mainMultiTex", value);
@@ -238,7 +238,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main MT Tiling, default = 1
         [ParserTarget("mainMultiFactor")]
-        public NumericParser<float> MainMultiFactorSetter
+        public NumericParser<float> MainMultiFactor
         {
             get => GetFloat("_mainMultiFactor");
             set => SetFloat("_mainMultiFactor", value);
@@ -246,21 +246,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Ground, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -268,21 +268,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High MT, default = "white" { }
         [ParserTarget("highMultiTex")]
-        public MaterialTextureParser HighMultiTexSetter
+        public MaterialTextureParser HighMultiTex
         {
-            get => null;
+            get => GetTexture("_highMultiTex")?.name;
             set => SetTexture("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexScale")]
-        public Vector2Parser HighMultiTexScaleSetter
+        public Vector2Parser HighMultiTexScale
         {
             get => GetTextureScale("_highMultiTex");
             set => SetTextureScale("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexOffset")]
-        public Vector2Parser HighMultiTexOffsetSetter
+        public Vector2Parser HighMultiTexOffset
         {
             get => GetTextureOffset("_highMultiTex");
             set => SetTextureOffset("_highMultiTex", value);
@@ -290,7 +290,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High MT Tiling, default = 1
         [ParserTarget("highMultiFactor")]
-        public NumericParser<float> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactor
         {
             get => GetFloat("_highMultiFactor");
             set => SetFloat("_highMultiFactor", value);
@@ -298,21 +298,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow, default = "white" { }
         [ParserTarget("snowTex")]
-        public MaterialTextureParser SnowTexSetter
+        public MaterialTextureParser SnowTex
         {
-            get => null;
+            get => GetTexture("_snowTex")?.name;
             set => SetTexture("_snowTex", value);
         }
 
         [ParserTarget("snowTexScale")]
-        public Vector2Parser SnowTexScaleSetter
+        public Vector2Parser SnowTexScale
         {
             get => GetTextureScale("_snowTex");
             set => SetTextureScale("_snowTex", value);
         }
 
         [ParserTarget("snowTexOffset")]
-        public Vector2Parser SnowTexOffsetSetter
+        public Vector2Parser SnowTexOffset
         {
             get => GetTextureOffset("_snowTex");
             set => SetTextureOffset("_snowTex", value);
@@ -320,21 +320,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow MT, default = "white" { }
         [ParserTarget("snowMultiTex")]
-        public MaterialTextureParser SnowMultiTexSetter
+        public MaterialTextureParser SnowMultiTex
         {
-            get => null;
+            get => GetTexture("_snowMultiTex")?.name;
             set => SetTexture("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexScale")]
-        public Vector2Parser SnowMultiTexScaleSetter
+        public Vector2Parser SnowMultiTexScale
         {
             get => GetTextureScale("_snowMultiTex");
             set => SetTextureScale("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexOffset")]
-        public Vector2Parser SnowMultiTexOffsetSetter
+        public Vector2Parser SnowMultiTexOffset
         {
             get => GetTextureOffset("_snowMultiTex");
             set => SetTextureOffset("_snowMultiTex", value);
@@ -342,7 +342,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow MT Tiling, default = 1
         [ParserTarget("snowMultiFactor")]
-        public NumericParser<float> SnowMultiFactorSetter
+        public NumericParser<float> SnowMultiFactor
         {
             get => GetFloat("_snowMultiFactor");
             set => SetFloat("_snowMultiFactor", value);
@@ -350,21 +350,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -372,7 +372,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep Start, default = 0
         [ParserTarget("deepStart")]
-        public NumericParser<float> DeepStartSetter
+        public NumericParser<float> DeepStart
         {
             get => GetFloat("_deepStart");
             set => SetFloat("_deepStart", value);
@@ -380,7 +380,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep End, default = 0.3
         [ParserTarget("deepEnd")]
-        public NumericParser<float> DeepEndSetter
+        public NumericParser<float> DeepEnd
         {
             get => GetFloat("_deepEnd");
             set => SetFloat("_deepEnd", value);
@@ -388,7 +388,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main lower boundary start, default = 0
         [ParserTarget("mainLoStart")]
-        public NumericParser<float> MainLoStartSetter
+        public NumericParser<float> MainLoStart
         {
             get => GetFloat("_mainLoStart");
             set => SetFloat("_mainLoStart", value);
@@ -396,7 +396,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main lower boundary end, default = 0.5
         [ParserTarget("mainLoEnd")]
-        public NumericParser<float> MainLoEndSetter
+        public NumericParser<float> MainLoEnd
         {
             get => GetFloat("_mainLoEnd");
             set => SetFloat("_mainLoEnd", value);
@@ -404,7 +404,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main upper boundary start, default = 0.3
         [ParserTarget("mainHiStart")]
-        public NumericParser<float> MainHiStartSetter
+        public NumericParser<float> MainHiStart
         {
             get => GetFloat("_mainHiStart");
             set => SetFloat("_mainHiStart", value);
@@ -412,7 +412,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main upper boundary end, default = 0.5
         [ParserTarget("mainHiEnd")]
-        public NumericParser<float> MainHiEndSetter
+        public NumericParser<float> MainHiEnd
         {
             get => GetFloat("_mainHiEnd");
             set => SetFloat("_mainHiEnd", value);
@@ -420,7 +420,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High lower boundary start, default = 0.6
         [ParserTarget("hiLoStart")]
-        public NumericParser<float> HiLoStartSetter
+        public NumericParser<float> HiLoStart
         {
             get => GetFloat("_hiLoStart");
             set => SetFloat("_hiLoStart", value);
@@ -428,7 +428,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High lower boundary end, default = 0.6
         [ParserTarget("hiLoEnd")]
-        public NumericParser<float> HiLoEndSetter
+        public NumericParser<float> HiLoEnd
         {
             get => GetFloat("_hiLoEnd");
             set => SetFloat("_hiLoEnd", value);
@@ -436,7 +436,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High upper boundary start, default = 0.6
         [ParserTarget("hiHiStart")]
-        public NumericParser<float> HiHiStartSetter
+        public NumericParser<float> HiHiStart
         {
             get => GetFloat("_hiHiStart");
             set => SetFloat("_hiHiStart", value);
@@ -444,7 +444,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High upper boundary end, default = 0.9
         [ParserTarget("hiHiEnd")]
-        public NumericParser<float> HiHiEndSetter
+        public NumericParser<float> HiHiEnd
         {
             get => GetFloat("_hiHiEnd");
             set => SetFloat("_hiHiEnd", value);
@@ -452,7 +452,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow Start, default = 0.9
         [ParserTarget("snowStart")]
-        public NumericParser<float> SnowStartSetter
+        public NumericParser<float> SnowStart
         {
             get => GetFloat("_snowStart");
             set => SetFloat("_snowStart", value);
@@ -460,7 +460,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow End, default = 1
         [ParserTarget("snowEnd")]
-        public NumericParser<float> SnowEndSetter
+        public NumericParser<float> SnowEnd
         {
             get => GetFloat("_snowEnd");
             set => SetFloat("_snowEnd", value);
@@ -468,7 +468,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Fog Color, default = (0,0,1,1)
         [ParserTarget("fogColor")]
-        public ColorParser FogColorSetter
+        public ColorParser FogColor
         {
             get => GetColor("_fogColor");
             set => SetColor("_fogColor", value);
@@ -476,7 +476,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Height Fall Off, default = 1
         [ParserTarget("heightFallOff")]
-        public NumericParser<float> HeightFallOffSetter
+        public NumericParser<float> HeightFallOff
         {
             get => GetFloat("_heightFallOff");
             set => SetFloat("_heightFallOff", value);
@@ -484,7 +484,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -492,7 +492,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Atmosphere Depth, default = 1
         [ParserTarget("atmosphereDepth")]
-        public NumericParser<float> AtmosphereDepthSetter
+        public NumericParser<float> AtmosphereDepth
         {
             get => GetFloat("_atmosphereDepth");
             set => SetFloat("_atmosphereDepth", value);
@@ -500,29 +500,29 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("FogColorRamp")]
         [KittopiaHideOption]
-        public Gradient FogColorRampGradientSetter
+        public Gradient FogColorRampGradient
         {
             set => SetGradient("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -530,7 +530,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
@@ -45,7 +45,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -53,7 +53,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -61,7 +61,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -69,7 +69,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Tiling, default = 1000
         [ParserTarget("texTiling")]
-        public NumericParser<float> TexTilingSetter
+        public NumericParser<float> TexTiling
         {
             get => GetFloat("_texTiling");
             set => SetFloat("_texTiling", value);
@@ -77,7 +77,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("texPower")]
-        public NumericParser<float> TexPowerSetter
+        public NumericParser<float> TexPower
         {
             get => GetFloat("_texPower");
             set => SetFloat("_texPower", value);
@@ -85,7 +85,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("multiPower")]
-        public NumericParser<float> MultiPowerSetter
+        public NumericParser<float> MultiPower
         {
             get => GetFloat("_multiPower");
             set => SetFloat("_multiPower", value);
@@ -93,7 +93,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -101,7 +101,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -109,7 +109,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Multifactor, default = 0.5
         [ParserTarget("multiFactor")]
-        public NumericParser<float> MultiFactorSetter
+        public NumericParser<float> MultiFactor
         {
             get => GetFloat("_multiFactor");
             set => SetFloat("_multiFactor", value);
@@ -117,21 +117,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_mainTex")?.name;
             set => SetTexture("_mainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_mainTex");
             set => SetTextureScale("_mainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_mainTex");
             set => SetTextureOffset("_mainTex", value);
@@ -139,7 +139,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -52,7 +52,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Tiling, default = 1000
         [ParserTarget("texTiling")]
-        public NumericParser<float> TexTilingSetter
+        public NumericParser<float> TexTiling
         {
             get => GetFloat("_texTiling");
             set => SetFloat("_texTiling", value);
@@ -76,7 +76,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Near Blend, default = 0.5
         [ParserTarget("texPower")]
-        public NumericParser<float> TexPowerSetter
+        public NumericParser<float> TexPower
         {
             get => GetFloat("_texPower");
             set => SetFloat("_texPower", value);
@@ -84,7 +84,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Far Blend, default = 0.5
         [ParserTarget("multiPower")]
-        public NumericParser<float> MultiPowerSetter
+        public NumericParser<float> MultiPower
         {
             get => GetFloat("_multiPower");
             set => SetFloat("_multiPower", value);
@@ -92,7 +92,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 2000
         [ParserTarget("groundTexStart")]
-        public NumericParser<float> GroundTexStartSetter
+        public NumericParser<float> GroundTexStart
         {
             get => GetFloat("_groundTexStart");
             set => SetFloat("_groundTexStart", value);
@@ -100,7 +100,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // NearFar Start, default = 10000
         [ParserTarget("groundTexEnd")]
-        public NumericParser<float> GroundTexEndSetter
+        public NumericParser<float> GroundTexEnd
         {
             get => GetFloat("_groundTexEnd");
             set => SetFloat("_groundTexEnd", value);
@@ -108,7 +108,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -124,7 +124,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -132,7 +132,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -140,21 +140,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep ground, default = "white" { }
         [ParserTarget("deepTex")]
-        public MaterialTextureParser DeepTexSetter
+        public MaterialTextureParser DeepTex
         {
-            get => null;
+            get => GetTexture("_deepTex")?.name;
             set => SetTexture("_deepTex", value);
         }
 
         [ParserTarget("deepTexScale")]
-        public Vector2Parser DeepTexScaleSetter
+        public Vector2Parser DeepTexScale
         {
             get => GetTextureScale("_deepTex");
             set => SetTextureScale("_deepTex", value);
         }
 
         [ParserTarget("deepTexOffset")]
-        public Vector2Parser DeepTexOffsetSetter
+        public Vector2Parser DeepTexOffset
         {
             get => GetTextureOffset("_deepTex");
             set => SetTextureOffset("_deepTex", value);
@@ -162,21 +162,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep MT, default = "white" { }
         [ParserTarget("deepMultiTex")]
-        public MaterialTextureParser DeepMultiTexSetter
+        public MaterialTextureParser DeepMultiTex
         {
-            get => null;
+            get => GetTexture("_deepMultiTex")?.name;
             set => SetTexture("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexScale")]
-        public Vector2Parser DeepMultiTexScaleSetter
+        public Vector2Parser DeepMultiTexScale
         {
             get => GetTextureScale("_deepMultiTex");
             set => SetTextureScale("_deepMultiTex", value);
         }
 
         [ParserTarget("deepMultiTexOffset")]
-        public Vector2Parser DeepMultiTexOffsetSetter
+        public Vector2Parser DeepMultiTexOffset
         {
             get => GetTextureOffset("_deepMultiTex");
             set => SetTextureOffset("_deepMultiTex", value);
@@ -184,7 +184,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep MT Tiling, default = 1
         [ParserTarget("deepMultiFactor")]
-        public NumericParser<float> DeepMultiFactorSetter
+        public NumericParser<float> DeepMultiFactor
         {
             get => GetFloat("_deepMultiFactor");
             set => SetFloat("_deepMultiFactor", value);
@@ -192,21 +192,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Texture, default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_mainTex")?.name;
             set => SetTexture("_mainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_mainTex");
             set => SetTextureScale("_mainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_mainTex");
             set => SetTextureOffset("_mainTex", value);
@@ -214,21 +214,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main MT, default = "white" { }
         [ParserTarget("mainMultiTex")]
-        public MaterialTextureParser MainMultiTexSetter
+        public MaterialTextureParser MainMultiTex
         {
-            get => null;
+            get => GetTexture("_mainMultiTex")?.name;
             set => SetTexture("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexScale")]
-        public Vector2Parser MainMultiTexScaleSetter
+        public Vector2Parser MainMultiTexScale
         {
             get => GetTextureScale("_mainMultiTex");
             set => SetTextureScale("_mainMultiTex", value);
         }
 
         [ParserTarget("mainMultiTexOffset")]
-        public Vector2Parser MainMultiTexOffsetSetter
+        public Vector2Parser MainMultiTexOffset
         {
             get => GetTextureOffset("_mainMultiTex");
             set => SetTextureOffset("_mainMultiTex", value);
@@ -236,7 +236,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main MT Tiling, default = 1
         [ParserTarget("mainMultiFactor")]
-        public NumericParser<float> MainMultiFactorSetter
+        public NumericParser<float> MainMultiFactor
         {
             get => GetFloat("_mainMultiFactor");
             set => SetFloat("_mainMultiFactor", value);
@@ -244,21 +244,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Ground, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -266,21 +266,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High MT, default = "white" { }
         [ParserTarget("highMultiTex")]
-        public MaterialTextureParser HighMultiTexSetter
+        public MaterialTextureParser HighMultiTex
         {
-            get => null;
+            get => GetTexture("_highMultiTex")?.name;
             set => SetTexture("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexScale")]
-        public Vector2Parser HighMultiTexScaleSetter
+        public Vector2Parser HighMultiTexScale
         {
             get => GetTextureScale("_highMultiTex");
             set => SetTextureScale("_highMultiTex", value);
         }
 
         [ParserTarget("highMultiTexOffset")]
-        public Vector2Parser HighMultiTexOffsetSetter
+        public Vector2Parser HighMultiTexOffset
         {
             get => GetTextureOffset("_highMultiTex");
             set => SetTextureOffset("_highMultiTex", value);
@@ -288,7 +288,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High MT Tiling, default = 1
         [ParserTarget("highMultiFactor")]
-        public NumericParser<float> HighMultiFactorSetter
+        public NumericParser<float> HighMultiFactor
         {
             get => GetFloat("_highMultiFactor");
             set => SetFloat("_highMultiFactor", value);
@@ -296,21 +296,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow, default = "white" { }
         [ParserTarget("snowTex")]
-        public MaterialTextureParser SnowTexSetter
+        public MaterialTextureParser SnowTex
         {
-            get => null;
+            get => GetTexture("_snowTex")?.name;
             set => SetTexture("_snowTex", value);
         }
 
         [ParserTarget("snowTexScale")]
-        public Vector2Parser SnowTexScaleSetter
+        public Vector2Parser SnowTexScale
         {
             get => GetTextureScale("_snowTex");
             set => SetTextureScale("_snowTex", value);
         }
 
         [ParserTarget("snowTexOffset")]
-        public Vector2Parser SnowTexOffsetSetter
+        public Vector2Parser SnowTexOffset
         {
             get => GetTextureOffset("_snowTex");
             set => SetTextureOffset("_snowTex", value);
@@ -318,21 +318,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow MT, default = "white" { }
         [ParserTarget("snowMultiTex")]
-        public MaterialTextureParser SnowMultiTexSetter
+        public MaterialTextureParser SnowMultiTex
         {
-            get => null;
+            get => GetTexture("_snowMultiTex")?.name;
             set => SetTexture("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexScale")]
-        public Vector2Parser SnowMultiTexScaleSetter
+        public Vector2Parser SnowMultiTexScale
         {
             get => GetTextureScale("_snowMultiTex");
             set => SetTextureScale("_snowMultiTex", value);
         }
 
         [ParserTarget("snowMultiTexOffset")]
-        public Vector2Parser SnowMultiTexOffsetSetter
+        public Vector2Parser SnowMultiTexOffset
         {
             get => GetTextureOffset("_snowMultiTex");
             set => SetTextureOffset("_snowMultiTex", value);
@@ -340,7 +340,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow MT Tiling, default = 1
         [ParserTarget("snowMultiFactor")]
-        public NumericParser<float> SnowMultiFactorSetter
+        public NumericParser<float> SnowMultiFactor
         {
             get => GetFloat("_snowMultiFactor");
             set => SetFloat("_snowMultiFactor", value);
@@ -348,21 +348,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -370,7 +370,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep Start, default = 0
         [ParserTarget("deepStart")]
-        public NumericParser<float> DeepStartSetter
+        public NumericParser<float> DeepStart
         {
             get => GetFloat("_deepStart");
             set => SetFloat("_deepStart", value);
@@ -378,7 +378,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Deep End, default = 0.3
         [ParserTarget("deepEnd")]
-        public NumericParser<float> DeepEndSetter
+        public NumericParser<float> DeepEnd
         {
             get => GetFloat("_deepEnd");
             set => SetFloat("_deepEnd", value);
@@ -386,7 +386,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main lower boundary start, default = 0
         [ParserTarget("mainLoStart")]
-        public NumericParser<float> MainLoStartSetter
+        public NumericParser<float> MainLoStart
         {
             get => GetFloat("_mainLoStart");
             set => SetFloat("_mainLoStart", value);
@@ -394,7 +394,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main lower boundary end, default = 0.5
         [ParserTarget("mainLoEnd")]
-        public NumericParser<float> MainLoEndSetter
+        public NumericParser<float> MainLoEnd
         {
             get => GetFloat("_mainLoEnd");
             set => SetFloat("_mainLoEnd", value);
@@ -402,7 +402,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main upper boundary start, default = 0.3
         [ParserTarget("mainHiStart")]
-        public NumericParser<float> MainHiStartSetter
+        public NumericParser<float> MainHiStart
         {
             get => GetFloat("_mainHiStart");
             set => SetFloat("_mainHiStart", value);
@@ -410,7 +410,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main upper boundary end, default = 0.5
         [ParserTarget("mainHiEnd")]
-        public NumericParser<float> MainHiEndSetter
+        public NumericParser<float> MainHiEnd
         {
             get => GetFloat("_mainHiEnd");
             set => SetFloat("_mainHiEnd", value);
@@ -418,7 +418,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High lower boundary start, default = 0.6
         [ParserTarget("hiLoStart")]
-        public NumericParser<float> HiLoStartSetter
+        public NumericParser<float> HiLoStart
         {
             get => GetFloat("_hiLoStart");
             set => SetFloat("_hiLoStart", value);
@@ -426,7 +426,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High lower boundary end, default = 0.6
         [ParserTarget("hiLoEnd")]
-        public NumericParser<float> HiLoEndSetter
+        public NumericParser<float> HiLoEnd
         {
             get => GetFloat("_hiLoEnd");
             set => SetFloat("_hiLoEnd", value);
@@ -434,7 +434,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High upper boundary start, default = 0.6
         [ParserTarget("hiHiStart")]
-        public NumericParser<float> HiHiStartSetter
+        public NumericParser<float> HiHiStart
         {
             get => GetFloat("_hiHiStart");
             set => SetFloat("_hiHiStart", value);
@@ -442,7 +442,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High upper boundary end, default = 0.9
         [ParserTarget("hiHiEnd")]
-        public NumericParser<float> HiHiEndSetter
+        public NumericParser<float> HiHiEnd
         {
             get => GetFloat("_hiHiEnd");
             set => SetFloat("_hiHiEnd", value);
@@ -450,7 +450,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow Start, default = 0.9
         [ParserTarget("snowStart")]
-        public NumericParser<float> SnowStartSetter
+        public NumericParser<float> SnowStart
         {
             get => GetFloat("_snowStart");
             set => SetFloat("_snowStart", value);
@@ -458,7 +458,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Snow End, default = 1
         [ParserTarget("snowEnd")]
-        public NumericParser<float> SnowEndSetter
+        public NumericParser<float> SnowEnd
         {
             get => GetFloat("_snowEnd");
             set => SetFloat("_snowEnd", value);
@@ -466,7 +466,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor, default = 10
         [ParserTarget("factor")]
-        public NumericParser<float> FactorSetter
+        public NumericParser<float> Factor
         {
             get => GetFloat("_factor");
             set => SetFloat("_factor", value);
@@ -52,7 +52,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor Blend Width, default = 0.1
         [ParserTarget("factorBlendWidth")]
-        public NumericParser<float> FactorBlendWidthSetter
+        public NumericParser<float> FactorBlendWidth
         {
             get => GetFloat("_factorBlendWidth");
             set => SetFloat("_factorBlendWidth", value);
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor Rotation, default = 30
         [ParserTarget("factorRotation")]
-        public NumericParser<float> FactorRotationSetter
+        public NumericParser<float> FactorRotation
         {
             get => GetFloat("_factorRotation");
             set => SetFloat("_factorRotation", value);
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -76,7 +76,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -84,7 +84,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -92,7 +92,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (0.2,0.2,0.2,0.2)
         [ParserTarget("specularColor")]
-        public ColorParser SpecularColorSetter
+        public ColorParser SpecularColor
         {
             get => GetColor("_specularColor");
             set => SetColor("_specularColor", value);
@@ -100,7 +100,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Brightness, default = 2
         [ParserTarget("albedoBrightness")]
-        public NumericParser<float> AlbedoBrightnessSetter
+        public NumericParser<float> AlbedoBrightness
         {
             get => GetFloat("_albedoBrightness");
             set => SetFloat("_albedoBrightness", value);
@@ -108,7 +108,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -124,7 +124,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -132,21 +132,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -154,21 +154,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -176,7 +176,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<float> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTiling
         {
             get => GetFloat("_steepNearTiling");
             set => SetFloat("_steepNearTiling", value);
@@ -184,7 +184,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -192,21 +192,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Texture, default = "white" { }
         [ParserTarget("lowTex")]
-        public MaterialTextureParser LowTexSetter
+        public MaterialTextureParser LowTex
         {
-            get => null;
+            get => GetTexture("_lowTex")?.name;
             set => SetTexture("_lowTex", value);
         }
 
         [ParserTarget("lowTexScale")]
-        public Vector2Parser LowTexScaleSetter
+        public Vector2Parser LowTexScale
         {
             get => GetTextureScale("_lowTex");
             set => SetTextureScale("_lowTex", value);
         }
 
         [ParserTarget("lowTexOffset")]
-        public Vector2Parser LowTexOffsetSetter
+        public Vector2Parser LowTexOffset
         {
             get => GetTextureOffset("_lowTex");
             set => SetTextureOffset("_lowTex", value);
@@ -214,7 +214,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Tiling, default = 100000
         [ParserTarget("lowTiling")]
-        public NumericParser<float> LowTilingSetter
+        public NumericParser<float> LowTiling
         {
             get => GetFloat("_lowTiling");
             set => SetFloat("_lowTiling", value);
@@ -222,21 +222,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Texture, default = "white" { }
         [ParserTarget("midTex")]
-        public MaterialTextureParser MidTexSetter
+        public MaterialTextureParser MidTex
         {
-            get => null;
+            get => GetTexture("_midTex")?.name;
             set => SetTexture("_midTex", value);
         }
 
         [ParserTarget("midTexScale")]
-        public Vector2Parser MidTexScaleSetter
+        public Vector2Parser MidTexScale
         {
             get => GetTextureScale("_midTex");
             set => SetTextureScale("_midTex", value);
         }
 
         [ParserTarget("midTexOffset")]
-        public Vector2Parser MidTexOffsetSetter
+        public Vector2Parser MidTexOffset
         {
             get => GetTextureOffset("_midTex");
             set => SetTextureOffset("_midTex", value);
@@ -244,7 +244,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Tiling, default = 100000
         [ParserTarget("midTiling")]
-        public NumericParser<float> MidTilingSetter
+        public NumericParser<float> MidTiling
         {
             get => GetFloat("_midTiling");
             set => SetFloat("_midTiling", value);
@@ -252,21 +252,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Map, default = "bump" { }
         [ParserTarget("midBumpMap")]
-        public MaterialTextureParser MidBumpMapSetter
+        public MaterialTextureParser MidBumpMap
         {
-            get => null;
+            get => GetTexture("_midBumpMap")?.name;
             set => SetTexture("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapScale")]
-        public Vector2Parser MidBumpMapScaleSetter
+        public Vector2Parser MidBumpMapScale
         {
             get => GetTextureScale("_midBumpMap");
             set => SetTextureScale("_midBumpMap", value);
         }
 
         [ParserTarget("midBumpMapOffset")]
-        public Vector2Parser MidBumpMapOffsetSetter
+        public Vector2Parser MidBumpMapOffset
         {
             get => GetTextureOffset("_midBumpMap");
             set => SetTextureOffset("_midBumpMap", value);
@@ -274,7 +274,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Mid Bump Tiling, default = 100000
         [ParserTarget("midBumpTiling")]
-        public NumericParser<float> MidBumpTilingSetter
+        public NumericParser<float> MidBumpTiling
         {
             get => GetFloat("_midBumpTiling");
             set => SetFloat("_midBumpTiling", value);
@@ -282,21 +282,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Texture, default = "white" { }
         [ParserTarget("highTex")]
-        public MaterialTextureParser HighTexSetter
+        public MaterialTextureParser HighTex
         {
-            get => null;
+            get => GetTexture("_highTex")?.name;
             set => SetTexture("_highTex", value);
         }
 
         [ParserTarget("highTexScale")]
-        public Vector2Parser HighTexScaleSetter
+        public Vector2Parser HighTexScale
         {
             get => GetTextureScale("_highTex");
             set => SetTextureScale("_highTex", value);
         }
 
         [ParserTarget("highTexOffset")]
-        public Vector2Parser HighTexOffsetSetter
+        public Vector2Parser HighTexOffset
         {
             get => GetTextureOffset("_highTex");
             set => SetTextureOffset("_highTex", value);
@@ -304,7 +304,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Tiling, default = 100000
         [ParserTarget("highTiling")]
-        public NumericParser<float> HighTilingSetter
+        public NumericParser<float> HighTiling
         {
             get => GetFloat("_highTiling");
             set => SetFloat("_highTiling", value);
@@ -312,7 +312,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition Start, default = 0
         [ParserTarget("lowStart")]
-        public NumericParser<float> LowStartSetter
+        public NumericParser<float> LowStart
         {
             get => GetFloat("_lowStart");
             set => SetFloat("_lowStart", value);
@@ -320,7 +320,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Low Transition End, default = 0.3
         [ParserTarget("lowEnd")]
-        public NumericParser<float> LowEndSetter
+        public NumericParser<float> LowEnd
         {
             get => GetFloat("_lowEnd");
             set => SetFloat("_lowEnd", value);
@@ -328,7 +328,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition Start, default = 0.8
         [ParserTarget("highStart")]
-        public NumericParser<float> HighStartSetter
+        public NumericParser<float> HighStart
         {
             get => GetFloat("_highStart");
             set => SetFloat("_highStart", value);
@@ -336,7 +336,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // High Transition End, default = 1
         [ParserTarget("highEnd")]
-        public NumericParser<float> HighEndSetter
+        public NumericParser<float> HighEnd
         {
             get => GetFloat("_highEnd");
             set => SetFloat("_highEnd", value);
@@ -344,7 +344,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -352,21 +352,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -374,7 +374,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -382,7 +382,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<float> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistance
         {
             get => GetFloat("_oceanFogDistance");
             set => SetFloat("_oceanFogDistance", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Color Lerp Modifier, default = 1
         [ParserTarget("colorLerpModifier")]
-        public NumericParser<float> ColorLerpModifierSetter
+        public NumericParser<float> ColorLerpModifier
         {
             get => GetFloat("_ColorLerpModifier");
             set => SetFloat("_ColorLerpModifier", value);
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Atlas Texture, default = 100000
         [ParserTarget("atlasTiling")]
-        public NumericParser<float> AtlasTilingSetter
+        public NumericParser<float> AtlasTiling
         {
             get => GetFloat("_AtlasTiling");
             set => SetFloat("_AtlasTiling", value);
@@ -77,7 +77,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Atlas Texture, default = "white" { }
         [ParserTargetCollection("AtlasTex")]
         [KittopiaHideOption]
-        public List<Texture2DParser> AtlasTexSetter
+        public List<Texture2DParser> AtlasTex
         {
             // TODO: Figure out if it is even possible to get the names out of a Texture2DArray
             get { return new List<Texture2DParser>(); }
@@ -96,7 +96,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Normal Atlas Texture, default = "white" { }
         [ParserTargetCollection("NormalTex")]
         [KittopiaHideOption]
-        public List<Texture2DParser> NormalTexSetter
+        public List<Texture2DParser> NormalTex
         {
             // TODO: Figure out if it is even possible to get the names out of a Texture2DArray
             get { return new List<Texture2DParser>(); }
@@ -114,7 +114,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor, default = 10
         [ParserTarget("factor")]
-        public NumericParser<float> FactorSetter
+        public NumericParser<float> Factor
         {
             get => GetFloat("_factor");
             set => SetFloat("_factor", value);
@@ -122,7 +122,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor Blend Width, default = 0.1
         [ParserTarget("factorBlendWidth")]
-        public NumericParser<float> FactorBlendWidthSetter
+        public NumericParser<float> FactorBlendWidth
         {
             get => GetFloat("_factorBlendWidth");
             set => SetFloat("_factorBlendWidth", value);
@@ -130,7 +130,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Factor Rotation, default = 30
         [ParserTarget("factorRotation")]
-        public NumericParser<float> FactorRotationSetter
+        public NumericParser<float> FactorRotation
         {
             get => GetFloat("_factorRotation");
             set => SetFloat("_factorRotation", value);
@@ -138,7 +138,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Saturation, default = 1
         [ParserTarget("saturation")]
-        public NumericParser<float> SaturationSetter
+        public NumericParser<float> Saturation
         {
             get => GetFloat("_saturation");
             set => SetFloat("_saturation", value);
@@ -146,7 +146,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Contrast, default = 1
         [ParserTarget("contrast")]
-        public NumericParser<float> ContrastSetter
+        public NumericParser<float> Contrast
         {
             get => GetFloat("_contrast");
             set => SetFloat("_contrast", value);
@@ -154,7 +154,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Colour Unsaturation (A = Factor), default = (1,1,1,0)
         [ParserTarget("tintColor")]
-        public ColorParser TintColorSetter
+        public ColorParser TintColor
         {
             get => GetColor("_tintColor");
             set => SetColor("_tintColor", value);
@@ -162,7 +162,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (0.2,0.2,0.2,0.2)
         [ParserTarget("specularColor")]
-        public ColorParser SpecularColorSetter
+        public ColorParser SpecularColor
         {
             get => GetColor("_specularColor");
             set => SetColor("_specularColor", value);
@@ -170,7 +170,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Brightness, default = 2
         [ParserTarget("albedoBrightness")]
-        public NumericParser<float> AlbedoBrightnessSetter
+        public NumericParser<float> AlbedoBrightness
         {
             get => GetFloat("_albedoBrightness");
             set => SetFloat("_albedoBrightness", value);
@@ -178,7 +178,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Blend, default = 1
         [ParserTarget("steepPower")]
-        public NumericParser<float> SteepPowerSetter
+        public NumericParser<float> SteepPower
         {
             get => GetFloat("_steepPower");
             set => SetFloat("_steepPower", value);
@@ -186,7 +186,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade Start, default = 20000
         [ParserTarget("steepTexStart")]
-        public NumericParser<float> SteepTexStartSetter
+        public NumericParser<float> SteepTexStart
         {
             get => GetFloat("_steepTexStart");
             set => SetFloat("_steepTexStart", value);
@@ -194,7 +194,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Fade End, default = 30000
         [ParserTarget("steepTexEnd")]
-        public NumericParser<float> SteepTexEndSetter
+        public NumericParser<float> SteepTexEnd
         {
             get => GetFloat("_steepTexEnd");
             set => SetFloat("_steepTexEnd", value);
@@ -202,21 +202,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Texture, default = "white" { }
         [ParserTarget("steepTex")]
-        public MaterialTextureParser SteepTexSetter
+        public MaterialTextureParser SteepTex
         {
-            get => null;
+            get => GetTexture("_steepTex")?.name;
             set => SetTexture("_steepTex", value);
         }
 
         [ParserTarget("steepTexScale")]
-        public Vector2Parser SteepTexScaleSetter
+        public Vector2Parser SteepTexScale
         {
             get => GetTextureScale("_steepTex");
             set => SetTextureScale("_steepTex", value);
         }
 
         [ParserTarget("steepTexOffset")]
-        public Vector2Parser SteepTexOffsetSetter
+        public Vector2Parser SteepTexOffset
         {
             get => GetTextureOffset("_steepTex");
             set => SetTextureOffset("_steepTex", value);
@@ -224,21 +224,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Bump Map, default = "bump" { }
         [ParserTarget("steepBumpMap")]
-        public MaterialTextureParser SteepBumpMapSetter
+        public MaterialTextureParser SteepBumpMap
         {
-            get => null;
+            get => GetTexture("_steepBumpMap")?.name;
             set => SetTexture("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapScale")]
-        public Vector2Parser SteepBumpMapScaleSetter
+        public Vector2Parser SteepBumpMapScale
         {
             get => GetTextureScale("_steepBumpMap");
             set => SetTextureScale("_steepBumpMap", value);
         }
 
         [ParserTarget("steepBumpMapOffset")]
-        public Vector2Parser SteepBumpMapOffsetSetter
+        public Vector2Parser SteepBumpMapOffset
         {
             get => GetTextureOffset("_steepBumpMap");
             set => SetTextureOffset("_steepBumpMap", value);
@@ -246,7 +246,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Near Tiling, default = 1
         [ParserTarget("steepNearTiling")]
-        public NumericParser<float> SteepNearTilingSetter
+        public NumericParser<float> SteepNearTiling
         {
             get => GetFloat("_steepNearTiling");
             set => SetFloat("_steepNearTiling", value);
@@ -254,7 +254,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Steep Far Tiling, default = 1
         [ParserTarget("steepTiling")]
-        public NumericParser<float> SteepTilingSetter
+        public NumericParser<float> SteepTiling
         {
             get => GetFloat("_steepTiling");
             set => SetFloat("_steepTiling", value);
@@ -262,7 +262,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // AP Global Density, default = 1
         [ParserTarget("globalDensity")]
-        public NumericParser<float> GlobalDensitySetter
+        public NumericParser<float> GlobalDensity
         {
             get => GetFloat("_globalDensity");
             set => SetFloat("_globalDensity", value);
@@ -270,21 +270,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // FogColorRamp, default = "white" { }
         [ParserTarget("fogColorRamp")]
-        public MaterialTextureParser FogColorRampSetter
+        public MaterialTextureParser FogColorRamp
         {
-            get => null;
+            get => GetTexture("_fogColorRamp")?.name;
             set => SetTexture("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampScale")]
-        public Vector2Parser FogColorRampScaleSetter
+        public Vector2Parser FogColorRampScale
         {
             get => GetTextureScale("_fogColorRamp");
             set => SetTextureScale("_fogColorRamp", value);
         }
 
         [ParserTarget("fogColorRampOffset")]
-        public Vector2Parser FogColorRampOffsetSetter
+        public Vector2Parser FogColorRampOffset
         {
             get => GetTextureOffset("_fogColorRamp");
             set => SetTextureOffset("_fogColorRamp", value);
@@ -292,7 +292,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // PlanetOpacity, default = 1
         [ParserTarget("planetOpacity")]
-        public NumericParser<float> PlanetOpacitySetter
+        public NumericParser<float> PlanetOpacity
         {
             get => GetFloat("_PlanetOpacity");
             set => SetFloat("_PlanetOpacity", value);
@@ -300,7 +300,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Ocean Fog Dist, default = 1000
         [ParserTarget("oceanFogDistance")]
-        public NumericParser<float> OceanFogDistanceSetter
+        public NumericParser<float> OceanFogDistance
         {
             get => GetFloat("_oceanFogDistance");
             set => SetFloat("_oceanFogDistance", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
@@ -44,21 +44,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Particle Texture, default = "white" { }
         [ParserTarget("texture")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -66,7 +66,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Soft Particles Factor, default = 1
         [ParserTarget("invFade")]
-        public NumericParser<float> InvFadeSetter
+        public NumericParser<float> InvFade
         {
             get => GetFloat("_InvFade");
             set => SetFloat("_InvFade", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
-        public ColorParser SpecColorSetter
+        public ColorParser SpecColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<float> ShininessSetter
+        public NumericParser<float> Shininess
         {
             get => GetFloat("_Shininess");
             set => SetFloat("_Shininess", value);
@@ -71,21 +71,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("texture")]
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -94,21 +94,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Normal map, default = "bump" { }
         [ParserTarget("normals")]
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<float> OpacitySetter
+        public NumericParser<float> Opacity
         {
             get => GetFloat("_Opacity");
             set => SetFloat("_Opacity", value);
@@ -124,7 +124,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rim Power, default = 3
         [ParserTarget("rimPower")]
-        public NumericParser<float> RimPowerSetter
+        public NumericParser<float> RimPower
         {
             get => GetFloat("_rimPower");
             set => SetFloat("_rimPower", value);
@@ -132,7 +132,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rim Blend, default = 1
         [ParserTarget("rimBlend")]
-        public NumericParser<float> RimBlendSetter
+        public NumericParser<float> RimBlend
         {
             get => GetFloat("_rimBlend");
             set => SetFloat("_rimBlend", value);
@@ -140,21 +140,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // RimColorRamp, default = "white" { }
         [ParserTarget("rimColorRamp")]
-        public MaterialTextureParser RimColorRampSetter
+        public MaterialTextureParser RimColorRamp
         {
-            get => null;
+            get => GetTexture("_rimColorRamp")?.name;
             set => SetTexture("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampScale")]
-        public Vector2Parser RimColorRampScaleSetter
+        public Vector2Parser RimColorRampScale
         {
             get => GetTextureScale("_rimColorRamp");
             set => SetTextureScale("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampOffset")]
-        public Vector2Parser RimColorRampOffsetSetter
+        public Vector2Parser RimColorRampOffset
         {
             get => GetTextureOffset("_rimColorRamp");
             set => SetTextureOffset("_rimColorRamp", value);
@@ -162,14 +162,14 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         [ParserTarget("Gradient")]
         [KittopiaHideOption]
-        public Gradient RimColorRampGradientSetter
+        public Gradient RimColorRampGradient
         {
             set => SetGradient("_rimColorRamp", value);
         }
 
         // LightDirection, default = (1,0,0,0)
         [ParserTarget("localLightDirection")]
-        public Vector4Parser LocalLightDirectionSetter
+        public Vector4Parser LocalLightDirection
         {
             get => GetVector("_localLightDirection");
             set => SetVector("_localLightDirection", value);
@@ -177,21 +177,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public MaterialTextureParser ResourceMapSetter
+        public MaterialTextureParser ResourceMap
         {
-            get => null;
+            get => GetTexture("_ResourceMap")?.name;
             set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
-        public Vector2Parser ResourceMapScaleSetter
+        public Vector2Parser ResourceMapScale
         {
             get => GetTextureScale("_ResourceMap");
             set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
-        public Vector2Parser ResourceMapOffsetSetter
+        public Vector2Parser ResourceMapOffset
         {
             get => GetTextureOffset("_ResourceMap");
             set => SetTextureOffset("_ResourceMap", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
-        public ColorParser SpecColorSetter
+        public ColorParser SpecColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -62,7 +62,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<float> ShininessSetter
+        public NumericParser<float> Shininess
         {
             get => GetFloat("_Shininess");
             set => SetFloat("_Shininess", value);
@@ -71,21 +71,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("texture")]
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -94,21 +94,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Normal map, default = "bump" { }
         [ParserTarget("normals")]
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<float> OpacitySetter
+        public NumericParser<float> Opacity
         {
             get => GetFloat("_Opacity");
             set => SetFloat("_Opacity", value);
@@ -124,7 +124,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rim Power, default = 3
         [ParserTarget("rimPower")]
-        public NumericParser<float> RimPowerSetter
+        public NumericParser<float> RimPower
         {
             get => GetFloat("_rimPower");
             set => SetFloat("_rimPower", value);
@@ -132,7 +132,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rim Blend, default = 1
         [ParserTarget("rimBlend")]
-        public NumericParser<float> RimBlendSetter
+        public NumericParser<float> RimBlend
         {
             get => GetFloat("_rimBlend");
             set => SetFloat("_rimBlend", value);
@@ -140,21 +140,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // RimColorRamp, default = "white" { }
         [ParserTarget("rimColorRamp")]
-        public MaterialTextureParser RimColorRampSetter
+        public MaterialTextureParser RimColorRamp
         {
-            get => null;
+            get => GetTexture("_rimColorRamp")?.name;
             set => SetTexture("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampScale")]
-        public Vector2Parser RimColorRampScaleSetter
+        public Vector2Parser RimColorRampScale
         {
             get => GetTextureScale("_rimColorRamp");
             set => SetTextureScale("_rimColorRamp", value);
         }
 
         [ParserTarget("rimColorRampOffset")]
-        public Vector2Parser RimColorRampOffsetSetter
+        public Vector2Parser RimColorRampOffset
         {
             get => GetTextureOffset("_rimColorRamp");
             set => SetTextureOffset("_rimColorRamp", value);
@@ -162,14 +162,14 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         [ParserTarget("Gradient")]
         [KittopiaHideOption]
-        public Gradient RimColorRampGradientSetter
+        public Gradient RimColorRampGradient
         {
             set => SetGradient("_rimColorRamp", value);
         }
 
         // LightDirection, default = (1,0,0,0)
         [ParserTarget("localLightDirection")]
-        public Vector4Parser LocalLightDirectionSetter
+        public Vector4Parser LocalLightDirection
         {
             get => GetVector("_localLightDirection");
             set => SetVector("_localLightDirection", value);
@@ -177,21 +177,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public MaterialTextureParser ResourceMapSetter
+        public MaterialTextureParser ResourceMap
         {
-            get => null;
+            get => GetTexture("_ResourceMap")?.name;
             set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
-        public Vector2Parser ResourceMapScaleSetter
+        public Vector2Parser ResourceMapScale
         {
             get => GetTextureScale("_ResourceMap");
             set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
-        public Vector2Parser ResourceMapOffsetSetter
+        public Vector2Parser ResourceMapOffset
         {
             get => GetTextureOffset("_ResourceMap");
             set => SetTextureOffset("_ResourceMap", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,7 +52,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
-        public ColorParser SpecColorSetter
+        public ColorParser SpecColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<float> ShininessSetter
+        public NumericParser<float> Shininess
         {
             get => GetFloat("_Shininess");
             set => SetFloat("_Shininess", value);
@@ -68,21 +68,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -90,21 +90,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normalmap, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -112,7 +112,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<float> OpacitySetter
+        public NumericParser<float> Opacity
         {
             get => GetFloat("_Opacity");
             set => SetFloat("_Opacity", value);
@@ -120,7 +120,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rim Color, default = (0.26,0.19,0.16,0)
         [ParserTarget("rimColor")]
-        public ColorParser RimColorSetter
+        public ColorParser RimColor
         {
             get => GetColor("_RimColor");
             set => SetColor("_RimColor", value);
@@ -128,7 +128,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Rim Power, default = 3
         [ParserTarget("rimPower")]
-        public NumericParser<float> RimPowerSetter
+        public NumericParser<float> RimPower
         {
             get => GetFloat("_RimPower");
             set => SetFloat("_RimPower", value);
@@ -136,21 +136,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public MaterialTextureParser ResourceMapSetter
+        public MaterialTextureParser ResourceMap
         {
-            get => null;
+            get => GetTexture("_ResourceMap")?.name;
             set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
-        public Vector2Parser ResourceMapScaleSetter
+        public Vector2Parser ResourceMapScale
         {
             get => GetTextureScale("_ResourceMap");
             set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
-        public Vector2Parser ResourceMapOffsetSetter
+        public Vector2Parser ResourceMapOffset
         {
             get => GetTextureOffset("_ResourceMap");
             set => SetTextureOffset("_ResourceMap", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Main Color, default = (1,1,1,1)
         [ParserTarget("color")]
-        public ColorParser ColorSetter
+        public ColorParser Color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,7 +52,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Color, default = (0.5,0.5,0.5,1)
         [ParserTarget("specColor")]
-        public ColorParser SpecColorSetter
+        public ColorParser SpecColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -60,7 +60,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Shininess, default = 0.078125
         [ParserTarget("shininess")]
-        public NumericParser<float> ShininessSetter
+        public NumericParser<float> Shininess
         {
             get => GetFloat("_Shininess");
             set => SetFloat("_Shininess", value);
@@ -69,21 +69,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Base (RGB) Gloss (A), default = "white" { }
         [ParserTarget("texture")]
         [ParserTarget("mainTex")]
-        public MaterialTextureParser MainTexSetter
+        public MaterialTextureParser MainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser MainTexScaleSetter
+        public Vector2Parser MainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser MainTexOffsetSetter
+        public Vector2Parser MainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -92,21 +92,21 @@ namespace Kopernicus.Configuration.MaterialLoader
         // Normal map, default = "bump" { }
         [ParserTarget("normals")]
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser BumpMapSetter
+        public MaterialTextureParser BumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser BumpMapScaleSetter
+        public Vector2Parser BumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser BumpMapOffsetSetter
+        public Vector2Parser BumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -114,7 +114,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Opacity, default = 1
         [ParserTarget("opacity")]
-        public NumericParser<float> OpacitySetter
+        public NumericParser<float> Opacity
         {
             get => GetFloat("_Opacity");
             set => SetFloat("_Opacity", value);
@@ -122,21 +122,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Resource Map (RGB), default = "black" { }
         [ParserTarget("resourceMap")]
-        public MaterialTextureParser ResourceMapSetter
+        public MaterialTextureParser ResourceMap
         {
-            get => null;
+            get => GetTexture("_ResourceMap")?.name;
             set => SetTexture("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapScale")]
-        public Vector2Parser ResourceMapScaleSetter
+        public Vector2Parser ResourceMapScale
         {
             get => GetTextureScale("_ResourceMap");
             set => SetTextureScale("_ResourceMap", value);
         }
 
         [ParserTarget("resourceMapOffset")]
-        public Vector2Parser ResourceMapOffsetSetter
+        public Vector2Parser ResourceMapOffset
         {
             get => GetTextureOffset("_ResourceMap");
             set => SetTextureOffset("_ResourceMap", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Color, default = (1.000000,1.000000,1.000000,1.000000)
         [ParserTarget("color", Optional = true)]
-        public ColorParser colorSetter
+        public ColorParser color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Albedo, default = "white" { }
         [ParserTarget("mainTex", Optional = true)]
-        public MaterialTextureParser mainTexSetter
+        public MaterialTextureParser mainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale", Optional = true)]
-        public Vector2Parser mainTexScaleSetter
+        public Vector2Parser mainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset", Optional = true)]
-        public Vector2Parser mainTexOffsetSetter
+        public Vector2Parser mainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -74,7 +74,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Alpha Cutoff, default = 0.500000
         [ParserTarget("cutoff", Optional = true)]
-        public NumericParser<float> cutoffSetter
+        public NumericParser<float> cutoff
         {
             get => GetFloat("_Cutoff");
             set => SetFloat("_Cutoff", value);
@@ -82,7 +82,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Smoothness, default = 0.500000
         [ParserTarget("glossiness", Optional = true)]
-        public NumericParser<float> glossinessSetter
+        public NumericParser<float> glossiness
         {
             get => GetFloat("_Glossiness");
             set => SetFloat("_Glossiness", value);
@@ -90,7 +90,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Smoothness Scale, default = 1.000000
         [ParserTarget("glossMapScale", Optional = true)]
-        public NumericParser<float> glossMapScaleSetter
+        public NumericParser<float> glossMapScale
         {
             get => GetFloat("_GlossMapScale");
             set => SetFloat("_GlossMapScale", value);
@@ -98,7 +98,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Smoothness texture channel, default = 0.000000
         [ParserTarget("smoothnessTextureChannel", Optional = true)]
-        public NumericParser<float> smoothnessTextureChannelSetter
+        public NumericParser<float> smoothnessTextureChannel
         {
             get => GetFloat("_SmoothnessTextureChannel");
             set => SetFloat("_SmoothnessTextureChannel", value);
@@ -106,7 +106,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Metallic, default = 0.000000
         [ParserTarget("metallic", Optional = true)]
-        public NumericParser<float> metallicSetter
+        public NumericParser<float> metallic
         {
             get => GetFloat("_Metallic");
             set => SetFloat("_Metallic", value);
@@ -114,21 +114,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Metallic, default = "white" { }
         [ParserTarget("metallicGlossMap", Optional = true)]
-        public MaterialTextureParser metallicGlossMapSetter
+        public MaterialTextureParser metallicGlossMap
         {
-            get => null;
+            get => GetTexture("_MetallicGlossMap")?.name;
             set => SetTexture("_MetallicGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapScale", Optional = true)]
-        public Vector2Parser metallicGlossMapScaleSetter
+        public Vector2Parser metallicGlossMapScale
         {
             get => GetTextureScale("_MetallicGlossMap");
             set => SetTextureScale("_MetallicGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapOffset", Optional = true)]
-        public Vector2Parser metallicGlossMapOffsetSetter
+        public Vector2Parser metallicGlossMapOffset
         {
             get => GetTextureOffset("_MetallicGlossMap");
             set => SetTextureOffset("_MetallicGlossMap", value);
@@ -136,7 +136,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Highlights, default = 1.000000
         [ParserTarget("specularHighlights", Optional = true)]
-        public NumericParser<float> specularHighlightsSetter
+        public NumericParser<float> specularHighlights
         {
             get => GetFloat("_SpecularHighlights");
             set => SetFloat("_SpecularHighlights", value);
@@ -144,7 +144,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Glossy Reflections, default = 1.000000
         [ParserTarget("glossyReflections", Optional = true)]
-        public NumericParser<float> glossyReflectionsSetter
+        public NumericParser<float> glossyReflections
         {
             get => GetFloat("_GlossyReflections");
             set => SetFloat("_GlossyReflections", value);
@@ -152,7 +152,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Scale, default = 1.000000
         [ParserTarget("bumpScale", Optional = true)]
-        public NumericParser<float> bumpScaleSetter
+        public NumericParser<float> bumpScale
         {
             get => GetFloat("_BumpScale");
             set => SetFloat("_BumpScale", value);
@@ -160,21 +160,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal Map, default = "bump" { }
         [ParserTarget("bumpMap", Optional = true)]
-        public MaterialTextureParser bumpMapSetter
+        public MaterialTextureParser bumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale", Optional = true)]
-        public Vector2Parser bumpMapScaleSetter
+        public Vector2Parser bumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset", Optional = true)]
-        public Vector2Parser bumpMapOffsetSetter
+        public Vector2Parser bumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -182,7 +182,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Height Scale, default = 0.020000
         [ParserTarget("parallax", Optional = true)]
-        public NumericParser<float> parallaxSetter
+        public NumericParser<float> parallax
         {
             get => GetFloat("_Parallax");
             set => SetFloat("_Parallax", value);
@@ -190,21 +190,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Height Map, default = "black" { }
         [ParserTarget("parallaxMap", Optional = true)]
-        public MaterialTextureParser parallaxMapSetter
+        public MaterialTextureParser parallaxMap
         {
-            get => null;
+            get => GetTexture("_ParallaxMap")?.name;
             set => SetTexture("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapScale", Optional = true)]
-        public Vector2Parser parallaxMapScaleSetter
+        public Vector2Parser parallaxMapScale
         {
             get => GetTextureScale("_ParallaxMap");
             set => SetTextureScale("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapOffset", Optional = true)]
-        public Vector2Parser parallaxMapOffsetSetter
+        public Vector2Parser parallaxMapOffset
         {
             get => GetTextureOffset("_ParallaxMap");
             set => SetTextureOffset("_ParallaxMap", value);
@@ -212,7 +212,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Strength, default = 1.000000
         [ParserTarget("occlusionStrength", Optional = true)]
-        public NumericParser<float> occlusionStrengthSetter
+        public NumericParser<float> occlusionStrength
         {
             get => GetFloat("_OcclusionStrength");
             set => SetFloat("_OcclusionStrength", value);
@@ -220,21 +220,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Occlusion, default = "white" { }
         [ParserTarget("occlusionMap", Optional = true)]
-        public MaterialTextureParser occlusionMapSetter
+        public MaterialTextureParser occlusionMap
         {
-            get => null;
+            get => GetTexture("_OcclusionMap")?.name;
             set => SetTexture("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapScale", Optional = true)]
-        public Vector2Parser occlusionMapScaleSetter
+        public Vector2Parser occlusionMapScale
         {
             get => GetTextureScale("_OcclusionMap");
             set => SetTextureScale("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapOffset", Optional = true)]
-        public Vector2Parser occlusionMapOffsetSetter
+        public Vector2Parser occlusionMapOffset
         {
             get => GetTextureOffset("_OcclusionMap");
             set => SetTextureOffset("_OcclusionMap", value);
@@ -242,7 +242,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Color, default = (0.000000,0.000000,0.000000,1.000000)
         [ParserTarget("emissionColor", Optional = true)]
-        public ColorParser emissionColorSetter
+        public ColorParser emissionColor
         {
             get => GetColor("_EmissionColor");
             set => SetColor("_EmissionColor", value);
@@ -250,21 +250,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Emission, default = "white" { }
         [ParserTarget("emissionMap", Optional = true)]
-        public MaterialTextureParser emissionMapSetter
+        public MaterialTextureParser emissionMap
         {
-            get => null;
+            get => GetTexture("_EmissionMap")?.name;
             set => SetTexture("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapScale", Optional = true)]
-        public Vector2Parser emissionMapScaleSetter
+        public Vector2Parser emissionMapScale
         {
             get => GetTextureScale("_EmissionMap");
             set => SetTextureScale("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapOffset", Optional = true)]
-        public Vector2Parser emissionMapOffsetSetter
+        public Vector2Parser emissionMapOffset
         {
             get => GetTextureOffset("_EmissionMap");
             set => SetTextureOffset("_EmissionMap", value);
@@ -272,21 +272,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Detail Mask, default = "white" { }
         [ParserTarget("detailMask", Optional = true)]
-        public MaterialTextureParser detailMaskSetter
+        public MaterialTextureParser detailMask
         {
-            get => null;
+            get => GetTexture("_DetailMask")?.name;
             set => SetTexture("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskScale", Optional = true)]
-        public Vector2Parser detailMaskScaleSetter
+        public Vector2Parser detailMaskScale
         {
             get => GetTextureScale("_DetailMask");
             set => SetTextureScale("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskOffset", Optional = true)]
-        public Vector2Parser detailMaskOffsetSetter
+        public Vector2Parser detailMaskOffset
         {
             get => GetTextureOffset("_DetailMask");
             set => SetTextureOffset("_DetailMask", value);
@@ -294,21 +294,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Detail Albedo x2, default = "grey" { }
         [ParserTarget("detailAlbedoMap", Optional = true)]
-        public MaterialTextureParser detailAlbedoMapSetter
+        public MaterialTextureParser detailAlbedoMap
         {
-            get => null;
+            get => GetTexture("_DetailAlbedoMap")?.name;
             set => SetTexture("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapScale", Optional = true)]
-        public Vector2Parser detailAlbedoMapScaleSetter
+        public Vector2Parser detailAlbedoMapScale
         {
             get => GetTextureScale("_DetailAlbedoMap");
             set => SetTextureScale("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapOffset", Optional = true)]
-        public Vector2Parser detailAlbedoMapOffsetSetter
+        public Vector2Parser detailAlbedoMapOffset
         {
             get => GetTextureOffset("_DetailAlbedoMap");
             set => SetTextureOffset("_DetailAlbedoMap", value);
@@ -316,22 +316,22 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal Map, default = "bump" { }
         [ParserTarget("detailNormalMap", Optional = true)]
-        public MaterialTextureParser detailNormalMapSetter
+        public MaterialTextureParser detailNormalMap
         {
-            get => null;
+            get => GetTexture("_DetailNormalMap")?.name;
             set => SetTexture("_DetailNormalMap", value);
         }
 
         // Scale, default = 1.000000
         [ParserTarget("detailNormalMapScale", Optional = true)]
-        public Vector2Parser detailNormalMapScaleSetter
+        public Vector2Parser detailNormalMapScale
         {
             get => GetTextureScale("_DetailNormalMap");
             set => SetTextureScale("_DetailNormalMap", value);
         }
 
         [ParserTarget("detailNormalMapOffset", Optional = true)]
-        public Vector2Parser detailNormalMapOffsetSetter
+        public Vector2Parser detailNormalMapOffset
         {
             get => GetTextureOffset("_DetailNormalMap");
             set => SetTextureOffset("_DetailNormalMap", value);
@@ -339,7 +339,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // UV Set for secondary textures, default = 0.000000
         [ParserTarget("UVSec", Optional = true)]
-        public NumericParser<float> UVSecSetter
+        public NumericParser<float> UVSec
         {
             get => GetFloat("_UVSec");
             set => SetFloat("_UVSec", value);
@@ -347,7 +347,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __mode, default = 0.000000
         [ParserTarget("mode", Optional = true)]
-        public NumericParser<float> modeSetter
+        public NumericParser<float> mode
         {
             get => GetFloat("_Mode");
             set => SetFloat("_Mode", value);
@@ -355,7 +355,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __src, default = 1.000000
         [ParserTarget("srcBlend", Optional = true)]
-        public NumericParser<float> srcBlendSetter
+        public NumericParser<float> srcBlend
         {
             get => GetFloat("_SrcBlend");
             set => SetFloat("_SrcBlend", value);
@@ -363,7 +363,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __dst, default = 0.000000
         [ParserTarget("dstBlend", Optional = true)]
-        public NumericParser<float> dstBlendSetter
+        public NumericParser<float> dstBlend
         {
             get => GetFloat("_DstBlend");
             set => SetFloat("_DstBlend", value);
@@ -371,7 +371,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __zw, default = 1.000000
         [ParserTarget("ZWrite", Optional = true)]
-        public NumericParser<float> ZWriteSetter
+        public NumericParser<float> ZWrite
         {
             get => GetFloat("_ZWrite");
             set => SetFloat("_ZWrite", value);

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
@@ -44,7 +44,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Color, default = (1.000000,1.000000,1.000000,1.000000)
         [ParserTarget("color")]
-        public ColorParser colorSetter
+        public ColorParser color
         {
             get => GetColor("_Color");
             set => SetColor("_Color", value);
@@ -52,21 +52,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Albedo, default = "white" { }
         [ParserTarget("mainTex")]
-        public MaterialTextureParser mainTexSetter
+        public MaterialTextureParser mainTex
         {
-            get => null;
+            get => GetTexture("_MainTex")?.name;
             set => SetTexture("_MainTex", value);
         }
 
         [ParserTarget("mainTexScale")]
-        public Vector2Parser mainTexScaleSetter
+        public Vector2Parser mainTexScale
         {
             get => GetTextureScale("_MainTex");
             set => SetTextureScale("_MainTex", value);
         }
 
         [ParserTarget("mainTexOffset")]
-        public Vector2Parser mainTexOffsetSetter
+        public Vector2Parser mainTexOffset
         {
             get => GetTextureOffset("_MainTex");
             set => SetTextureOffset("_MainTex", value);
@@ -74,7 +74,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Alpha Cutoff, default = 0.500000
         [ParserTarget("cutoff")]
-        public NumericParser<float> cutoffSetter
+        public NumericParser<float> cutoff
         {
             get => GetFloat("_Cutoff");
             set => SetFloat("_Cutoff", value);
@@ -82,7 +82,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Smoothness, default = 0.500000
         [ParserTarget("glossiness")]
-        public NumericParser<float> glossinessSetter
+        public NumericParser<float> glossiness
         {
             get => GetFloat("_Glossiness");
             set => SetFloat("_Glossiness", value);
@@ -90,7 +90,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Smoothness Scale, default = 1.000000
         [ParserTarget("glossMapScale")]
-        public NumericParser<float> glossMapScaleSetter
+        public NumericParser<float> glossMapScale
         {
             get => GetFloat("_GlossMapScale");
             set => SetFloat("_GlossMapScale", value);
@@ -98,7 +98,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Smoothness texture channel, default = 0.000000
         [ParserTarget("smoothnessTextureChannel")]
-        public NumericParser<float> smoothnessTextureChannelSetter
+        public NumericParser<float> smoothnessTextureChannel
         {
             get => GetFloat("_SmoothnessTextureChannel");
             set => SetFloat("_SmoothnessTextureChannel", value);
@@ -106,7 +106,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular, default = (0.2,0.2,0.2,1)
         [ParserTarget("specColor")]
-        public ColorParser specColorSetter
+        public ColorParser specColor
         {
             get => GetColor("_SpecColor");
             set => SetColor("_SpecColor", value);
@@ -114,21 +114,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular, default = "white" { }
         [ParserTarget("specGlossMap")]
-        public MaterialTextureParser specGlossMapSetter
+        public MaterialTextureParser specGlossMap
         {
-            get => null;
+            get => GetTexture("_SpecGlossMap")?.name;
             set => SetTexture("_SpecGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapScale")]
-        public Vector2Parser metallicGlossMapScaleSetter
+        public Vector2Parser metallicGlossMapScale
         {
             get => GetTextureScale("_SpecGlossMap");
             set => SetTextureScale("_SpecGlossMap", value);
         }
 
         [ParserTarget("metallicGlossMapOffset")]
-        public Vector2Parser metallicGlossMapOffsetSetter
+        public Vector2Parser metallicGlossMapOffset
         {
             get => GetTextureOffset("_SpecGlossMap");
             set => SetTextureOffset("_SpecGlossMap", value);
@@ -136,7 +136,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Specular Highlights, default = 1.000000
         [ParserTarget("specularHighlights")]
-        public NumericParser<float> specularHighlightsSetter
+        public NumericParser<float> specularHighlights
         {
             get => GetFloat("_SpecularHighlights");
             set => SetFloat("_SpecularHighlights", value);
@@ -144,7 +144,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Glossy Reflections, default = 1.000000
         [ParserTarget("glossyReflections")]
-        public NumericParser<float> glossyReflectionsSetter
+        public NumericParser<float> glossyReflections
         {
             get => GetFloat("_GlossyReflections");
             set => SetFloat("_GlossyReflections", value);
@@ -152,7 +152,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Scale, default = 1.000000
         [ParserTarget("bumpScale")]
-        public NumericParser<float> bumpScaleSetter
+        public NumericParser<float> bumpScale
         {
             get => GetFloat("_BumpScale");
             set => SetFloat("_BumpScale", value);
@@ -160,21 +160,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal Map, default = "bump" { }
         [ParserTarget("bumpMap")]
-        public MaterialTextureParser bumpMapSetter
+        public MaterialTextureParser bumpMap
         {
-            get => null;
+            get => GetTexture("_BumpMap")?.name;
             set => SetTexture("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapScale")]
-        public Vector2Parser bumpMapScaleSetter
+        public Vector2Parser bumpMapScale
         {
             get => GetTextureScale("_BumpMap");
             set => SetTextureScale("_BumpMap", value);
         }
 
         [ParserTarget("bumpMapOffset")]
-        public Vector2Parser bumpMapOffsetSetter
+        public Vector2Parser bumpMapOffset
         {
             get => GetTextureOffset("_BumpMap");
             set => SetTextureOffset("_BumpMap", value);
@@ -182,7 +182,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Height Scale, default = 0.020000
         [ParserTarget("parallax")]
-        public NumericParser<float> parallaxSetter
+        public NumericParser<float> parallax
         {
             get => GetFloat("_Parallax");
             set => SetFloat("_Parallax", value);
@@ -190,21 +190,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Height Map, default = "black" { }
         [ParserTarget("parallaxMap")]
-        public MaterialTextureParser parallaxMapSetter
+        public MaterialTextureParser parallaxMap
         {
-            get => null;
+            get => GetTexture("_ParallaxMap")?.name;
             set => SetTexture("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapScale")]
-        public Vector2Parser parallaxMapScaleSetter
+        public Vector2Parser parallaxMapScale
         {
             get => GetTextureScale("_ParallaxMap");
             set => SetTextureScale("_ParallaxMap", value);
         }
 
         [ParserTarget("parallaxMapOffset")]
-        public Vector2Parser parallaxMapOffsetSetter
+        public Vector2Parser parallaxMapOffset
         {
             get => GetTextureOffset("_ParallaxMap");
             set => SetTextureOffset("_ParallaxMap", value);
@@ -212,7 +212,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Strength, default = 1.000000
         [ParserTarget("occlusionStrength")]
-        public NumericParser<float> occlusionStrengthSetter
+        public NumericParser<float> occlusionStrength
         {
             get => GetFloat("_OcclusionStrength");
             set => SetFloat("_OcclusionStrength", value);
@@ -220,21 +220,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Occlusion, default = "white" { }
         [ParserTarget("occlusionMap")]
-        public MaterialTextureParser occlusionMapSetter
+        public MaterialTextureParser occlusionMap
         {
-            get => null;
+            get => GetTexture("_OcclusionMap")?.name;
             set => SetTexture("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapScale")]
-        public Vector2Parser occlusionMapScaleSetter
+        public Vector2Parser occlusionMapScale
         {
             get => GetTextureScale("_OcclusionMap");
             set => SetTextureScale("_OcclusionMap", value);
         }
 
         [ParserTarget("occlusionMapOffset")]
-        public Vector2Parser occlusionMapOffsetSetter
+        public Vector2Parser occlusionMapOffset
         {
             get => GetTextureOffset("_OcclusionMap");
             set => SetTextureOffset("_OcclusionMap", value);
@@ -242,7 +242,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Color, default = (0.000000,0.000000,0.000000,1.000000)
         [ParserTarget("emissionColor")]
-        public ColorParser emissionColorSetter
+        public ColorParser emissionColor
         {
             get => GetColor("_EmissionColor");
             set => SetColor("_EmissionColor", value);
@@ -250,21 +250,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Emission, default = "white" { }
         [ParserTarget("emissionMap")]
-        public MaterialTextureParser emissionMapSetter
+        public MaterialTextureParser emissionMap
         {
-            get => null;
+            get => GetTexture("_EmissionMap")?.name;
             set => SetTexture("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapScale")]
-        public Vector2Parser emissionMapScaleSetter
+        public Vector2Parser emissionMapScale
         {
             get => GetTextureScale("_EmissionMap");
             set => SetTextureScale("_EmissionMap", value);
         }
 
         [ParserTarget("emissionMapOffset")]
-        public Vector2Parser emissionMapOffsetSetter
+        public Vector2Parser emissionMapOffset
         {
             get => GetTextureOffset("_EmissionMap");
             set => SetTextureOffset("_EmissionMap", value);
@@ -272,21 +272,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Detail Mask, default = "white" { }
         [ParserTarget("detailMask")]
-        public MaterialTextureParser detailMaskSetter
+        public MaterialTextureParser detailMask
         {
-            get => null;
+            get => GetTexture("_DetailMask")?.name;
             set => SetTexture("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskScale")]
-        public Vector2Parser detailMaskScaleSetter
+        public Vector2Parser detailMaskScale
         {
             get => GetTextureScale("_DetailMask");
             set => SetTextureScale("_DetailMask", value);
         }
 
         [ParserTarget("detailMaskOffset")]
-        public Vector2Parser detailMaskOffsetSetter
+        public Vector2Parser detailMaskOffset
         {
             get => GetTextureOffset("_DetailMask");
             set => SetTextureOffset("_DetailMask", value);
@@ -294,21 +294,21 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Detail Albedo x2, default = "grey" { }
         [ParserTarget("detailAlbedoMap")]
-        public MaterialTextureParser detailAlbedoMapSetter
+        public MaterialTextureParser detailAlbedoMap
         {
-            get => null;
+            get => GetTexture("_DetailAlbedoMap")?.name;
             set => SetTexture("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapScale")]
-        public Vector2Parser detailAlbedoMapScaleSetter
+        public Vector2Parser detailAlbedoMapScale
         {
             get => GetTextureScale("_DetailAlbedoMap");
             set => SetTextureScale("_DetailAlbedoMap", value);
         }
 
         [ParserTarget("detailAlbedoMapOffset")]
-        public Vector2Parser detailAlbedoMapOffsetSetter
+        public Vector2Parser detailAlbedoMapOffset
         {
             get => GetTextureOffset("_DetailAlbedoMap");
             set => SetTextureOffset("_DetailAlbedoMap", value);
@@ -316,22 +316,22 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // Normal Map, default = "bump" { }
         [ParserTarget("detailNormalMap")]
-        public MaterialTextureParser detailNormalMapSetter
+        public MaterialTextureParser detailNormalMap
         {
-            get => null;
+            get => GetTexture("_DetailNormalMap")?.name;
             set => SetTexture("_DetailNormalMap", value);
         }
 
         // Scale, default = 1.000000
         [ParserTarget("detailNormalMapScale")]
-        public Vector2Parser detailNormalMapScaleSetter
+        public Vector2Parser detailNormalMapScale
         {
             get => GetTextureScale("_DetailNormalMap");
             set => SetTextureScale("_DetailNormalMap", value);
         }
 
         [ParserTarget("detailNormalMapOffset")]
-        public Vector2Parser detailNormalMapOffsetSetter
+        public Vector2Parser detailNormalMapOffset
         {
             get => GetTextureOffset("_DetailNormalMap");
             set => SetTextureOffset("_DetailNormalMap", value);
@@ -339,7 +339,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // UV Set for secondary textures, default = 0.000000
         [ParserTarget("UVSec")]
-        public NumericParser<float> UVSecSetter
+        public NumericParser<float> UVSec
         {
             get => GetFloat("_UVSec");
             set => SetFloat("_UVSec", value);
@@ -347,7 +347,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __mode, default = 0.000000
         [ParserTarget("mode")]
-        public NumericParser<float> modeSetter
+        public NumericParser<float> mode
         {
             get => GetFloat("_Mode");
             set => SetFloat("_Mode", value);
@@ -355,7 +355,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __src, default = 1.000000
         [ParserTarget("srcBlend")]
-        public NumericParser<float> srcBlendSetter
+        public NumericParser<float> srcBlend
         {
             get => GetFloat("_SrcBlend");
             set => SetFloat("_SrcBlend", value);
@@ -363,7 +363,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __dst, default = 0.000000
         [ParserTarget("dstBlend")]
-        public NumericParser<float> dstBlendSetter
+        public NumericParser<float> dstBlend
         {
             get => GetFloat("_DstBlend");
             set => SetFloat("_DstBlend", value);
@@ -371,7 +371,7 @@ namespace Kopernicus.Configuration.MaterialLoader
 
         // __zw, default = 1.000000
         [ParserTarget("ZWrite")]
-        public NumericParser<float> ZWriteSetter
+        public NumericParser<float> ZWrite
         {
             get => GetFloat("_ZWrite");
             set => SetFloat("_ZWrite", value);


### PR DESCRIPTION
Nobody should be accessing these anyway, and this is a nicer cleanup.