### PR TITLE
Properly emit texture names for material loader texture properties

### DIFF
--- a/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AerialTransCutoutLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/AlphaTestDiffuseLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/DiffuseWrapLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/EmissiveMultiRampSunspotsLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("rampMap")]
         public MaterialTextureParser RampMap
         {
-            get => GetTexture("_RampMap")?.name;
+            get => GetTextureName("_RampMap");
             set => SetTexture("_RampMap", value);
         }
 
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("noiseMap")]
         public MaterialTextureParser NoiseMap
         {
-            get => GetTexture("_NoiseMap")?.name;
+            get => GetTextureName("_NoiseMap");
             set => SetTexture("_NoiseMap", value);
         }
 
@@ -106,7 +106,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("sunspotTex")]
         public MaterialTextureParser SunspotTex
         {
-            get => GetTexture("_SunspotTex")?.name;
+            get => GetTextureName("_SunspotTex");
             set => SetTexture("_SunspotTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/GasGiantLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("movementControlTexture")]
         public MaterialTextureParser MovementTexture
         {
-            get => GetTexture("_MovementTexture")?.name;
+            get => GetTextureName("_MovementTexture");
             set => SetTexture("_MovementTexture", value);
         }
 
@@ -77,7 +77,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("swirlControlTexture")]
         public MaterialTextureParser SwirlRotationControlTexture
         {
-            get => GetTexture("_SwirlRotationControlTexture")?.name;
+            get => GetTextureName("_SwirlRotationControlTexture");
             set => SetTexture("_SwirlRotationControlTexture", value);
         }
 
@@ -101,7 +101,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("colorMap")]
         public MaterialTextureParser CloudColorMap
         {
-            get => GetTexture("_CloudColorMap")?.name;
+            get => GetTextureName("_CloudColorMap");
             set => SetTexture("_CloudColorMap", value);
         }
 
@@ -123,7 +123,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("colorMap2")]
         public MaterialTextureParser CloudColorMap2
         {
-            get => GetTexture("_CloudColorMap2")?.name;
+            get => GetTextureName("_CloudColorMap2");
             set => SetTexture("_CloudColorMap2", value);
         }
 
@@ -145,7 +145,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailColorMap")]
         public MaterialTextureParser DetailCloudColorMap
         {
-            get => GetTexture("_DetailCloudColorMap")?.name;
+            get => GetTextureName("_DetailCloudColorMap");
             set => SetTexture("_DetailCloudColorMap", value);
         }
 
@@ -168,7 +168,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("cloudPatternMap")]
         public MaterialTextureParser CloudPatternTexture
         {
-            get => GetTexture("_CloudPatternTexture")?.name;
+            get => GetTextureName("_CloudPatternTexture");
             set => SetTexture("_CloudPatternTexture", value);
         }
 
@@ -190,7 +190,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailCloudPatternMap")]
         public MaterialTextureParser DetailCloudPatternTexture
         {
-            get => GetTexture("_DetailCloudPatternTexture")?.name;
+            get => GetTextureName("_DetailCloudPatternTexture");
             set => SetTexture("_DetailCloudPatternTexture", value);
         }
 
@@ -214,7 +214,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser NormalMap
         {
-            get => GetTexture("_NormalMap")?.name;
+            get => GetTextureName("_NormalMap");
             set => SetTexture("_NormalMap", value);
         }
 
@@ -236,7 +236,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailNormalMap")]
         public MaterialTextureParser DetailNormalMap
         {
-            get => GetTexture("_DetailNormalMap")?.name;
+            get => GetTextureName("_DetailNormalMap");
             set => SetTexture("_DetailNormalMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/KSPBumpedSpecularLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -68,7 +68,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/MaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/MaterialLoader.cs
@@ -400,6 +400,29 @@ public abstract class MaterialLoader : BaseLoader, IParserEventSubscriber
         return Value.GetTexture(key);
     }
 
+    /// <summary>
+    /// Get the texture path or name associated with <paramref name="key"/>.
+    /// </summary>
+    public string GetTextureName(string key)
+    {
+        if (Entries.TryGetValue(key, out var path))
+            return path;
+        if (Value is null)
+            return null;
+
+        var texture = Value.GetTexture(key);
+        if (texture == null)
+            return null;
+
+        var name = texture.name;
+        if (GameDatabase.Instance.ExistsTexture(name))
+            return name;
+        if (TextureLoader.TextureExists(name))
+            return name;
+
+        return $"BUILTIN/{name}";
+    }
+
     public void SetTexture(string key, MaterialTextureParser path)
     {
         if (path is null)

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalBumpedLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -76,7 +76,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseDetailLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -76,7 +76,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detail")]
         public MaterialTextureParser Detail
         {
-            get => GetTexture("_Detail")?.name;
+            get => GetTextureName("_Detail");
             set => SetTexture("_Detail", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/NormalDiffuseLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainExtrasLoader.cs
@@ -128,7 +128,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -150,7 +150,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -188,7 +188,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowTex")]
         public MaterialTextureParser LowTex
         {
-            get => GetTexture("_lowTex")?.name;
+            get => GetTextureName("_lowTex");
             set => SetTexture("_lowTex", value);
         }
 
@@ -210,7 +210,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowBumpMap")]
         public MaterialTextureParser LowBumpMap
         {
-            get => GetTexture("_lowBumpMap")?.name;
+            get => GetTextureName("_lowBumpMap");
             set => SetTexture("_lowBumpMap", value);
         }
 
@@ -264,7 +264,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midTex")]
         public MaterialTextureParser MidTex
         {
-            get => GetTexture("_midTex")?.name;
+            get => GetTextureName("_midTex");
             set => SetTexture("_midTex", value);
         }
 
@@ -286,7 +286,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midBumpMap")]
         public MaterialTextureParser MidBumpMap
         {
-            get => GetTexture("_midBumpMap")?.name;
+            get => GetTextureName("_midBumpMap");
             set => SetTexture("_midBumpMap", value);
         }
 
@@ -340,7 +340,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -362,7 +362,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highBumpMap")]
         public MaterialTextureParser HighBumpMap
         {
-            get => GetTexture("_highBumpMap")?.name;
+            get => GetTextureName("_highBumpMap");
             set => SetTexture("_highBumpMap", value);
         }
 
@@ -456,7 +456,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainFastBlendLoader.cs
@@ -126,7 +126,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -148,7 +148,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -186,7 +186,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowTex")]
         public MaterialTextureParser LowTex
         {
-            get => GetTexture("_lowTex")?.name;
+            get => GetTextureName("_lowTex");
             set => SetTexture("_lowTex", value);
         }
 
@@ -208,7 +208,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowBumpMap")]
         public MaterialTextureParser LowBumpMap
         {
-            get => GetTexture("_lowBumpMap")?.name;
+            get => GetTextureName("_lowBumpMap");
             set => SetTexture("_lowBumpMap", value);
         }
 
@@ -262,7 +262,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midTex")]
         public MaterialTextureParser MidTex
         {
-            get => GetTexture("_midTex")?.name;
+            get => GetTextureName("_midTex");
             set => SetTexture("_midTex", value);
         }
 
@@ -284,7 +284,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midBumpMap")]
         public MaterialTextureParser MidBumpMap
         {
-            get => GetTexture("_midBumpMap")?.name;
+            get => GetTextureName("_midBumpMap");
             set => SetTexture("_midBumpMap", value);
         }
 
@@ -330,7 +330,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -352,7 +352,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highBumpMap")]
         public MaterialTextureParser HighBumpMap
         {
-            get => GetTexture("_highBumpMap")?.name;
+            get => GetTextureName("_highBumpMap");
             set => SetTexture("_highBumpMap", value);
         }
 
@@ -446,7 +446,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedFastBlendLoader.cs
@@ -126,7 +126,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -148,7 +148,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -186,7 +186,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowTex")]
         public MaterialTextureParser LowTex
         {
-            get => GetTexture("_lowTex")?.name;
+            get => GetTextureName("_lowTex");
             set => SetTexture("_lowTex", value);
         }
 
@@ -224,7 +224,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midTex")]
         public MaterialTextureParser MidTex
         {
-            get => GetTexture("_midTex")?.name;
+            get => GetTextureName("_midTex");
             set => SetTexture("_midTex", value);
         }
 
@@ -246,7 +246,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midBumpMap")]
         public MaterialTextureParser MidBumpMap
         {
-            get => GetTexture("_midBumpMap")?.name;
+            get => GetTextureName("_midBumpMap");
             set => SetTexture("_midBumpMap", value);
         }
 
@@ -292,7 +292,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -370,7 +370,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainOptimisedLoader.cs
@@ -128,7 +128,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -150,7 +150,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -188,7 +188,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowTex")]
         public MaterialTextureParser LowTex
         {
-            get => GetTexture("_lowTex")?.name;
+            get => GetTextureName("_lowTex");
             set => SetTexture("_lowTex", value);
         }
 
@@ -226,7 +226,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midTex")]
         public MaterialTextureParser MidTex
         {
-            get => GetTexture("_midTex")?.name;
+            get => GetTextureName("_midTex");
             set => SetTexture("_midTex", value);
         }
 
@@ -248,7 +248,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midBumpMap")]
         public MaterialTextureParser MidBumpMap
         {
-            get => GetTexture("_midBumpMap")?.name;
+            get => GetTextureName("_midBumpMap");
             set => SetTexture("_midBumpMap", value);
         }
 
@@ -294,7 +294,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -372,7 +372,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainShaderLoader.cs
@@ -128,7 +128,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -150,7 +150,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -188,7 +188,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowTex")]
         public MaterialTextureParser LowTex
         {
-            get => GetTexture("_lowTex")?.name;
+            get => GetTextureName("_lowTex");
             set => SetTexture("_lowTex", value);
         }
 
@@ -210,7 +210,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowBumpMap")]
         public MaterialTextureParser LowBumpMap
         {
-            get => GetTexture("_lowBumpMap")?.name;
+            get => GetTextureName("_lowBumpMap");
             set => SetTexture("_lowBumpMap", value);
         }
 
@@ -264,7 +264,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midTex")]
         public MaterialTextureParser MidTex
         {
-            get => GetTexture("_midTex")?.name;
+            get => GetTextureName("_midTex");
             set => SetTexture("_midTex", value);
         }
 
@@ -286,7 +286,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midBumpMap")]
         public MaterialTextureParser MidBumpMap
         {
-            get => GetTexture("_midBumpMap")?.name;
+            get => GetTextureName("_midBumpMap");
             set => SetTexture("_midBumpMap", value);
         }
 
@@ -340,7 +340,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -362,7 +362,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highBumpMap")]
         public MaterialTextureParser HighBumpMap
         {
-            get => GetTexture("_highBumpMap")?.name;
+            get => GetTextureName("_highBumpMap");
             set => SetTexture("_highBumpMap", value);
         }
 
@@ -456,7 +456,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSMainTriplanarZoomRotationLoader.cs
@@ -118,7 +118,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -148,7 +148,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -178,7 +178,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowTex")]
         public MaterialTextureParser LowTex
         {
-            get => GetTexture("_lowTex")?.name;
+            get => GetTextureName("_lowTex");
             set => SetTexture("_lowTex", value);
         }
 
@@ -208,7 +208,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowBumpMap")]
         public MaterialTextureParser LowBumpMap
         {
-            get => GetTexture("_lowBumpMap")?.name;
+            get => GetTextureName("_lowBumpMap");
             set => SetTexture("_lowBumpMap", value);
         }
 
@@ -238,7 +238,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midTex")]
         public MaterialTextureParser MidTex
         {
-            get => GetTexture("_midTex")?.name;
+            get => GetTextureName("_midTex");
             set => SetTexture("_midTex", value);
         }
 
@@ -268,7 +268,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midBumpMap")]
         public MaterialTextureParser MidBumpMap
         {
-            get => GetTexture("_midBumpMap")?.name;
+            get => GetTextureName("_midBumpMap");
             set => SetTexture("_midBumpMap", value);
         }
 
@@ -298,7 +298,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -328,7 +328,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highBumpMap")]
         public MaterialTextureParser HighBumpMap
         {
-            get => GetTexture("_highBumpMap")?.name;
+            get => GetTextureName("_highBumpMap");
             set => SetTexture("_highBumpMap", value);
         }
 
@@ -398,7 +398,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadFallbackLoader.cs
@@ -95,7 +95,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("waterTex")]
         public MaterialTextureParser WaterTex
         {
-            get => GetTexture("_WaterTex")?.name;
+            get => GetTextureName("_WaterTex");
             set => SetTexture("_WaterTex", value);
         }
 
@@ -117,7 +117,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("waterTex1")]
         public MaterialTextureParser WaterTex1
         {
-            get => GetTexture("_WaterTex1")?.name;
+            get => GetTextureName("_WaterTex1");
             set => SetTexture("_WaterTex1", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSOceanSurfaceQuadLoader.cs
@@ -96,7 +96,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("waterTex")]
         public MaterialTextureParser WaterTex
         {
-            get => GetTexture("_WaterTex")?.name;
+            get => GetTextureName("_WaterTex");
             set => SetTexture("_WaterTex", value);
         }
 
@@ -118,7 +118,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("waterTex1")]
         public MaterialTextureParser WaterTex1
         {
-            get => GetTexture("_WaterTex1")?.name;
+            get => GetTextureName("_WaterTex1");
             set => SetTexture("_WaterTex1", value);
         }
 
@@ -148,7 +148,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 
@@ -258,7 +258,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionAerialQuadRelativeLoader.cs
@@ -144,7 +144,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("deepTex")]
         public MaterialTextureParser DeepTex
         {
-            get => GetTexture("_deepTex")?.name;
+            get => GetTextureName("_deepTex");
             set => SetTexture("_deepTex", value);
         }
 
@@ -166,7 +166,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("deepMultiTex")]
         public MaterialTextureParser DeepMultiTex
         {
-            get => GetTexture("_deepMultiTex")?.name;
+            get => GetTextureName("_deepMultiTex");
             set => SetTexture("_deepMultiTex", value);
         }
 
@@ -196,7 +196,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_mainTex")?.name;
+            get => GetTextureName("_mainTex");
             set => SetTexture("_mainTex", value);
         }
 
@@ -218,7 +218,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainMultiTex")]
         public MaterialTextureParser MainMultiTex
         {
-            get => GetTexture("_mainMultiTex")?.name;
+            get => GetTextureName("_mainMultiTex");
             set => SetTexture("_mainMultiTex", value);
         }
 
@@ -248,7 +248,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -270,7 +270,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highMultiTex")]
         public MaterialTextureParser HighMultiTex
         {
-            get => GetTexture("_highMultiTex")?.name;
+            get => GetTextureName("_highMultiTex");
             set => SetTexture("_highMultiTex", value);
         }
 
@@ -300,7 +300,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("snowTex")]
         public MaterialTextureParser SnowTex
         {
-            get => GetTexture("_snowTex")?.name;
+            get => GetTextureName("_snowTex");
             set => SetTexture("_snowTex", value);
         }
 
@@ -322,7 +322,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("snowMultiTex")]
         public MaterialTextureParser SnowMultiTex
         {
-            get => GetTexture("_snowMultiTex")?.name;
+            get => GetTextureName("_snowMultiTex");
             set => SetTexture("_snowMultiTex", value);
         }
 
@@ -352,7 +352,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -502,7 +502,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionFallbackLoader.cs
@@ -119,7 +119,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_mainTex")?.name;
+            get => GetTextureName("_mainTex");
             set => SetTexture("_mainTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSProjectionSurfaceQuadLoader.cs
@@ -142,7 +142,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("deepTex")]
         public MaterialTextureParser DeepTex
         {
-            get => GetTexture("_deepTex")?.name;
+            get => GetTextureName("_deepTex");
             set => SetTexture("_deepTex", value);
         }
 
@@ -164,7 +164,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("deepMultiTex")]
         public MaterialTextureParser DeepMultiTex
         {
-            get => GetTexture("_deepMultiTex")?.name;
+            get => GetTextureName("_deepMultiTex");
             set => SetTexture("_deepMultiTex", value);
         }
 
@@ -194,7 +194,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_mainTex")?.name;
+            get => GetTextureName("_mainTex");
             set => SetTexture("_mainTex", value);
         }
 
@@ -216,7 +216,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainMultiTex")]
         public MaterialTextureParser MainMultiTex
         {
-            get => GetTexture("_mainMultiTex")?.name;
+            get => GetTextureName("_mainMultiTex");
             set => SetTexture("_mainMultiTex", value);
         }
 
@@ -246,7 +246,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -268,7 +268,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highMultiTex")]
         public MaterialTextureParser HighMultiTex
         {
-            get => GetTexture("_highMultiTex")?.name;
+            get => GetTextureName("_highMultiTex");
             set => SetTexture("_highMultiTex", value);
         }
 
@@ -298,7 +298,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("snowTex")]
         public MaterialTextureParser SnowTex
         {
-            get => GetTexture("_snowTex")?.name;
+            get => GetTextureName("_snowTex");
             set => SetTexture("_snowTex", value);
         }
 
@@ -320,7 +320,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("snowMultiTex")]
         public MaterialTextureParser SnowMultiTex
         {
-            get => GetTexture("_snowMultiTex")?.name;
+            get => GetTextureName("_snowMultiTex");
             set => SetTexture("_snowMultiTex", value);
         }
 
@@ -350,7 +350,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationLoader.cs
@@ -134,7 +134,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -156,7 +156,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -194,7 +194,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("lowTex")]
         public MaterialTextureParser LowTex
         {
-            get => GetTexture("_lowTex")?.name;
+            get => GetTextureName("_lowTex");
             set => SetTexture("_lowTex", value);
         }
 
@@ -224,7 +224,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midTex")]
         public MaterialTextureParser MidTex
         {
-            get => GetTexture("_midTex")?.name;
+            get => GetTextureName("_midTex");
             set => SetTexture("_midTex", value);
         }
 
@@ -254,7 +254,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("midBumpMap")]
         public MaterialTextureParser MidBumpMap
         {
-            get => GetTexture("_midBumpMap")?.name;
+            get => GetTextureName("_midBumpMap");
             set => SetTexture("_midBumpMap", value);
         }
 
@@ -284,7 +284,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("highTex")]
         public MaterialTextureParser HighTex
         {
-            get => GetTexture("_highTex")?.name;
+            get => GetTextureName("_highTex");
             set => SetTexture("_highTex", value);
         }
 
@@ -354,7 +354,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/PQSTriplanarZoomRotationTextureArrayLoader.cs
@@ -204,7 +204,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepTex")]
         public MaterialTextureParser SteepTex
         {
-            get => GetTexture("_steepTex")?.name;
+            get => GetTextureName("_steepTex");
             set => SetTexture("_steepTex", value);
         }
 
@@ -226,7 +226,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("steepBumpMap")]
         public MaterialTextureParser SteepBumpMap
         {
-            get => GetTexture("_steepBumpMap")?.name;
+            get => GetTextureName("_steepBumpMap");
             set => SetTexture("_steepBumpMap", value);
         }
 
@@ -272,7 +272,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("fogColorRamp")]
         public MaterialTextureParser FogColorRamp
         {
-            get => GetTexture("_fogColorRamp")?.name;
+            get => GetTextureName("_fogColorRamp");
             set => SetTexture("_fogColorRamp", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ParticleAddSmoothLoader.cs
@@ -46,7 +46,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("texture")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialLoader.cs
@@ -73,7 +73,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -96,7 +96,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 
@@ -142,7 +142,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("rimColorRamp")]
         public MaterialTextureParser RimColorRamp
         {
-            get => GetTexture("_rimColorRamp")?.name;
+            get => GetTextureName("_rimColorRamp");
             set => SetTexture("_rimColorRamp", value);
         }
 
@@ -179,7 +179,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("resourceMap")]
         public MaterialTextureParser ResourceMap
         {
-            get => GetTexture("_ResourceMap")?.name;
+            get => GetTextureName("_ResourceMap");
             set => SetTexture("_ResourceMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimAerialStandardLoader.cs
@@ -73,7 +73,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -96,7 +96,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 
@@ -142,7 +142,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("rimColorRamp")]
         public MaterialTextureParser RimColorRamp
         {
-            get => GetTexture("_rimColorRamp")?.name;
+            get => GetTextureName("_rimColorRamp");
             set => SetTexture("_rimColorRamp", value);
         }
 
@@ -179,7 +179,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("resourceMap")]
         public MaterialTextureParser ResourceMap
         {
-            get => GetTexture("_ResourceMap")?.name;
+            get => GetTextureName("_ResourceMap");
             set => SetTexture("_ResourceMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetRimLightLoader.cs
@@ -70,7 +70,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -92,7 +92,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 
@@ -138,7 +138,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("resourceMap")]
         public MaterialTextureParser ResourceMap
         {
-            get => GetTexture("_ResourceMap")?.name;
+            get => GetTextureName("_ResourceMap");
             set => SetTexture("_ResourceMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/ScaledPlanetSimpleLoader.cs
@@ -71,7 +71,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser MainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -94,7 +94,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser BumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 
@@ -124,7 +124,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("resourceMap")]
         public MaterialTextureParser ResourceMap
         {
-            get => GetTexture("_ResourceMap")?.name;
+            get => GetTextureName("_ResourceMap");
             set => SetTexture("_ResourceMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex", Optional = true)]
         public MaterialTextureParser mainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("metallicGlossMap", Optional = true)]
         public MaterialTextureParser metallicGlossMap
         {
-            get => GetTexture("_MetallicGlossMap")?.name;
+            get => GetTextureName("_MetallicGlossMap");
             set => SetTexture("_MetallicGlossMap", value);
         }
 
@@ -162,7 +162,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap", Optional = true)]
         public MaterialTextureParser bumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 
@@ -192,7 +192,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("parallaxMap", Optional = true)]
         public MaterialTextureParser parallaxMap
         {
-            get => GetTexture("_ParallaxMap")?.name;
+            get => GetTextureName("_ParallaxMap");
             set => SetTexture("_ParallaxMap", value);
         }
 
@@ -222,7 +222,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("occlusionMap", Optional = true)]
         public MaterialTextureParser occlusionMap
         {
-            get => GetTexture("_OcclusionMap")?.name;
+            get => GetTextureName("_OcclusionMap");
             set => SetTexture("_OcclusionMap", value);
         }
 
@@ -252,7 +252,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("emissionMap", Optional = true)]
         public MaterialTextureParser emissionMap
         {
-            get => GetTexture("_EmissionMap")?.name;
+            get => GetTextureName("_EmissionMap");
             set => SetTexture("_EmissionMap", value);
         }
 
@@ -274,7 +274,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailMask", Optional = true)]
         public MaterialTextureParser detailMask
         {
-            get => GetTexture("_DetailMask")?.name;
+            get => GetTextureName("_DetailMask");
             set => SetTexture("_DetailMask", value);
         }
 
@@ -296,7 +296,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailAlbedoMap", Optional = true)]
         public MaterialTextureParser detailAlbedoMap
         {
-            get => GetTexture("_DetailAlbedoMap")?.name;
+            get => GetTextureName("_DetailAlbedoMap");
             set => SetTexture("_DetailAlbedoMap", value);
         }
 
@@ -318,7 +318,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailNormalMap", Optional = true)]
         public MaterialTextureParser detailNormalMap
         {
-            get => GetTexture("_DetailNormalMap")?.name;
+            get => GetTextureName("_DetailNormalMap");
             set => SetTexture("_DetailNormalMap", value);
         }
 

--- a/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/StandardSpecularLoader.cs
@@ -54,7 +54,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("mainTex")]
         public MaterialTextureParser mainTex
         {
-            get => GetTexture("_MainTex")?.name;
+            get => GetTextureName("_MainTex");
             set => SetTexture("_MainTex", value);
         }
 
@@ -116,7 +116,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("specGlossMap")]
         public MaterialTextureParser specGlossMap
         {
-            get => GetTexture("_SpecGlossMap")?.name;
+            get => GetTextureName("_SpecGlossMap");
             set => SetTexture("_SpecGlossMap", value);
         }
 
@@ -162,7 +162,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("bumpMap")]
         public MaterialTextureParser bumpMap
         {
-            get => GetTexture("_BumpMap")?.name;
+            get => GetTextureName("_BumpMap");
             set => SetTexture("_BumpMap", value);
         }
 
@@ -192,7 +192,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("parallaxMap")]
         public MaterialTextureParser parallaxMap
         {
-            get => GetTexture("_ParallaxMap")?.name;
+            get => GetTextureName("_ParallaxMap");
             set => SetTexture("_ParallaxMap", value);
         }
 
@@ -222,7 +222,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("occlusionMap")]
         public MaterialTextureParser occlusionMap
         {
-            get => GetTexture("_OcclusionMap")?.name;
+            get => GetTextureName("_OcclusionMap");
             set => SetTexture("_OcclusionMap", value);
         }
 
@@ -252,7 +252,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("emissionMap")]
         public MaterialTextureParser emissionMap
         {
-            get => GetTexture("_EmissionMap")?.name;
+            get => GetTextureName("_EmissionMap");
             set => SetTexture("_EmissionMap", value);
         }
 
@@ -274,7 +274,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailMask")]
         public MaterialTextureParser detailMask
         {
-            get => GetTexture("_DetailMask")?.name;
+            get => GetTextureName("_DetailMask");
             set => SetTexture("_DetailMask", value);
         }
 
@@ -296,7 +296,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailAlbedoMap")]
         public MaterialTextureParser detailAlbedoMap
         {
-            get => GetTexture("_DetailAlbedoMap")?.name;
+            get => GetTextureName("_DetailAlbedoMap");
             set => SetTexture("_DetailAlbedoMap", value);
         }
 
@@ -318,7 +318,7 @@ namespace Kopernicus.Configuration.MaterialLoader
         [ParserTarget("detailNormalMap")]
         public MaterialTextureParser detailNormalMap
         {
-            get => GetTexture("_DetailNormalMap")?.name;
+            get => GetTextureName("_DetailNormalMap");
             set => SetTexture("_DetailNormalMap", value);
         }
 


### PR DESCRIPTION
This mirrors how it is done for MapSOLoader, which should be accurate enough.