### PR TITLE
Allow configuring amount of ring texture dedicated to sides vs rims

### DIFF
--- a/src/Kopernicus/Components/Ring.cs
+++ b/src/Kopernicus/Components/Ring.cs
@@ -96,6 +96,13 @@ namespace Kopernicus.Components
         public Int32 tiles;
 
         /// <summary>
+        /// Fraction of the texture width (U axis) used by the flat side faces
+        /// when tiling. The remaining width is split evenly between the inner
+        /// and outer rim faces.
+        /// </summary>
+        public float sideUvWidth = 0.2f;
+
+        /// <summary>
         /// For new shader, makes planet shadow softer (values larger than one) or less soft (smaller than one)
         /// softness still depends on distance from sun, distance from planet and radius of sun and planet
         /// </summary>
@@ -537,20 +544,22 @@ namespace Kopernicus.Components
             Single outerScale,
             Vector3 thicknessOffset)
         {
-            const Single SIDE_TEX_W = 0.2f,
-                INNER_TEX_W = 0.4f,
-                OUTER_TEX_W = 0.4f;
+            // The side faces get a configurable fraction of the texture width;
+            // the rest is split evenly between the inner and outer rim faces.
+            float sideTexW = Mathf.Clamp01(sideUvWidth);
+            float innerTexW = (1f - sideTexW) / 2f;
+            float outerTexW = innerTexW;
             // Define coordinates for 3 textures:
             //   1. The "side" faces that point normal and antinormal
             //      (classic rings)
             Vector2 sideInnerU = Vector2.zero;
-            Vector2 sideOuterU = sideInnerU + SIDE_TEX_W * Vector2.right;
+            Vector2 sideOuterU = sideInnerU + sideTexW * Vector2.right;
             //   2. The "inner" face that points at the body
             Vector2 innerBottomU = sideOuterU;
-            Vector2 innerTopU = innerBottomU + INNER_TEX_W * Vector2.right;
+            Vector2 innerTopU = innerBottomU + innerTexW * Vector2.right;
             //   3. The "outer" face that points away from the body
             Vector2 outerBottomU = innerTopU;
-            Vector2 outerTopU = outerBottomU + OUTER_TEX_W * Vector2.right;
+            Vector2 outerTopU = outerBottomU + outerTexW * Vector2.right;
 
             Int32 wrapping = steps * 2;
 

--- a/src/Kopernicus/Configuration/RingLoader.cs
+++ b/src/Kopernicus/Configuration/RingLoader.cs
@@ -266,6 +266,19 @@ namespace Kopernicus.Configuration
         }
 
         /// <summary>
+        /// Fraction of the texture width used by the flat side faces when tiling.
+        /// The remaining width is split evenly between the inner and outer rim faces.
+        /// </summary>
+        [ParserTarget("sideUvWidth")]
+        [KittopiaDescription(
+            "Fraction of the texture width used by the flat side faces when tiling. The remaining width is split evenly between the inner and outer rim faces.")]
+        public NumericParser<float> SideUvWidth
+        {
+            get { return Value.sideUvWidth; }
+            set { Value.sideUvWidth = value; }
+        }
+
+        /// <summary>
         /// This texture's opaque pixels cast shadows on our inner surface
         /// </summary>
         [ParserTarget("innerShadeTexture")]


### PR DESCRIPTION
So by default the ring mesh dedicates UV space on the ring texture as follows

```
| 20% visible ring sides | 40% inner rim | 40% outer rim |
```

This allocation makes absolutely no sense to me, the inner/outer rim are completely unused in the KSP modding ecosystem and even if they were dedicating 80% of the texture to them seems ridiculous. I almost suspect that they were supposed to be used for the actual sides of the ring instead of the rims.

In any case, this commit makes it so that you can configure the amount of the texture dedicated to rims vs the visible sides. We can't change the default because that would break any existing tiled ring, but we can at least make it so that the ring is actually reasonable.

The way to do this is by setting `sideUvWidth = x` on the `Ring` node. That will control how much of the texture is dedicated to the sides vs the rims.