### PR TITLE
Avoid NRE spam in KopernicusStar.LateUpdate

### DIFF
--- a/src/Kopernicus/Components/KopernicusStar.cs
+++ b/src/Kopernicus/Components/KopernicusStar.cs
@@ -366,6 +366,10 @@ namespace Kopernicus.Components
         [SuppressMessage("ReSharper", "ArrangeStaticMemberQualifier")]
         private void LateUpdate()
         {
+            // Avoid spamming NREs if we got set up wrong.
+            if (shifter.IsNullOrDestroyed() || lensFlare.IsNullOrDestroyed() || target.IsNullOrDestroyed())
+                return;
+
             // Set precision
             sunRotationPrecision = MapView.MapIsEnabled ? sunRotationPrecisionMapView : sunRotationPrecisionDefault;
 


### PR DESCRIPTION
If the system fails to load then often you end up with a ton of NRE spam because the KopernicusStar components are not set up correctly. This guards against that by just disabling them if they are missing some dependent components.