### PR TITLE
Clear existing textures when replaced with an on-demand texture

### DIFF
--- a/src/Kopernicus/Configuration/MaterialLoader/MaterialLoader.cs
+++ b/src/Kopernicus/Configuration/MaterialLoader/MaterialLoader.cs
@@ -607,6 +607,7 @@ public abstract class MaterialLoader : BaseLoader, IParserEventSubscriber
         {
             path = Utility.ValidateOnDemandTexture(path);
             Entries[key] = path;
+            Value.SetTexture(key, null);
             return null;
         }
         else


### PR DESCRIPTION
This way texture load errors give a white sphere and not minmok.