### PR TITLE
Clear outgoing body's inverseRotation flag

### DIFF
--- a/src/Kopernicus/Patches/OrbitPhysicsManager_setDominantBody.cs
+++ b/src/Kopernicus/Patches/OrbitPhysicsManager_setDominantBody.cs
@@ -1,0 +1,21 @@
+using HarmonyLib;
+
+namespace Kopernicus.Patches;
+
+/// <summary>
+/// Clear the outgoing dominant body's inverseRotation so that only the current dominant body
+/// is ever in the rotating frame. The SOI transition has already re-expressed vessel state in
+/// the new reference body's frame, so this has no velocity side effect.
+/// </summary>
+[HarmonyPatch(typeof(OrbitPhysicsManager), "setDominantBody")]
+static class OrbitPhysicsManager_setDominantBody
+{
+    static void Prefix(OrbitPhysicsManager __instance, CelestialBody body)
+    {
+        CelestialBody outgoing = __instance.dominantBody;
+        if (outgoing != null && outgoing != body)
+        {
+            outgoing.inverseRotation = false;
+        }
+    }
+}


### PR DESCRIPTION
When a craft leaves the SOI of a moon but is still in the inverse rotation threshold of the object, `OrbitPhysicsManager.setDominantBody()` reassigns `dominantBody` but doesn't clear the outgoing body's `inverseRotation` flag.

`Planetarium.CBUpdate()` rebuilds the single global `Planetarium.Zup` frame from any body with inverseRotation == true, and that frame is what every on-rails body position is expressed through (`getPositionFromTrueAnomaly` -> `Planetarium.Zup.WorldToLocal`).

This closes half of issue #825 (the craft being dragged around the sun).