### PR TITLE
Fix KopernicusSolarPanel NullReferenceException after vessel unpack

### DIFF
--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -447,7 +447,10 @@ namespace Kopernicus.Components
                 return;
             }
 
-            Vessel vesselActive = FlightGlobals.ActiveVessel;
+            Vessel vesselActive = FlightGlobals.ActiveVessel ?? vessel;
+            if (vesselActive == null)
+                return;
+
             Vector3d position = VesselPosition(vesselActive);
             List<KopernicusStar> starList = new List<KopernicusStar>();
 
@@ -1173,6 +1176,9 @@ namespace Kopernicus.Components
                 if (sunCatcherPosition == null)
                     sunCatcherPosition = panelModule.part.FindModelTransform(panelModule.secondaryTransformName);
 
+                if (sunCatcherPosition == null)
+                    return occludingFactor;
+
                 Physics.Raycast(sunCatcherPosition.position + (sunDir * panelModule.raycastOffset), sunDir, out raycastHit, 10000f, occlusionLayerMask);
 
                 if (raycastHit.collider != null)
@@ -1198,6 +1204,10 @@ namespace Kopernicus.Components
             // we use the current panel orientation, only doing it ourself when analytic = true
             public override double GetCosineFactor(Vector3d sunDir)
             {
+                // trackingDotTransform can be null for a few FixedUpdates after vessel unpack
+                if (panelModule.trackingDotTransform == null)
+                    return 0.0;
+
                 switch (panelModule.panelType)
                 {
                     case ModuleDeployableSolarPanel.PanelType.FLAT:

--- a/src/Kopernicus/Components/KopernicusSolarPanel.cs
+++ b/src/Kopernicus/Components/KopernicusSolarPanel.cs
@@ -1204,15 +1204,16 @@ namespace Kopernicus.Components
             // we use the current panel orientation, only doing it ourself when analytic = true
             public override double GetCosineFactor(Vector3d sunDir)
             {
-                // trackingDotTransform can be null for a few FixedUpdates after vessel unpack
-                if (panelModule.trackingDotTransform == null)
-                    return 0.0;
-
                 switch (panelModule.panelType)
                 {
                     case ModuleDeployableSolarPanel.PanelType.FLAT:
+                        // trackingDotTransform can be null for a few FixedUpdates after vessel unpack
+                        if (panelModule.trackingDotTransform == null)
+                            return 0.0;
                         return Math.Max(Vector3d.Dot(sunDir, panelModule.trackingDotTransform.forward), 0.0);
                     case ModuleDeployableSolarPanel.PanelType.CYLINDRICAL:
+                        if (panelModule.trackingDotTransform == null)
+                            return 0.0;
                         return Math.Max((1.0 - Math.Abs(Vector3d.Dot(sunDir, panelModule.trackingDotTransform.forward))) * (1.0 / Math.PI), 0.0);
                     case ModuleDeployableSolarPanel.PanelType.SPHERICAL:
                         return 0.25;


### PR DESCRIPTION
Guard null trackingDotTransform and sunCatcherPosition in stock panel cosine/occlusion checks, and fall back when ActiveVessel is not ready yet